### PR TITLE
TypeScript guidelines minor fixes/updates

### DIFF
--- a/docs/design/typescript/DesignGuidelines.mdk
+++ b/docs/design/typescript/DesignGuidelines.mdk
@@ -437,8 +437,8 @@ This section covers the contents of your tsconfig.json. After implementing this 
   set `compilerOptions.experimentalDecorators` to `true`. The experimentalDecorators flag adds support for "v1 decorators" to TypeScript. Unfortunately the standards process has moved on to a somewhat incompatible second version that is not yet implemented by TypeScript. Taking a dependency on decorators now means signing up your users for potential breakage later. Until decorators become a standard feature, projects must not use decorators.
 ~
 
-~ Must {#ts-config-sourceMaps}
-  set `compilerOptions.sourceMaps` and `compilerOptions.declarationMap` to true. Shipping source maps in your package ensures clients can easily debug into your library code. `sourceMaps` maps your emitted JS source to the declaration file and `declarationMap` maps the declaration file back to the TypeScript source that generated it. Be sure to include your original TypeScript sources in the package.
+~ Must {#ts-config-sourceMap}
+  set `compilerOptions.sourceMap` and `compilerOptions.declarationMap` to true. Shipping source maps in your package ensures clients can easily debug into your library code. `sourceMap` maps your emitted JS source to the declaration file and `declarationMap` maps the declaration file back to the TypeScript source that generated it. Be sure to include your original TypeScript sources in the package.
 ~
 
 ~ Must {#ts-config-importHelpers}

--- a/docs/design/typescript/DesignGuidelines.mdk
+++ b/docs/design/typescript/DesignGuidelines.mdk
@@ -32,7 +32,7 @@ support 100% of the features supported by the backing services. Gaps in function
 
 These guidelines are in addition to the [general guidelines for configuration](#general-configuration).
 
-~ Must
+~ Todo
 use the `@azure/core-configuration` package which implements the above guidelines for the JS SDK.
 ~
 

--- a/docs/design/typescript/DesignGuidelines.mdk
+++ b/docs/design/typescript/DesignGuidelines.mdk
@@ -348,7 +348,7 @@ Both of these protocols are built into the language (Iterators as of ES6, Async 
 
 ### TypeScript
 
-~ Should {#ts-use-typescript}
+~ Must {#ts-use-typescript}
   implement your library in TypeScript.
 ~
 

--- a/docs/design/typescript/DesignGuidelines.mdk
+++ b/docs/design/typescript/DesignGuidelines.mdk
@@ -200,7 +200,7 @@ set `main` to point to either a CommonJS or a UMD module. Main is the entry poin
 set `main` to include any ES6+ syntax.
 ~
 
-~ Must
+~ Must {#ts-package-json-module}
 set `module` to the ES6 module entrypoint of your application. 
 Tools such as Webpack use this key to discover the static module graph of your application for optimization purposes. See [#ts-source-distros-esm] for more information.
 ~
@@ -314,7 +314,7 @@ Library APIs must be idiomatic and must follow best practices.
 
 In addition to the guidelines in [#general-error-handling], the following guidelines apply to JavaScript libraries.
 
-~ Must {}
+~ Must {#ts-error-handling}
 use ECMAScript built-in error types for validation failures when appropriate. Specifically,
 
 * Use `TypeError` for errors relating to passing in an incorrect type, such as an Object when a string is expected.

--- a/docs/design/typescript/DesignGuidelines.mdk
+++ b/docs/design/typescript/DesignGuidelines.mdk
@@ -170,7 +170,7 @@ set `bugs` to an object with a `url` key pointing to your library's issue tracke
 ~
 
 ~ Must {#ts-package-json-repo}
-set `repository` to the JS SDK monorepo - `github:azure/azure-sdk`. Use of the `github:user/repo` short-hand is recommended.
+set `repository` to the JS SDK monorepo - `github:Azure/azure-sdk-for-js`. Use of the `github:user/repo` short-hand is recommended.
 ~
 
 ~ Must {#ts-package-json-description}


### PR DESCRIPTION
Implements minor changes to the TypeScript-specific guidelines:
- Creates the `ts-package-json-module` and `ts-error-handling` rule IDs for existing rules
- Upgrades the requirement that TypeScript be used from "Should" to "Must"
- Marks usage of the `@azure/core-configuration` package as a TODO (package does not exist yet)
- In `ts-package-json-repo`, changes the monorepo link from this repository's link to the JavaScript/Typescript-specific monorepo
- Renames `ts-config-sourceMaps` to `ts-config-sourceMap` and accordingly for any instance of the string `sourceMaps` (typo)