### PR TITLE
moving readme template links into the design guidelines.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ The Azure SDK delivers a platform for developers to leverage the wide variety of
 
 ## Azure SDK Design Guidelines
 
-- [.NET](https://azuresdkspecs.z5.web.core.windows.net/DotNetSpec.html) ([template](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/template/Azure.Template))
-- [Java](https://azuresdkspecs.z5.web.core.windows.net/JavaSpec.html) ([template](https://github.com/Azure/azure-sdk-for-java/tree/master/sdk/template/azure-sdk-template))
-- [Python](https://azuresdkspecs.z5.web.core.windows.net/PythonSpec.html) ([template](https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/template/azure-template))
-- [TypeScript](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html) ([template](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/template/template))
+- [.NET](https://azuresdkspecs.z5.web.core.windows.net/DotNetSpec.html)
+- [Java](https://azuresdkspecs.z5.web.core.windows.net/JavaSpec.html)
+- [Python](https://azuresdkspecs.z5.web.core.windows.net/PythonSpec.html)
+- [TypeScript](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html)
 
 Service teams should schedule reviews of their client libraries with the ADP Review Board.  See the [Review Process](docs/ReviewProcess.md) for more information.
 

--- a/docs/design/OpenSource.mdk
+++ b/docs/design/OpenSource.mdk
@@ -33,7 +33,12 @@ review the Microsoft Open Source Guidelines' [community section](https://docs.op
 ## README.md {#general-readme}
 
 ~ Must {#github-readme}
-include a `README.md` in the client library folder within the repository. The `README.md` should follow the [readme template](https://github.com/Azure/azure-sdk/blob/master/docs/README-TEMPLATE.md).
+include a `README.md` in the client library folder within the repository. The `README.md` should follow the readme template that matches the language based off of the [general template](https://github.com/Azure/azure-sdk/blob/master/docs/README-TEMPLATE.md):
+
+* [.NET](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/template/Azure.Template)
+* [Java](https://github.com/Azure/azure-sdk-for-java/tree/master/sdk/template/azure-sdk-template)
+* [Python](https://github.com/Azure/azure-sdk-for-python/tree/master/sdk/template/azure-template)
+* [TypeScript](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/template/template)
 ~
 
 ## CONTRIBUTING.md


### PR DESCRIPTION
Now that we taking a dependency on 2.0 packages, we should just simplify and and let the < 4.7.2 problem phase out.