### PR TITLE
Add requirement that per-try timeouts should have clear and actionable errors

### DIFF
--- a/docs/design/general/AzureCorePipeline.mdk
+++ b/docs/design/general/AzureCorePipeline.mdk
@@ -117,6 +117,10 @@ retry if the service successfully responds indicating that it is throttling requ
 retry if the service responds with a 400-level response code unless a retry-after header is also returned.
 ~
 
+~ Must {#azurecore-retry-clear-errors}
+indicate when errors are thrown as a result of a retry policy's per-try timeout being exceeded, and include a note about how it should be configured by the user.
+~
+
 ~ MustNot {#azurecore-retry-no-change-request-id}
 change any client-side generated request-id as this represents the logical operation and should be the same across all physical retries of this operation.  When looking at server logs, multiple entries with the same client request-id show each retry and this is useful information to help diagnose issues.
 ~


### PR DESCRIPTION
@JeffreyRichter raised this point in a meeting the other day, I think it's important enough to lift to a guideline. What do you think?