### PR TITLE
Add watch task and vscode config with recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["maelvalais.madoko"]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,21 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "watch",
+      "problemMatcher": []
+    },
+    {
+      "type": "npm",
+      "script": "build",
+      "problemMatcher": [],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "madoko ./docs/design/DesignGuidelines.mdk ./docs/design/java/JavaSpec.mdk ./docs/design/dotnet/DotNetSpec.mdk ./docs/design/python/PythonSpec.mdk ./docs/design/typescript/TypeScriptSpec.mdk"
+    "build": "madoko ./docs/design/DesignGuidelines.mdk ./docs/design/java/JavaSpec.mdk ./docs/design/dotnet/DotNetSpec.mdk ./docs/design/python/PythonSpec.mdk ./docs/design/typescript/TypeScriptSpec.mdk",
+    "watch": "chokidar ./docs/**/*.mdk -c \"npm run build\""
   },
   "repository": {
     "type": "git",
@@ -23,6 +24,7 @@
   "homepage": "https://github.com/Azure/azure-sdk#readme",
   "devDependencies": {
     "@types/node": "^10.12.18",
+    "chokidar-cli": "^1.2.1",
     "madoko": "^1.1.4"
   }
 }


### PR DESCRIPTION
<kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>B</kbd> builds the document by default now. You can optionally invoke watch which will run in the background and rebuild the document if any input source changes.

I've also added an extensions.json that recommends the madoko extension for syntax highlighting goodness.