### PR TITLE
Update to clarify that cancellation and timeouts are not separate entities

### DIFF
--- a/docs/design/Cancellations.mdk
+++ b/docs/design/Cancellations.mdk
@@ -1,4 +1,4 @@
-## Cancellation & Timeouts {#general-cancellations}
+## Cancellation with Timeouts {#general-cancellations}
 
 When an application makes a network request, the network infrastructure (like routers) and the called service may take a long time to respond and, in fact, may never respond. A well-written application SHOULD NEVER give up its control to the network infrastucture or service. 
 


### PR DESCRIPTION
The header `Cancellation & Timeouts` had me thinking that both needed to implemented as 2 separate options i.e provide cancellation token as well as a separate timeout option.

On discussion with @bterlson, it was clarified that the cancellation mechanism is expected to have the timeout logic in it and a separate timeout is not needed.

This PR is to update the header to clarify this.