### PR TITLE
Create multi-library release note template

### DIFF
--- a/docs/release-notes/preview/high-level-relnote-template.md
+++ b/docs/release-notes/preview/high-level-relnote-template.md
@@ -15,7 +15,7 @@ To install them individually
     $> SomeOackMain install
 
 ## Feedback
-If you have a bug or feature request for one of the libraries, please post an issue to TODO [GitHub](https://github.com/auzre/azure-sdk-for-XXX/issues) and add the labels Preview and Bug or Feature
+If you have a bug or feature request for one of the libraries, please post an issue to TODO [GitHub](https://github.com/azure/azure-sdk-for-XXX/issues) and add the labels Preview and Bug or Feature
 
 If you have a question, please post a question to Stack Overflow with the following Tags:
 > [azure-sdk] [beta] [ TODO_ONE_OF [python], [java], [javascript], [.net]]

--- a/docs/release-notes/preview/high-level-relnote-template.md
+++ b/docs/release-notes/preview/high-level-relnote-template.md
@@ -1,6 +1,6 @@
 # Azure SDK TODO_LANG Preview 1 Release Notes 
 
-TODO High level info about the release
+TODO High level info about the release what goals, what libraries are coming with this release, key new features.
 
 ## Installation Instructions
 To install all the of the packages, copy and paste the below into a terminal.
@@ -15,18 +15,19 @@ To install them individually
     $> SomeOackMain install
 
 ## Feedback
-If you have a question, please post a question to Stack Overflow with the following Tags:
-> [azure-sdk] [beta] [ TODO ONE OF [python], [java], [javascript], [.net]]
+If you have a bug or feature request for one of the libraries, please post an issue to TODO [GitHub](https://github.com/auzre/azure-sdk-for-XXX/issues) and add the labels Preview and Bug or Feature
 
-If you have a bug or feature request for one of the libraries, please post an issue to [GitHub](https://github.com/auzre/azure-sdk-for-XXX/issues) and add the labels Preview and Bug or Feature
+If you have a question, please post a question to Stack Overflow with the following Tags:
+> [azure-sdk] [beta] [ TODO_ONE_OF [python], [java], [javascript], [.net]]
+
 
 ## Changelog
 Detailed change logs are linked to in the Quick Links below. Here are some critical call outs.
 
-TODO: Replace with bigger items.
+TODO: Replace with the top 5 to 10 Features, Known Issues, or Migration pointers.
 
 ## Quick Links
 TODO: fill out table and update links
 | Service  | Install | Quickstart |  API Reference | Changelog |
 | -- | -- | -- | -- | -- |
-| Storage Blobs | TODO [package](https://crates.io/crates/azure_sdk_for_rust) | TODO [Readme.md](github.com) | TODO [Preview Documentation](docs.microsoft.com) | TODO [Changelog.md](github.com) |
+| Storage Blobs | TODO [package](https://crates.io/crates/azure_sdk_for_rust) | TODO [Readme.md](github.com) | TODO [Preview Documentation](azure.github.io) | TODO [Changelog.md](github.com) |

--- a/docs/release-notes/preview/high-level-relnote-template.md
+++ b/docs/release-notes/preview/high-level-relnote-template.md
@@ -1,0 +1,32 @@
+# Azure SDK TODO_LANG Preview 1 Release Notes 
+
+TODO High level info about the release
+
+## Installation Instructions
+To install all the of the packages, copy and paste the below into a terminal.
+
+TODO Update code below
+    
+    SomePackMan install_command XXX_cosmosFQ XXX_eventhubsFQ XXX_keyvaultFQ XXX_storageFQ
+
+To install them individually
+
+    $> SomePackMan install_command Cosmos
+    $> SomeOackMain install
+
+## Feedback
+If you have a question, please post a question to Stack Overflow with the following Tags:
+> [azure-sdk] [beta] [ TODO ONE OF [python], [java], [javascript], [.net]]
+
+If you have a bug or feature request for one of the libraries, please post an issue to [GitHub](https://github.com/auzre/azure-sdk-for-XXX/issues) and add the labels Preview and Bug or Feature
+
+## Changelog
+Detailed change logs are linked to in the Quick Links below. Here are some critical call outs.
+
+TODO: Replace with bigger items.
+
+## Quick Links
+TODO: fill out table and update links
+| Service  | Install | Quickstart |  API Reference | Changelog |
+| -- | -- | -- | -- | -- |
+| Storage Blobs | TODO [package](https://crates.io/crates/azure_sdk_for_rust) | TODO [Readme.md](github.com) | TODO [Preview Documentation](docs.microsoft.com) | TODO [Changelog.md](github.com) |


### PR DESCRIPTION
Library packages are released one at a time or many at once. When
multiple are being released at once, this template should be used
to provide easy jumping off pointers and information about the set of
packages in the group.

To use it, fill in the details in the TODOs and copy in a versioned
folder in the release-notes directory of the Azure-SDK repository.