### PR TITLE
Introduce separate spec documents for Python, C# and TypeScript

### DIFF
--- a/docs/design/dotnet/DotNetSpec.mdk
+++ b/docs/design/dotnet/DotNetSpec.mdk
@@ -1,0 +1,46 @@
+Madoko documentation: http://madoko.org/reference.html
+
+Title       : Azure SDK Design Guidelines for C#
+Title Note  : Version 1.0.0-preview2
+Author      : Krzysztof Cwalina
+Affiliation : Azure SDK Team / .NET
+Email       : kcwalina@microsoft.com
+Logo        : False
+Embed       : False
+css         : custom.css
+
+[INCLUDE=../components.mdk]
+
+[TITLE]
+
+This document describes architectural and API design guidelines for Azure client libraries, specifically for C#. It includes a number of general specifications as well, but the C#-specific guidance later in the specification overrules any general guidance.
+
+[TOC]
+
+# Introduction
+
+This section covers C#-specific requirements to successfully implement and release a C# SDK component for Azure, that must be followed in addition to the common guidelines presented below.
+
+[INCLUDE=../Requirements.mdk]
+
+[INCLUDE=../OpenSource.mdk]
+
+# Language-Independent Guidelines
+
+[INCLUDE=../GeneralGuidelines.mdk]
+
+[INCLUDE=../Telemetry.mdk]
+
+[INCLUDE=../Logging.mdk]
+
+[INCLUDE=../Retry.mdk]
+
+[INCLUDE=../Cancellations.mdk]
+
+[INCLUDE=../Dependencies.mdk]
+
+[INCLUDE=../Configuration.mdk]
+
+# C#-Specific Guidelines
+
+[INCLUDE=DesignGuidelines.mdk]

--- a/docs/design/java/JavaSpec.mdk
+++ b/docs/design/java/JavaSpec.mdk
@@ -19,7 +19,7 @@ This document describes architectural and API design guidelines for Azure client
 
 # Introduction
 
-This section covers Java-specific requirements to successfully implement and release a Java SDK component for Azure, that must be followed in addition to the common guidelines presented above.
+This section covers Java-specific requirements to successfully implement and release a Java SDK component for Azure, that must be followed in addition to the common guidelines presented below.
 
 [INCLUDE=../Requirements.mdk]
 

--- a/docs/design/python/PythonSpec.mdk
+++ b/docs/design/python/PythonSpec.mdk
@@ -1,0 +1,46 @@
+Madoko documentation: http://madoko.org/reference.html
+
+Title       : Azure SDK Design Guidelines for Python
+Title Note  : Version 1.0.0-preview2
+Author      : Johan Stenberg
+Affiliation : Azure SDK Team / Python
+Email       : johan.stenberg@microsoft.com
+Logo        : False
+Embed       : False
+css         : custom.css
+
+[INCLUDE=../components.mdk]
+
+[TITLE]
+
+This document describes architectural and API design guidelines for Azure client libraries, specifically for Python. It includes a number of general specifications as well, but the Python-specific guidance later in the specification overrules any general guidance.
+
+[TOC]
+
+# Introduction
+
+This section covers Python-specific requirements to successfully implement and release a Python SDK component for Azure, that must be followed in addition to the common guidelines presented below.
+
+[INCLUDE=../Requirements.mdk]
+
+[INCLUDE=../OpenSource.mdk]
+
+# Language-Independent Guidelines
+
+[INCLUDE=../GeneralGuidelines.mdk]
+
+[INCLUDE=../Telemetry.mdk]
+
+[INCLUDE=../Logging.mdk]
+
+[INCLUDE=../Retry.mdk]
+
+[INCLUDE=../Cancellations.mdk]
+
+[INCLUDE=../Dependencies.mdk]
+
+[INCLUDE=../Configuration.mdk]
+
+# Python-Specific Guidelines
+
+[INCLUDE=DesignGuidelines.mdk]

--- a/docs/design/typescript/TypeScriptSpec.mdk
+++ b/docs/design/typescript/TypeScriptSpec.mdk
@@ -1,0 +1,46 @@
+Madoko documentation: http://madoko.org/reference.html
+
+Title       : Azure SDK Design Guidelines for TypeScript
+Title Note  : Version 1.0.0-preview2
+Author      : Brian Terlson
+Affiliation : Azure SDK Team / JS &amp; TS
+Email       : brian.terlson@microsoft.com
+Logo        : False
+Embed       : False
+css         : custom.css
+
+[INCLUDE=../components.mdk]
+
+[TITLE]
+
+This document describes architectural and API design guidelines for Azure client libraries, specifically for TypeScript. It includes a number of general specifications as well, but the TypeScript-specific guidance later in the specification overrules any general guidance.
+
+[TOC]
+
+# Introduction
+
+This section covers TypeScript-specific requirements to successfully implement and release a TypeScript SDK component for Azure, that must be followed in addition to the common guidelines presented below.
+
+[INCLUDE=../Requirements.mdk]
+
+[INCLUDE=../OpenSource.mdk]
+
+# Language-Independent Guidelines
+
+[INCLUDE=../GeneralGuidelines.mdk]
+
+[INCLUDE=../Telemetry.mdk]
+
+[INCLUDE=../Logging.mdk]
+
+[INCLUDE=../Retry.mdk]
+
+[INCLUDE=../Cancellations.mdk]
+
+[INCLUDE=../Dependencies.mdk]
+
+[INCLUDE=../Configuration.mdk]
+
+# TypeScript-Specific Guidelines
+
+[INCLUDE=DesignGuidelines.mdk]

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "madoko ./docs/design/DesignGuidelines.mdk ./docs/design/java/JavaSpec.mdk"
+    "build": "madoko ./docs/design/DesignGuidelines.mdk ./docs/design/java/JavaSpec.mdk ./docs/design/dotnet/DotNetSpec.mdk ./docs/design/python/PythonSpec.mdk ./docs/design/typescript/TypeScriptSpec.mdk"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We now have separate spec documents in addition to the 'full spec' doc that always existed.