### PR TITLE
initial release guidance

### DIFF
--- a/docs/engineering-system/releases.md
+++ b/docs/engineering-system/releases.md
@@ -23,7 +23,11 @@ We use GitHub releases as a convenient place to put release notes. The change lo
 
 ## Release Cycle
 
-The release cycle of each SDK Component may vary based on the needs of the underlying service. The Azure SDK team recommends a release cycle around quarterly for most services.
+The release cycle of each SDK Component may vary based on the needs of the underlying service. The Azure SDK team recommends:
++ Avoiding breaking changes (major releases) under most circumstances
++ Minor releases quarterly or less
++ Patch releases as soon as bug fixes are available
++ Rev a minor release for each new Azure API version
 
 ## Package Versioning
 The team makes every effort to follow [SemVer](https://semver.org/) for versioning. Because different languages have slightly different conventions for numbering, the way that preview releases are designated varies. In a nutshell, SemVer is defined as `Major.Minor.Patch`, where
@@ -32,30 +36,37 @@ The team makes every effort to follow [SemVer](https://semver.org/) for versioni
 + Increments to the patch number (1.1.1 to 1.1.2) indicate bug fixes
 
 In addition to standard SemVer, the team occasionally releases a preview of a package that is not yet considered fully done to allow the community to dogfood and give feedback on new features. These packages may be released as one or both of:
-+ Daily: a build containing daily changes for dogfooding purposes. Expect frequent breakage.
-+ Preview: nearly complete and expected to change minimally with small tweaks. Not expected to rev often, except to graduate to being the primary release.
++ Dev: a build containing the most up-to-date changes based on the current master branch. Expect frequent and potentially breaking change in this release.
++ Preview: a release generated to get customer feedback before a GA. Preview releases rev less often than dev - most likely every few weeks. Preview releases may have breaking changes from the previous preview, but should not have breaking changes from the last GA release.
 
 ### Python
 Python version numbers follow the guidance in [PEP 440](https://www.python.org/dev/peps/pep-0440/) for versioning Python packages. This means that regular releases follow the above specified SemVer format. Preview releases follow the [PEP 440 specification for pre-releases](https://www.python.org/dev/peps/pep-0440/#pre-releases):
-+ `X.YaYYYYMMDD` (daily using alpha convention)
-+ `X.YrcZ` (preview release using release candidate convention)
++ `X.YaYYYYMMDD` (dev using alpha convention)
++ `X.YbZ` (preview release using beta convention)
+
+Python dev releases are not published to PyPi. Instead, take the Git tag to use a dev release.
 
 ### JavaScript
-The JavaScript community generally follows SemVer. For preview releases, we will release with an [NPM distribution tag](https://docs.npmjs.com/cli/dist-tag) in the formats:
-+ `X.Y.Z-daily.YYYYMMDD`
-+ `X.Y.Z-previewN`
+The JavaScript community generally follows SemVer. For preview releases, we will release with an [npm distribution tag](https://docs.npmjs.com/cli/dist-tag) in the formats:
++ `X.Y.Z-dev.YYYYMMDD`
++ `X.Y.Z-preview.N`
+
+JavaScript dev and preview releases are published to npm with the `@dev` and `@preview` tags.
 
 ### .NET
 NuGet supports designating a package as 'pre-release'. In this ecosystem, pre-release packages will have daily build numbers in the format:
-+ `X.Y.Z-daily.SHORTDATE`
++ `X.Y.Z-dev.SHORTDATE`
     + SHORTDATE is set to `yy` * 1000 + 50 * `mm` + `dd`. In year 2018 the value is in range [18051, 18631]
-+ `X.Y.Z-previewN`
++ `X.Y.Z-preview.N`
+
+Preview .NET packages will be published to NuGet with the pre-release designation. The location of dev packages is TBD.
 
 ### Java
 Maven supports the [convention](https://cwiki.apache.org/confluence/display/MAVENOLD/Versioning) `MAJOR.MINOR.PATCH-QUALIFIER`. As such, for Java distributions, the preferred format for version numbers is:
-+ `X.Y.Z-SNAPSHOT` (Daily build qualifier used in Maven. Snapshots overwrite with new versions on re-publish.)
-+ `X.Y.Z-previewN`
++ `X.Y.Z-SNAPSHOT` (Dev build qualifier used in Maven. Snapshots overwrite with new versions on re-publish.)
++ `X.Y.Z-preview.N`
 
+Dev and preview Java packages are published direct to the Maven registry.
 
 ## Deprecation
 Deprecation cycle for released versions is TBD.

--- a/docs/engineering-system/releases.md
+++ b/docs/engineering-system/releases.md
@@ -48,7 +48,8 @@ The JavaScript community generally follows SemVer. For preview releases, we will
 
 ### .NET
 NuGet supports designating a package as 'pre-release'. In this ecosystem, pre-release packages will have daily build numbers in the format:
-+ `X.Y.Z-DailyComputedTag`
++ `X.Y.Z-daily.SHORTDATE`
+    + SHORTDATE is set to `yy` * 1000 + 50 * `mm` + `dd`. In year 2018 the value is in range [18051, 18631]
 + `X.Y.Z-previewN`
 
 ### Java

--- a/docs/engineering-system/releases.md
+++ b/docs/engineering-system/releases.md
@@ -19,7 +19,7 @@ Because each language repository contains multiple packages inside of it, releas
 
 ## GitHub Releases
 
-We use GitHub releases for archival and note purposes, but recommend consuming the code using one of our preferred package managers - not the release archive on GitHub. The change log for a release is available with the GitHub release. Developers not using a package manager may also find the released libraries here.
+We use GitHub releases as a convenient place to put release notes. The change log and any additional notes will be available here. No artifacts are published to the github release. Instead, use a supported package registry.
 
 ## Release Cycle
 

--- a/docs/engineering-system/releases.md
+++ b/docs/engineering-system/releases.md
@@ -1,21 +1,10 @@
 The release process for the Azure SDK accommodates the need to release different SDK packages based on the ship cycle of the underlying service. 
 
 ## Terms
-
-SDK - The entire SDK for all Azure services
-Service - An Azure service like storage, event hub, or key vault
-Library - The SDK code for a given service and language, i.e. "Python Library for Storage"
-Package - an individual package consumed by a package manager. A library may have many packages. For example, the key vault library for .NET contains:
-
-+ Microsoft.Azure.KeyVault
-+ Microsoft.Azure.KeyVault.Core
-+ Microsoft.Azure.Management.KeyVault
-+ Microsoft.Azure.Management.KeyVault.Fluent
-+ Microsoft.Azure.KeyVault.Extensions
-+ Microsoft.Azure.KeyVault.Cryptography
+The terms "SDK", "SDK Component", "library" and "package" are used throughout this doc. Definitions can be found [here](/azure-sdk/docs/design/Introduction.mdk).
 
 ## Supported Registries
-We release libraries to the following registries:
+We release client libraries to the following registries:
 + NuGet (.NET)
 + PyPi (Python)
 + npm (JavaScript)
@@ -34,7 +23,7 @@ We use GitHub releases for archival and note purposes, but recommend consuming t
 
 ## Release Cycle
 
-The release cycle of each library may vary based on the needs of the underlying service. The Azure SDK team recommends a release cycle around quarterly for most services. It is best practice to include a "Next Release Target Date" in the README file for each library.
+The release cycle of each SDK Component may vary based on the needs of the underlying service. The Azure SDK team recommends a release cycle around quarterly for most services. It is best practice to include a "Next Release Target Date" in the README file for each library.
 
 ## Package Versioning
 The team makes every effort to follow [SemVer](https://semver.org/) for versioning. Because different languages have slightly different conventions for numbering, the way that preview releases are designated varies. In a nutshell, SemVer is defined as `Major.Minor.Patch`, where

--- a/docs/engineering-system/releases.md
+++ b/docs/engineering-system/releases.md
@@ -37,26 +37,24 @@ In addition to standard SemVer, the team occasionally releases a preview of a pa
 + Release Candidate (RC): nearly complete and expected to change very little besides small tweaks. Not expected to rev, except to graduate to being the primary release.
 
 ### Python
-Python version numbers follow the guidance in [PEP 440](https://www.python.org/dev/peps/pep-0440/) for versioning Python packages. This means that regular releases follow the above specified SemVer format. Preview releases follow the PEP 440 specification:
+Python version numbers follow the guidance in [PEP 440](https://www.python.org/dev/peps/pep-0440/) for versioning Python packages. This means that regular releases follow the above specified SemVer format. Preview releases follow the [PEP 440 specification for pre-releases](https://www.python.org/dev/peps/pep-0440/#pre-releases):
 + `X.YaYYYYMMDD` (daily using alpha convention)
-+ `X.YbZ` (beta)
-+ `X.YrcZ` (release candidate)
++ `X.YrcZ` (preview release using release candidate convention)
 
 ### JavaScript
 The JavaScript community generally follows SemVer. For preview releases, we will release with an [NPM distribution tag](https://docs.npmjs.com/cli/dist-tag) in the formats:
 + `X.Y.Z-daily.YYYYMMDD`
-+ `X.Y.Z-betaN`
-+ `X.Y.Z-rcN`
++ `X.Y.Z-previewN`
 
 ### .NET
 NuGet supports designating a package as 'pre-release'. In this ecosystem, pre-release packages will have daily build numbers in the format:
-+ `X.Y.Z.DailyComputedTag`
++ `X.Y.Z-DailyComputedTag`
++ `X.Y.Z-previewN`
 
 ### Java
 Maven supports the [convention](https://cwiki.apache.org/confluence/display/MAVENOLD/Versioning) `MAJOR.MINOR.PATCH-QUALIFIER`. As such, for Java distributions, the preferred format for version numbers is:
 + `X.Y.Z-SNAPSHOT` (Daily build qualifier used in Maven. Snapshots overwrite with new versions on re-publish.)
-+ `X.Y.Z-betaN`
-+ `X.Y.Z-rcN`
++ `X.Y.Z-previewN`
 
 ## Deprecation
 Deprecation cycle for released versions is TBD.

--- a/docs/engineering-system/releases.md
+++ b/docs/engineering-system/releases.md
@@ -23,7 +23,7 @@ We use GitHub releases as a convenient place to put release notes. The change lo
 
 ## Release Cycle
 
-The release cycle of each SDK Component may vary based on the needs of the underlying service. The Azure SDK team recommends a release cycle around quarterly for most services. It is best practice to include a "Next Release Target Date" in the README file for each library.
+The release cycle of each SDK Component may vary based on the needs of the underlying service. The Azure SDK team recommends a release cycle around quarterly for most services.
 
 ## Package Versioning
 The team makes every effort to follow [SemVer](https://semver.org/) for versioning. Because different languages have slightly different conventions for numbering, the way that preview releases are designated varies. In a nutshell, SemVer is defined as `Major.Minor.Patch`, where
@@ -55,6 +55,7 @@ NuGet supports designating a package as 'pre-release'. In this ecosystem, pre-re
 Maven supports the [convention](https://cwiki.apache.org/confluence/display/MAVENOLD/Versioning) `MAJOR.MINOR.PATCH-QUALIFIER`. As such, for Java distributions, the preferred format for version numbers is:
 + `X.Y.Z-SNAPSHOT` (Daily build qualifier used in Maven. Snapshots overwrite with new versions on re-publish.)
 + `X.Y.Z-previewN`
+
 
 ## Deprecation
 Deprecation cycle for released versions is TBD.

--- a/docs/engineering-system/releases.md
+++ b/docs/engineering-system/releases.md
@@ -31,10 +31,9 @@ The team makes every effort to follow [SemVer](https://semver.org/) for versioni
 + Increments to the minor digit (1.1.X to 1.2.X) indicate the addition of new features. 
 + Increments to the patch number (1.1.1 to 1.1.2) indicate bug fixes
 
-In addition to standard SemVer, the team occasionally releases a preview of a package that is not yet considered fully done to allow the community to dogfood and give feedback on new features. A preview may be released as one or all of of:
+In addition to standard SemVer, the team occasionally releases a preview of a package that is not yet considered fully done to allow the community to dogfood and give feedback on new features. These packages may be released as one or both of:
 + Daily: a build containing daily changes for dogfooding purposes. Expect frequent breakage.
-+ Beta: beta's rev less frequently than dailies (weekly or so), but expect to find bugs and incomplete features.
-+ Release Candidate (RC): nearly complete and expected to change very little besides small tweaks. Not expected to rev, except to graduate to being the primary release.
++ Preview: nearly complete and expected to change minimally with small tweaks. Not expected to rev often, except to graduate to being the primary release.
 
 ### Python
 Python version numbers follow the guidance in [PEP 440](https://www.python.org/dev/peps/pep-0440/) for versioning Python packages. This means that regular releases follow the above specified SemVer format. Preview releases follow the [PEP 440 specification for pre-releases](https://www.python.org/dev/peps/pep-0440/#pre-releases):

--- a/docs/engineering-system/releases.md
+++ b/docs/engineering-system/releases.md
@@ -14,14 +14,14 @@ Package - an individual package consumed by a package manager. A library may hav
 + Microsoft.Azure.KeyVault.Extensions
 + Microsoft.Azure.KeyVault.Cryptography
 
-## Supported Package Managers
-We release libraries to the following package managers:
+## Supported Registries
+We release libraries to the following registries:
 + NuGet (.NET)
 + PyPi (Python)
 + npm (JavaScript)
 + Maven (Java)
 
-Package managers are the recommended way to consume the Azure SDK.
+Package managers that support these registries are the recommended way to consume the Azure SDK.
 
 ## Git Tagging
 

--- a/docs/engineering-system/releases.md
+++ b/docs/engineering-system/releases.md
@@ -1,0 +1,73 @@
+The release process for the Azure SDK accommodates the need to release different SDK packages based on the ship cycle of the underlying service. 
+
+## Terms
+
+SDK - The entire SDK for all Azure services
+Service - An Azure service like storage, event hub, or key vault
+Library - The SDK code for a given service and language, i.e. "Python Library for Storage"
+Package - an individual package consumed by a package manager. A library may have many packages. For example, the key vault library for .NET contains:
+
++ Microsoft.Azure.KeyVault
++ Microsoft.Azure.KeyVault.Core
++ Microsoft.Azure.Management.KeyVault
++ Microsoft.Azure.Management.KeyVault.Fluent
++ Microsoft.Azure.KeyVault.Extensions
++ Microsoft.Azure.KeyVault.Cryptography
+
+## Supported Package Managers
+We release libraries to the following package managers:
++ NuGet (.NET)
++ PyPi (Python)
++ npm (JavaScript)
++ Maven (Java)
+
+Package managers are the recommended way to consume the Azure SDK.
+
+## Git Tagging
+
+Because each language repository contains multiple packages inside of it, releases for each package are tagged in the format `<package-name>_<package-version>`.
+
+
+## GitHub Releases
+
+We use GitHub releases for archival and note purposes, but recommend consuming the code using one of our preferred package managers - not the release archive on GitHub. The change log for a release is available with the GitHub release. Developers not using a package manager may also find the released libraries here.
+
+## Release Cycle
+
+The release cycle of each library may vary based on the needs of the underlying service. The Azure SDK team recommends a release cycle around quarterly for most services. It is best practice to include a "Next Release Target Date" in the README file for each library.
+
+## Package Versioning
+The team makes every effort to follow [SemVer](https://semver.org/) for versioning. Because different languages have slightly different conventions for numbering, the way that preview releases are designated varies. In a nutshell, SemVer is defined as `Major.Minor.Patch`, where
++ Changes to the major digit (1.X.Y to 2.X.Y) indicate that breaking changes have been introduced. 
++ Increments to the minor digit (1.1.X to 1.2.X) indicate the addition of new features. 
++ Increments to the patch number (1.1.1 to 1.1.2) indicate bug fixes
+
+In addition to standard SemVer, the team occasionally releases a preview of a package that is not yet considered fully done to allow the community to dogfood and give feedback on new features. A preview may be released as one or all of of:
++ Daily: a build containing daily changes for dogfooding purposes. Expect frequent breakage.
++ Beta: beta's rev less frequently than dailies (weekly or so), but expect to find bugs and incomplete features.
++ Release Candidate (RC): nearly complete and expected to change very little besides small tweaks. Not expected to rev, except to graduate to being the primary release.
+
+### Python
+Python version numbers follow the guidance in [PEP 440](https://www.python.org/dev/peps/pep-0440/) for versioning Python packages. This means that regular releases follow the above specified SemVer format. Preview releases follow the PEP 440 specification:
++ `X.YaYYYYMMDD` (daily using alpha convention)
++ `X.YbZ` (beta)
++ `X.YrcZ` (release candidate)
+
+### JavaScript
+The JavaScript community generally follows SemVer. For preview releases, we will release with an [NPM distribution tag](https://docs.npmjs.com/cli/dist-tag) in the formats:
++ `X.Y.Z-daily.YYYYMMDD`
++ `X.Y.Z-betaN`
++ `X.Y.Z-rcN`
+
+### .NET
+NuGet supports designating a package as 'pre-release'. In this ecosystem, pre-release packages will have daily build numbers in the format:
++ `X.Y.Z.DailyComputedTag`
+
+### Java
+Maven supports the [convention](https://cwiki.apache.org/confluence/display/MAVENOLD/Versioning) `MAJOR.MINOR.PATCH-QUALIFIER`. As such, for Java distributions, the preferred format for version numbers is:
++ `X.Y.Z-SNAPSHOT` (Daily build qualifier used in Maven. Snapshots overwrite with new versions on re-publish.)
++ `X.Y.Z-betaN`
++ `X.Y.Z-rcN`
+
+## Deprecation
+Deprecation cycle for released versions is TBD.


### PR DESCRIPTION
This is an initial stab at how we want to handle the SDK release process including preview releases. A LOT of stuff is outstanding/not determined here and I'm sure there will be tons of opinions. Send me your thoughts!

Some issues to think about:
+ ~~Do we need to support daily, beta, and RC releases? Opinions seem divided about this. Do we just have one kind of 'preview' release? Is that one kind of preview a daily?~~
  + Just using 'Daily' and 'Preview'
+ ~~@weshaggard was pretty set on having .NET just do daily and then actual releases. Wes - do you have the algorithm you were using to generate day numbers as short's for me?~~
  + See above
+ ~~Can we require that all libraries have a 'next expected release date' in the README? this might be the easiest guideline to provide?~~
  + Guidance removed
+ What is the guidance on breaking compatibility/breaking changes?
+ How do we publish preview releases in Python and .NET? There is some desire to not use PyPi and NuGet for nightlies as they don't like this behavior.
+ Do we publish build artifacts to the GitHub release?

@JonathanGiles @johanste @bterlson does this look like what you were thinking for version numbering?