### PR TITLE
Adding accessibility for emoji's and updating code style

### DIFF
--- a/docs/design/components.mdk
+++ b/docs/design/components.mdk
@@ -2,43 +2,43 @@ Logo        : False
 Embed       : False
 
 Must {
-  before:"<a class='req-label' href='#&id;'>✅</a> **DO** ";
+  before:"<a class='req-label' href='#&id;' role='img' aria-label='DO'>✅</a> **DO** ";
   toc: requirements;
   toc-line: "<tr><td>&id;</td><td>blah</td></tr>";
 }
 
 MustNot {
-  before:"<a class='req-label' href='#&id;'>⛔️</a> **DO NOT** ";
+  before:"<a class='req-label' href='#&id;' role='img' aria-label='DO NOT'>⛔️</a> **DO NOT** ";
 }
 
 Should {
-  before:"<a class='req-label' href='#&id;'>☑️</a> **YOU SHOULD** ";
+  before:"<a class='req-label' href='#&id;' role='img' aria-label='YOU SHOULD'>☑️</a> **YOU SHOULD** ";
 }
 
 ShouldNot {
-  before:"<a class='req-label' href='#&id;'>⚠️</a> **YOU SHOULD NOT** ";
+  before:"<a class='req-label' href='#&id;' role='img' aria-label='YOU SHOULD NOT'>⚠️</a> **YOU SHOULD NOT** ";
 }
 
 May {
-  before:"<a class='req-label' href='#&id;'>☑️</a> **YOU MAY** ";
+  before:"<a class='req-label' href='#&id;' role='img' aria-label='YOU MAY'>☑️</a> **YOU MAY** ";
 }
 
 Optional {
-  before:"<a class='req-label' href='#&id;'>⚠️</a> **IT IS OPTIONAL** to ";
+  before:"<a class='req-label' href='#&id;' role='img' aria-label='IT IS OPTIONAL'>⚠️</a> **IT IS OPTIONAL** to ";
 }
 
 Note {
-  before:"<a class='req-label' href='#&id;'>⚠️</a>";
+  before:"<a class='req-label' href='#&id;' role='img' aria-label='Note'>⚠️</a>";
 }
 
 Todo {
-  before:"<a class='req-label' href='#&id;'>✏️</a>";
+  before:"<a class='req-label' href='#&id;' role='img' aria-label='To Do'>✏️</a>";
 }
 
 Example {
-  before:"<a class='req-label' href='#&id;'>🔍</a>";
+  before:"<a class='req-label' href='#&id;' role='img' aria-label='Example'>🔍</a>";
 }
 
 Draft {
-  before:"<p class='draft-header'>⚠️ Draft</p>";
+  before:"<p class='draft-header' role='img' aria-label='Draft'>⚠️ Draft</p>";
 }

--- a/docs/design/general/custom.css
+++ b/docs/design/general/custom.css
@@ -1,6 +1,7 @@
 body.madoko {
   font-size: 16px;
-  font-family: Segoe UI, SegoeUI, Segoe WP, Helvetica Neue, Helvetica, Tahoma, Arial, sans-serif;
+  font-family: Segoe UI, SegoeUI, Segoe WP, Helvetica Neue, Helvetica, Tahoma,
+    Arial, sans-serif;
 }
 
 .must,
@@ -55,11 +56,18 @@ a.req-label {
 }
 
 .madoko code.code,
-.madoko span.code,
-.madoko pre code {
-  color: #aa0000;
+.madoko span.code {
   font-weight: 700;
+  border-radius: 3px;
+  background-color: rgba(27, 31, 35, 0.05);
+  padding: 0.2em 0.4em;
+  line-height: 1.6;
 }
+
+.madoko pre code {
+  background-color: white;
+}
+
 .madoko p {
   text-align: left;
 }


### PR DESCRIPTION
This PR 
1. Adds role='img" and descriptive aria-label tags to the hyperlinked emoji's for screen readers.
2. Updates the code style to follow a GitHub-like highlighted gray-box style for **code**
 