### PR TITLE
Drop requirement to support Python 3.4

### DIFF
--- a/docs/design/python/DesignGuidelines.mdk
+++ b/docs/design/python/DesignGuidelines.mdk
@@ -1,7 +1,7 @@
 ## Supported Python versions {#python-scope; @h1-h2: decimal; }
 
 ~ Must {#python-version-support}
-provide packages supporting Python 2.7 and Python 3.4+
+provide packages supporting Python 2.7 and Python 3.5.3.
 ~
 
 ## Supported Python interpreters


### PR DESCRIPTION
New baseline is 3.5.3 (3.4 is EOL).