### PR TITLE
Update .NET package version to use date and revision

### DIFF
--- a/docs/engineering-system/releases.md
+++ b/docs/engineering-system/releases.md
@@ -86,8 +86,8 @@ JavaScript dev and preview releases are published to npm with the `@dev` and `@p
 
 ### .NET
 NuGet supports designating a package as 'pre-release'. In this ecosystem, pre-release packages will have daily build numbers in the format:
-+ `X.Y.Z-dev.SHORTDATE`
-    + SHORTDATE is set to `yy` * 1000 + 50 * `mm` + `dd`. In year 2018 the value is in range [18051, 18631]
++ `X.Y.Z-dev.YYYMMDD.r`
+    + r is the number of builds done in a given day. 
 + `X.Y.Z-preview.N`
 
 Preview .NET packages will be published to NuGet with the pre-release designation. The location of dev packages is TBD.

--- a/docs/engineering-system/releases.md
+++ b/docs/engineering-system/releases.md
@@ -86,7 +86,7 @@ JavaScript dev and preview releases are published to npm with the `@dev` and `@p
 
 ### .NET
 NuGet supports designating a package as 'pre-release'. In this ecosystem, pre-release packages will have daily build numbers in the format:
-+ `X.Y.Z-dev.YYYMMDD.r`
++ `X.Y.Z-dev.YYYYMMDD.r`
     + r is the number of builds done in a given day. 
 + `X.Y.Z-preview.N`
 


### PR DESCRIPTION
@maggiepint using the date for .NET works pretty well so updating to doc.

In case you are interested the implementation for this in the .NET repo is https://github.com/Azure/azure-sdk-for-net/pull/6237

