### PR TITLE
Renaming ConfigurationClientModelFactory to ConfigurationModelFactory

### DIFF
--- a/docs/design/dotnet/DesignGuidelines.mdk
+++ b/docs/design/dotnet/DesignGuidelines.mdk
@@ -526,7 +526,7 @@ var mockResponse = new Mock<Response>();
 var mock = new Mock<ConfigurationClient>();
 // Setup client method
 mock.Setup(c => c.Get("Key", It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
-    .Returns(new Response<ConfigurationSetting>(mockResponse.Object, ConfigurationClientModelFactory.ConfigurationSetting("Key", "Value")));
+    .Returns(new Response<ConfigurationSetting>(mockResponse.Object, ConfigurationModelFactory.ConfigurationSetting("Key", "Value")));
 
 // Use the client mock
 ConfigurationClient client = mock.Object;


### PR DESCRIPTION
Per .NET guidelines