### PR TITLE
(#503) Removed chokidar-cli (security issues)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "madoko ./docs/design/general/DesignGuidelines.mdk ./docs/design/java/JavaSpec.mdk ./docs/design/dotnet/DotNetSpec.mdk ./docs/design/python/PythonSpec.mdk ./docs/design/typescript/TypeScriptSpec.mdk",
-    "build-pdf": "madoko --pdf -v ./docs/design/general/DesignGuidelines.mdk ./docs/design/java/JavaSpec.mdk ./docs/design/dotnet/DotNetSpec.mdk ./docs/design/python/PythonSpec.mdk ./docs/design/typescript/TypeScriptSpecNew.mdk",
-    "watch": "chokidar ./docs/**/*.mdk -c \"npm run build\""
+    "build-pdf": "madoko --pdf -v ./docs/design/general/DesignGuidelines.mdk ./docs/design/java/JavaSpec.mdk ./docs/design/dotnet/DotNetSpec.mdk ./docs/design/python/PythonSpec.mdk ./docs/design/typescript/TypeScriptSpecNew.mdk"
   },
   "repository": {
     "type": "git",
@@ -24,8 +23,6 @@
   },
   "homepage": "https://github.com/Azure/azure-sdk#readme",
   "devDependencies": {
-    "@types/node": "^10.12.18",
-    "chokidar-cli": "^1.2.1",
     "madoko": "^1.1.4"
   }
 }


### PR DESCRIPTION
chokidar-cli relies on lodash < 4.17.12, which means it has a high-risk security vulnerability.  Disabling the watch capability until we can get an alternate file watcher going.