### PR TITLE
Adding ChangeLog Guidance

### DIFF
--- a/docs/engineering-system/releases.md
+++ b/docs/engineering-system/releases.md
@@ -29,6 +29,7 @@ How?
 
 * **.NET:** extend nuspec to include `changelog.md` in the `.nupkg.` 
 * **Java:** add `changelog.md` to the existing artifact list.
+    * Note that the convention here is `<packageIdentifier>.md`. This mirrors the four existing artifacts per package.
 * **JS:** ensure `changelog.md` is included in the package tarball.
 * **Python:** ensure `changelog.md` is present in the `sdist` artifact.
 

--- a/docs/engineering-system/releases.md
+++ b/docs/engineering-system/releases.md
@@ -19,7 +19,33 @@ Because each language repository contains multiple packages inside of it, releas
 
 ## GitHub Releases
 
-We use GitHub releases as a convenient place to put release notes. The change log and any additional notes will be available here. No artifacts are published to the github release. Instead, use a supported package registry.
+We use GitHub releases as a convenient place to put release notes. The change log and any additional notes will be available here. ES Systems will automatically publish release notes to a GitHub release if the changelog guidance below is followed. No artifacts are published to the GitHub release. Instead, use a supported package registry.
+
+## ChangeLog Guidance
+
+We recommend that every package maintain a changelog just a matter of course. However, there is an additional benefit. Ensuring that a `changelog.md` file is both available and formatted appropriately will result in automatically formatted release notes on each GitHub release. 
+
+How?
+
+* **.NET:** extend nuspec to include `changelog.md` in the `.nupkg.` 
+* **Java:** add `changelog.md` to the existing artifact list.
+* **JS:** ensure `changelog.md` is included in the package tarball.
+* **Python:** ensure `changelog.md` is present in the `sdist` artifact.
+
+A given `changelog.md` file must follow the below form:
+
+```
+# <release date in YYYY-MM-DD> - <versionSpecifier>
+
+<content. as long as it doesn't introduce another header that looks like the one above>
+
+...additional changelog entries
+
+```
+
+During release, if there exists a changelog entry with a version specifier _matching_ that of the currently releasing package, that changelog entry will be added as the body of the GitHub release.
+
+The [JS ServiceBus SDK](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/servicebus/service-bus/changelog.md) maintains a great changelog example. Given that changelog, this is what a [release](https://github.com/Azure/azure-sdk-for-js/releases/tag/%40azure%2Fservice-bus_1.0.0-preview.2) looks like.
 
 ## Release Cycle
 

--- a/docs/engineering-system/releases.md
+++ b/docs/engineering-system/releases.md
@@ -19,7 +19,7 @@ Because each language repository contains multiple packages inside of it, releas
 
 ## GitHub Releases
 
-We use GitHub releases as a convenient place to put release notes. The change log and any additional notes will be available here. ES Systems will automatically publish release notes to a GitHub release if the changelog guidance below is followed. No artifacts are published to the GitHub release. Instead, use a supported package registry.
+We use GitHub releases as a convenient place to put release notes. The change log and any additional notes will be available here. ES automation will automatically publish release notes to a GitHub release if the changelog guidance below is followed. No artifacts are published to the GitHub release. Instead, use a supported package registry.
 
 ## ChangeLog Guidance
 

--- a/docs/engineering-system/releases.md
+++ b/docs/engineering-system/releases.md
@@ -23,7 +23,7 @@ We use GitHub releases as a convenient place to put release notes. The change lo
 
 ## ChangeLog Guidance
 
-We recommend that every package maintain a changelog just a matter of course. However, there is an additional benefit. Ensuring that a `changelog.md` file is both available and formatted appropriately will result in automatically formatted release notes on each GitHub release. 
+We recommend that every package maintain a changelog just as a matter of course. However, there is an additional benefit. Ensuring that a `changelog.md` file is both available and formatted appropriately will result in automatically formatted release notes on each GitHub release. 
 
 How?
 
@@ -37,14 +37,18 @@ A given `changelog.md` file must follow the below form:
 
 ```
 # <release date in YYYY-MM-DD> - <versionSpecifier>
-
 <content. as long as it doesn't introduce another header that looks like the one above>
 
-...additional changelog entries
+...
+
+# <an older release date> - <older versionSpecifier>
+<content/changes for the older release>
+
+... older release details trail off into history below
 
 ```
 
-During release, if there exists a changelog entry with a version specifier _matching_ that of the currently releasing package, that changelog entry will be added as the body of the GitHub release.
+For clarity, a `change log entry` is simply the header + content up to the next release header OR EOF. During release, if there exists a changelog entry with a version specifier _matching_ that of the currently releasing package, that changelog entry will be added as the body of the GitHub release.
 
 The [JS ServiceBus SDK](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/servicebus/service-bus/changelog.md) maintains a great changelog example. Given that changelog, this is what a [release](https://github.com/Azure/azure-sdk-for-js/releases/tag/%40azure%2Fservice-bus_1.0.0-preview.2) looks like.
 

--- a/docs/engineering-system/releases.md
+++ b/docs/engineering-system/releases.md
@@ -36,12 +36,12 @@ How?
 A given `changelog.md` file must follow the below form:
 
 ```
-# <release date in YYYY-MM-DD> - <versionSpecifier>
+# <versionSpecifier>
 <content. as long as it doesn't introduce another header that looks like the one above>
 
 ...
 
-# <an older release date> - <older versionSpecifier>
+# <older versionSpecifier>
 <content/changes for the older release>
 
 ... older release details trail off into history below


### PR DESCRIPTION
Only part in contention will probably be:

```
# <versionSpecifier>
<content. as long as it doesn't introduce another header that looks like the one above>
...additional changelog entries
```
Does anyone have a problem with this style?
