### PR TITLE
Reorganized .NET Guideline "Template"

### DIFF
--- a/docs/design/Cancellations.mdk
+++ b/docs/design/Cancellations.mdk
@@ -1,4 +1,4 @@
-## Cancellation & Timeouts
+## Cancellation & Timeouts {#general-cancellations}
 
 When an application makes a network request, the network infrastrucutre(like routers) and the called service may take a long time to respond and, in fact, may never respond. A well-written application SHOULD NEVER give up its control to the network infrasture or service. To ensure that users of our SDKs can keep control of their application, SDK methods that perform I/O operations MUST accept some kind of cancellation & timeout mechanism specific to the programming language.
 

--- a/docs/design/OpenSource.mdk
+++ b/docs/design/OpenSource.mdk
@@ -1,4 +1,4 @@
-# Open Source
+# Open Source {#general-oss}
 
 ~ Must {#github-open-source}
 ensure that all library code is public and open source on GitHub. Library code must be in Azure SDK 'mono-repo' for its language (e.g. [Azure SDK for Java](https://github.com/Azure/azure-sdk-for-java)).

--- a/docs/design/Requirements.mdk
+++ b/docs/design/Requirements.mdk
@@ -1,4 +1,4 @@
-# Requirements
+# Release Requirements
 
 Releasing an SDK component that provides a more convenient means of connecting to a service requires that the service itself be in a state where it has stabilized. 
 An SDK components might be built and available in a preview form whilst a service stabilizes, but should never be distributed as a GA release until the service and the client library are both stable.
@@ -11,7 +11,7 @@ make a GA release of a SDK component until the underlying service is also in GA,
 make a GA release of a SDK component for a service whose protocol is based on a REST API until there is a stable GA Swagger specification available.
 ~
 
-## Functionality
+## Service Freature Parity
 
 ~ Must {#support-all-service-features}
 support 100% of the features provided by the Azure service the SDK component represents. Gaps in functionality cause confusion and frustration among developers.

--- a/docs/design/dotnet/DesignGuidelines.mdk
+++ b/docs/design/dotnet/DesignGuidelines.mdk
@@ -4,7 +4,7 @@ Currently, the document describes guidelines for .NET APIs exposing HTTP/REST se
 
 To illustrate various design concepts, we will be using Azure Application Configuration service in code examples. You can find sources for this component [here](https://github.com/Azure/azure-sdk-for-net-lab/tree/master/Configuration). The Azure.ApplicationModel.Configuration component can serve as an illustration of what we expect a great Azure SDK component for .NET to look like.
 
-## General .NET API Design
+## General Guidelines
 
 ~ Must {#dotnet-follow-official-framework-guidelines}
 follow the official [Framework Design Guidelines](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/). 
@@ -112,6 +112,8 @@ make all methods that can result in network I/O async, i.e. return ```Task<T>```
 
 ~ Must {#dotnet-method-cancellation}
 ensure all async methods take an optional ```CancellationToken``` parameter called _cancellation_.
+
+For more contenxt see language-independent [Cancellation Guidelines](#general-cancellations).
 ~
 
 ~ Must {#dotnet-method-return}
@@ -353,6 +355,9 @@ else {
 ~
 ## Repository Guidelines
 
+~ Must 
+follow general [Azure SDK open source guidelines](#general-oss).
+
 ~ Must {#dotnet-repository}
 have samples, readme, and prescribed folder structure. The README.md file must be in the component's root folder. 
 ~
@@ -371,6 +376,7 @@ This can be acomplished by making the samples into tests, as in the example abov
 ~~ 
 
 ~
+
 
 ## Common Type Usage
 
@@ -484,7 +490,7 @@ consider deserializing the return type lazily if the type is a large graph conta
 This allows callers to avoid large number of GC heap allocations. ```Response<T>``` allows for such lazy deserialization. See ```Response<T>``` documentation for how to do it.
 ~
 
-## Commonly Overlooked .NET API Design Guidelines { @h1-h2: "A" }
+## Commonly Overlooked .NET API Design Guidelines
 
 Some .NET Design Guidelines have been notoriously overlooked in existing Azure SDKs. This section serves as a way to highlight these guidelines.
 

--- a/docs/design/dotnet/DesignGuidelines.mdk
+++ b/docs/design/dotnet/DesignGuidelines.mdk
@@ -53,7 +53,7 @@ name service client types with the _Client_ suffix, e.g. ```ConfigurationClient`
 ~
 
 ~ Must {#dotnet-proxy-client-namespace}
-place service clients in the root namespace of their corresponsing component.
+place service clients in the root namespace of their corresponding component.
 ~
 
 ~ Must {#dotnet-proxy-class}
@@ -92,7 +92,7 @@ namespace Azure.ApplicationModel.Configuration {
 
 ### Service Methods
 This section describes guidelines for designing service client methods that call service endpoints. 
-As a quick illustration, here are the main service call methods in the ConfigurationClient, and further below detailed guidelines codyfining various elements of the design.
+As a quick illustration, here are the main service call methods in the ConfigurationClient, and further below detailed guidelines codifying various elements of the design.
 
 ```csharp
 public class ConfigurationClient {
@@ -131,7 +131,7 @@ See [Using HttpPipeline](#dotnet-usage-httppipeline) for details.
 As mentioned above, service methods should return ```Task<Response<T>>``` (or equivalent). The ```T``` can be ```System.IO.Stream``` in case of untyped results (e.g. content of a storage blob) or a _model type_ representing deserialized response content. This section describes how such _model type_ and all its transitive closure dependencies (return type graph) should be designed.
 
 ~ Must {#dotnet-return-type}
-return ```Task<Response<Stream>>``` if the response contnent is just a stream of bytes, and ```Task<Response<T>>```, where it ```T``` is a _model type_ if the content has a schema and can be deserialized.
+return ```Task<Response<Stream>>``` if the response content is just a stream of bytes, and ```Task<Response<T>>```, where it ```T``` is a _model type_ if the content has a schema and can be deserialized.
 
 For example, the configuration service _model type_ looks like the following:
 ```csharp
@@ -172,7 +172,7 @@ public class ConfigurationClient {
 ensure model public properties are get-only if they are not intended to be changed by the user.
 
 For example, the _Locked_ property of _ConfigurationSetting_ is not intended to be changed by the user and so its setter should be internal,
-whereas the _ContentType_ property needs is designed tyo be modified and so it has a public setter.
+whereas the _ContentType_ property needs is designed to be modified and so it has a public setter.
 ```csharp
     public sealed class ConfigurationSetting : IEquatable<ConfigurationSetting> {
 
@@ -181,7 +181,7 @@ whereas the _ContentType_ property needs is designed tyo be modified and so it h
         public bool Locked { get; internal set; }
     }
 ```
-Note: the intenral setter for these get-only properties is there to allow the component to deserialize the model types. 
+Note: the internal setter for these get-only properties is there to allow the component to deserialize the model types. 
 See more on this in [Serialization](#dotnet-usage-serialization) section below.
 ~
 
@@ -305,11 +305,11 @@ have dependencies on any NuGet packages besides:
 
 * The .NET Standard, 
 * Azure.* packages from the [azure/azure-sdk-for-net](https://github.com/Azure/azure-sdk-for-net) repo 
-* packages produced by your oun team.
+* packages produced by your on team.
 
 In the past, a very common external dependency was JSON.NET package. To avoid this dependency, 
 we recommend [System.Text.Json](https://github.com/dotnet/corefx/tree/master/src/System.Text.Json/source_package) 
-package that is now a part of the .NET platfrom. 
+package that is now a part of the .NET platform. 
 In particular, the source version of the package which allows for maximum reach.
 ~
 
@@ -372,7 +372,7 @@ See [Configuration Service Hello World](https://github.com/Azure/azure-sdk-for-n
 make sure all the samples build and run as part of the CI process. 
 
 ~~ Draft
-This can be acomplished by making the samples into tests, as in the example above.
+This can be accomplished by making the samples into tests, as in the example above.
 ~~ 
 
 ~

--- a/docs/design/dotnet/DotNetSpec.mdk
+++ b/docs/design/dotnet/DotNetSpec.mdk
@@ -1,6 +1,6 @@
 Madoko documentation: http://madoko.org/reference.html
 
-Title       : Azure SDK Design Guidelines for C#
+Title       : Azure SDK Design Guidelines for .NET
 Title Note  : Version 1.0.0-preview2
 Author      : Krzysztof Cwalina
 Affiliation : Azure SDK Team / .NET
@@ -13,34 +13,34 @@ css         : custom.css
 
 [TITLE]
 
-This document describes architectural and API design guidelines for Azure client libraries, specifically for C#. It includes a number of general specifications as well, but the C#-specific guidance later in the specification overrules any general guidance.
+This document describes architectural and API design guidelines for .NET Azure SDK libraries.
 
 [TOC]
 
 # Introduction
 
-This section covers C#-specific requirements to successfully implement and release a C# SDK component for Azure, that must be followed in addition to the common guidelines presented below.
+[INCLUDE=DesignGuidelines.mdk]
 
 [INCLUDE=../Requirements.mdk]
 
 [INCLUDE=../OpenSource.mdk]
 
-# Language-Independent Guidelines
+# Requirements Implemented by HttpPipeline 
 
-[INCLUDE=../GeneralGuidelines.mdk]
+This section describes requirements that are automatically satisfied by components that use the [HttpPipeline](#dotnet-usage-httppipeline) to implement their service method calls. 
 
-[INCLUDE=../Telemetry.mdk]
+For example, the pipeline automatically takes care of [logging](#general-logging), [retry](#general-retry), and [telemetry](#general-telemetry) requirements described in detail in this section. 
+
+If for some reason you cannot use the _HttpPipeline_, you will have to manually support the requirements described in this section.
 
 [INCLUDE=../Logging.mdk]
 
 [INCLUDE=../Retry.mdk]
 
+[INCLUDE=../Telemetry.mdk]
+
+# Context and Rationale
+
+Language-specific guidelines guidelines, described above, stem from language-independent requirements described in this section. If you follow the language-specific guidelines, you don't have to worry about these language-independent guidelines, but they do provide context and rationale for many of the language specific guidelines.
+
 [INCLUDE=../Cancellations.mdk]
-
-[INCLUDE=../Dependencies.mdk]
-
-[INCLUDE=../Configuration.mdk]
-
-# C#-Specific Guidelines
-
-[INCLUDE=DesignGuidelines.mdk]


### PR DESCRIPTION
Reorganized the document, added some clarifications, fixed misspellings, removed some sections that either don't add value or need to be clarified. 

I think this makes the .net guidelines doc ready for consumption.