### PR TITLE
[General] Add pagination guidelines

### DIFF
--- a/docs/design/DesignGuidelines.mdk
+++ b/docs/design/DesignGuidelines.mdk
@@ -57,6 +57,8 @@ There are language-specific guidelines for C#, Java, Python, and JavaScript toda
 
 [INCLUDE=Configuration.mdk]
 
+[INCLUDE=Pagination.mdk]
+
 # C# Specific Guidelines
 
 [INCLUDE=./dotnet/DesignGuidelines.mdk]

--- a/docs/design/Pagination.mdk
+++ b/docs/design/Pagination.mdk
@@ -1,0 +1,38 @@
+## Pagination {#general-pagination}
+
+~ Must {#general-pagination-must-use-async-iterators}
+expose paginated collections using language-canonical async iterators over pages and items within pages. The APIs used to expose the async iterators are language-dependent but should align with any existing common practices in your ecosystem.
+~
+
+~ Must {#general-pagination-must-use-iterators}
+expose paginated collections using an iterator or cursor pattern if async iterators aren't a built-in feature of your language.
+~
+
+~ Must {#general-pagination-distinct-types}
+use distinct types for entities in a list endpoint and an entity returned from a get endpoint if these are different types, and otherwise you must use the same types in these situations.
+~
+
+~ Note
+Services should refrain having a difference between the type of a particular entity as it exists in a list versus the result of a GET request for that individual item as it makes the client library's surface area simpler.
+~
+
+~ MustNot {#general-pagination-no-item-iterators}
+expose an iterator over each individual item if getting each item requires a corresponding GET request to the service. One GET per item is often too expensive and so not an action we want to take on behalf of users.
+~
+
+~ Draft
+The following requirements are controversial and are not yet normative.
+
+~~ Must {#general-pagination-must-be-used-for-lists}
+expose paginated collections for any conceptual list from a service endpoint, even if the service does not yet support pagination. This will allow the client library to absorb endpoint changes in non-breaking ways.
+~~
+
+~~ Must {#general-pagination-support-toArray}
+expose an API to get a paginated collection into an array without having to implement iteration.
+~~
+
+~~ Must {#general-pagination-low-level-APIs}
+expose low-level APIs to interact with the paged endpoint directly. These low-level APIs provide more fine-grained control over the pagination process while also providing users without access to (or understanding of) async iterators to use your library.
+~~
+
+~

--- a/docs/design/Pagination.mdk
+++ b/docs/design/Pagination.mdk
@@ -1,7 +1,9 @@
 ## Pagination {#general-pagination}
 
-~ Must {#general-pagination-must-use-async-iterators}
-expose paginated collections using language-canonical async iterators over items within pages. The APIs used to expose the async iterators are language-dependent but should align with any existing common practices in your ecosystem.
+These guidelines eschew low-level pagination APIs in favor of high-level abstractions. High-level APIs are easy for developers to use for the majority use case but can be more confusing when finer grained control is required (e.g. over quota/throttling) and debugging when things go wrong. Other guidelines in this document work to mitigate this limitation e.g. by providing robust logging, tracing, and pipeline customization options.
+
+~ Must {#general-pagination-must-use-iterators}
+expose paginated collections using language-canonical iterators over items within pages. The APIs used to expose the async iterators are language-dependent but should align with any existing common practices in your ecosystem.
 ~
 
 ~ Must {#general-pagination-must-use-iterators}
@@ -12,29 +14,28 @@ expose paginated collections using an iterator or cursor pattern if async iterat
 expose non-paginated list endpoints identically to paginated list endpoints. Users shouldn't need to appreciate the difference.
 ~
 
-~ MustNot {#general-pagination-no-page-iterators}
-expose an iterator over pages (i.e. an async iterator over `Page<Response<T>>`). Services which have a use case for this iterator should reach out to the Arch board for approval.
-~
-
 ~ Must {#general-pagination-distinct-types}
 use distinct types for entities in a list endpoint and an entity returned from a get endpoint if these are different types, and otherwise you must use the same types in these situations.
 ~
 
 ~ Note
-Services should refrain having a difference between the type of a particular entity as it exists in a list versus the result of a GET request for that individual item as it makes the client library's surface area simpler.
+Services should refrain having a difference between the type of a particular entity as it exists in a list versus the result of a GET request for that individual item as it makes the client library's surface area simpler. alj asljf asldjf jlaskdj fasldkjf alsd asla  asdlaslaldj alkla this is   ajalsd jfajksdf lasjdf
 ~
 
 ~ MustNot {#general-pagination-no-item-iterators}
 expose an iterator over each individual item if getting each item requires a corresponding GET request to the service. One GET per item is often too expensive and so not an action we want to take on behalf of users.
 ~
 
-
 ~ MustNot {#general-pagination-support-toArray}
 expose an API to get a paginated collection into an array. This is a dangerous capability for services which may return many many pages.
 ~
 
-~ May {#general-pagination-low-level-APIs}
-expose low-level APIs to interact with the paged endpoint directly. These low-level APIs provide more fine-grained control over the pagination process while also providing users without access to (or understanding of) async iterators to use your library.
+The following restrictions may be lifted in the future based on user feedback and experience in the field. Projects which want to expose such APIs should reach out to the Arch board for approval.
+
+~ MustNot {#general-pagination-no-page-iterators}
+expose an iterator over pages (i.e. an async iterator over `Response<Page<T>>`). Services which have a use case for this iterator should reach out to the Arch board for approval.
 ~
 
-The guidelines in this section eschew low-level pagination APIs in favor of high-level abstractions. High-level APIs are easy for developers to use for the majority use case but can be more confusing when finer grained control is required (e.g. over quota/throttling) and debugging when things go wrong. Other guidelines in this document work to (or intend to) mitigate this limitation e.g. by providing robust logging and tracing and by providing per-operation request/response hooks.
+~ MustNot {#general-pagination-low-level-APIs}
+expose low-level APIs to interact with the paged endpoint directly. These low-level APIs provide more fine-grained control over the pagination process while also providing users without access to (or understanding of) async iterators to use your library.
+~

--- a/docs/design/Pagination.mdk
+++ b/docs/design/Pagination.mdk
@@ -20,15 +20,16 @@ Services should refrain having a difference between the type of a particular ent
 expose an iterator over each individual item if getting each item requires a corresponding GET request to the service. One GET per item is often too expensive and so not an action we want to take on behalf of users.
 ~
 
+
+~~ MustNot {#general-pagination-support-toArray}
+expose an API to get a paginated collection into an array. This is a dangerous capability for services which may return many many pages.
+~~
+
 ~ Draft
 The following requirements are controversial and are not yet normative.
 
 ~~ Must {#general-pagination-must-be-used-for-lists}
 expose paginated collections for any conceptual list from a service endpoint, even if the service does not yet support pagination. This will allow the client library to absorb endpoint changes in non-breaking ways.
-~~
-
-~~ Must {#general-pagination-support-toArray}
-expose an API to get a paginated collection into an array without having to implement iteration.
 ~~
 
 ~~ Must {#general-pagination-low-level-APIs}

--- a/docs/design/Pagination.mdk
+++ b/docs/design/Pagination.mdk
@@ -1,11 +1,19 @@
 ## Pagination {#general-pagination}
 
 ~ Must {#general-pagination-must-use-async-iterators}
-expose paginated collections using language-canonical async iterators over pages and items within pages. The APIs used to expose the async iterators are language-dependent but should align with any existing common practices in your ecosystem.
+expose paginated collections using language-canonical async iterators over items within pages. The APIs used to expose the async iterators are language-dependent but should align with any existing common practices in your ecosystem.
 ~
 
 ~ Must {#general-pagination-must-use-iterators}
 expose paginated collections using an iterator or cursor pattern if async iterators aren't a built-in feature of your language.
+~
+
+~ Must {#general-pagination-paginate-lists}
+expose non-paginated list endpoints identically to paginated list endpoints. Users shouldn't need to appreciate the difference.
+~
+
+~ MustNot {#general-pagination-no-page-iterators}
+expose an iterator over pages (i.e. an async iterator over `Page<Response<T>>`). Services which have a use case for this iterator should reach out to the Arch board for approval.
 ~
 
 ~ Must {#general-pagination-distinct-types}
@@ -21,19 +29,12 @@ expose an iterator over each individual item if getting each item requires a cor
 ~
 
 
-~~ MustNot {#general-pagination-support-toArray}
+~ MustNot {#general-pagination-support-toArray}
 expose an API to get a paginated collection into an array. This is a dangerous capability for services which may return many many pages.
-~~
-
-~ Draft
-The following requirements are controversial and are not yet normative.
-
-~~ Must {#general-pagination-must-be-used-for-lists}
-expose paginated collections for any conceptual list from a service endpoint, even if the service does not yet support pagination. This will allow the client library to absorb endpoint changes in non-breaking ways.
-~~
-
-~~ Must {#general-pagination-low-level-APIs}
-expose low-level APIs to interact with the paged endpoint directly. These low-level APIs provide more fine-grained control over the pagination process while also providing users without access to (or understanding of) async iterators to use your library.
-~~
-
 ~
+
+~ May {#general-pagination-low-level-APIs}
+expose low-level APIs to interact with the paged endpoint directly. These low-level APIs provide more fine-grained control over the pagination process while also providing users without access to (or understanding of) async iterators to use your library.
+~
+
+The guidelines in this section eschew low-level pagination APIs in favor of high-level abstractions. High-level APIs are easy for developers to use for the majority use case but can be more confusing when finer grained control is required (e.g. over quota/throttling) and debugging when things go wrong. Other guidelines in this document work to (or intend to) mitigate this limitation e.g. by providing robust logging and tracing and by providing per-operation request/response hooks.

--- a/docs/design/components.mdk
+++ b/docs/design/components.mdk
@@ -24,7 +24,7 @@ MustNot {
 }
 
 Note {
-  before:"<a class='req-label' href='#&id;'>⚠️</a> **NOTE** ";
+  before:"<a class='req-label' href='#&id;'>⚠️</a>";
 }
 
 Todo {

--- a/docs/design/typescript/TypeScriptSpec.mdk
+++ b/docs/design/typescript/TypeScriptSpec.mdk
@@ -36,6 +36,7 @@ follow these guidelines even if you're not publishing an Azure library under the
 [INCLUDE=../Cancellations.mdk]
 [INCLUDE=../Dependencies.mdk]
 [INCLUDE=../Configuration.mdk]
+[INCLUDE=../Pagination.mdk]
 
 # TypeScript-Specific Guidelines
 [INCLUDE=DesignGuidelines.mdk]


### PR DESCRIPTION
This supplants the gist discussion from earlier. I've put the controversial guidelines in a draft section. Maybe we can reach consensus on GitHub? For clarity, we the contentious items (indexes from the gist are preserved 😄)

1. Expose non-paginated APIs as paginated APIs so client changes don't break us
2. ~~Expose APIs to get all the items at a paginated endpoint into an array~~
3. Expose low-level paging APIs that enable a more manual traversal process