### PR TITLE
Add general requirement for copyright headers and CLA for contributions

### DIFF
--- a/docs/design/OpenSource.mdk
+++ b/docs/design/OpenSource.mdk
@@ -13,12 +13,16 @@ remain active in GitHub. Your SDK component's is your primary touch point with t
 Issues and pull requests on GitHub must have an authoritative comment within one week of filing.
 ~
 
+~ Should {#github-review-open-source-guidelines}
+review the Microsoft Open Source Guidelines' [community section](https://docs.opensource.microsoft.com/releasing/foster-your-community.html) for more information on fostering a healthy open-source community.
+~
+
 ~ Must {#github-cla}
  use the [Microsoft CLA](https://cla.opensource.microsoft.com/). Microsoft makes significant contributions to [cla-assistant](https://cla-assistant.io/). It is the easiest way to ensure the CLA is signed by all contributors.
 ~
 
-~ Should {#github-review-open-source-guidelines}
-review the Microsoft Open Source Guidelines' [community section](https://docs.opensource.microsoft.com/releasing/foster-your-community.html) for more information on fostering a healthy open-source community.
+~ Must {#github-source-headers}
+ include a copyright header at the top of every source file. See the [Microsoft Open Source Guidelines](https://docs.opensource.microsoft.com/releasing/copyright-headers.html) for example headers in various languages.
 ~
 
 ## README<span></span>.md

--- a/docs/design/OpenSource.mdk
+++ b/docs/design/OpenSource.mdk
@@ -13,6 +13,10 @@ remain active in GitHub. Your SDK component's is your primary touch point with t
 Issues and pull requests on GitHub must have an authoritative comment within one week of filing.
 ~
 
+~ Must {#github-cla}
+ use the [Microsoft CLA](https://cla.opensource.microsoft.com/). Microsoft makes significant contributions to [cla-assistant](https://cla-assistant.io/). It is the easiest way to ensure the CLA is signed by all contributors.
+~
+
 ~ Should {#github-review-open-source-guidelines}
 review the Microsoft Open Source Guidelines' [community section](https://docs.opensource.microsoft.com/releasing/foster-your-community.html) for more information on fostering a healthy open-source community.
 ~

--- a/docs/design/typescript/DesignGuidelines.mdk
+++ b/docs/design/typescript/DesignGuidelines.mdk
@@ -331,10 +331,6 @@ The chosen license must be present as a comment at the top of every source file.
 // Licensed under the MIT License.
 ```
 
-### CLA {#ts-cla}
-
-Packages must use the [Microsoft CLA](https://cla.opensource.microsoft.com/). Microsoft makes significant contributions to [cla-assistant](https://cla-assistant.io/) and as a result is the easiest way to ensure the CLA is signed by all contributors.
-
 ## Dependencies {#ts-dependencies}
 
 Packages should avoid taking dependencies on tiny libraries as the cost of many small libraries adds up over time. Packages are recommended to include dependencies on larger libraries where necessary. Dependencies are subject to

--- a/docs/design/typescript/DesignGuidelines.mdk
+++ b/docs/design/typescript/DesignGuidelines.mdk
@@ -476,16 +476,6 @@ Typedoc comments give your users a pleasant tooling experience by pulling in you
 
 There is a work in progress tool called [tsdoc](https://github.com/Microsoft/tsdoc/) that aims to be the standard way to document TypeScript code. ANPS will migrate to this new documentation format, but in the meantime, the Docs team is set up to ingest only Typedoc, and thus Typedoc is the way to go for now.
 
-## GitHub Repo
-
-Library code must be public and open source on GitHub. Library code must be either in the Azure GitHub organization or a module in the [Azure SDK for Node](https://github.com/Azure/azure-sdk-for-node) repo. If an independent repo is used then the repository name must be "azure-[service-name]-node" or "azure-[service-name]-js".
-
-Package authors are encouraged to develop in the open on GitHub. It is recommended to have your GitHub repo be set up and active at least a month prior to your initial release.
-
-Your package's GitHub repo is your primary touch point with the developer community so it's important to keep up with the activity there. Issues and pull requests on GitHub must have an authoritative comment within 1 week of filing.
-
-See the Microsoft Open Source Guidelines' [community section](https://docs.opensource.microsoft.com/releasing/foster-your-community.html) for more information on fostering a healthy open-source community.
-
 ## Documentation
 
 Your package's documentation must consist of at least one quickstarts or tutorial in addition to samples, API documentation, and a reference overview. Some content, such as samples, must be included in-repo. Other content may be written externally for example on docs.microsoft.com. The following sections cover this content in more detail.

--- a/docs/design/typescript/DesignGuidelines.mdk
+++ b/docs/design/typescript/DesignGuidelines.mdk
@@ -311,26 +311,6 @@ Versions of Webpack prior to 4.0 would produce better optimized bundles if libra
 
 Azure packages authored using TypeScript export standard ES6 modules. As Node does not yet support ES6 modules natively, authoring ES6 modules for consumption in Node has a bit of friction. Most notable, a commonJS package can only import a single value. The difference between this model and ES6 modules where you can export many different things is the primary source of friction.
 
-## License, Copyright &amp; IP {#ts-ip}
-~ Todo
-Fold into common sections
-~
-
-Packages must comply with the [Microsoft Open Source guidelines](https://docs.opensource.microsoft.com/using/overview.html). In some cases, this document may be more explicit, in which case these requirements are normative. In case of conflicts, however, the Microsoft Open Source guidelines are normative.
-
-In general this section does not attempt to re-state everything in the Microsoft Open Source guidelines. An effort has been made to extract the most relevant information here, but package authors must read the Microsoft Open Source guidelines to ensure their packages are compliant.
-
-### License {#ts-license}
-
-Packages must be licensed with an [OSI-approved](https://opensource.org/licenses) license. MIT seems to be the most popular across most Azure packages, and thus is recommended. The Apache license is recommended if its patent licensing is important for your consumers, though this is unlikely.
-
-The chosen license must be present as a comment at the top of every source file. An example copyright header follows:
-
-```
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-```
-
 ## Dependencies {#ts-dependencies}
 
 Packages should avoid taking dependencies on tiny libraries as the cost of many small libraries adds up over time. Packages are recommended to include dependencies on larger libraries where necessary. Dependencies are subject to


### PR DESCRIPTION
This promotes copyright headers and CLA requirements from TypeScript to the general guidelines (these are required by MS OSS Guidelines: https://docs.opensource.microsoft.com/).