### PR TITLE
Update copyright header definitions and add missing IDs

### DIFF
--- a/docs/design/general/OpenSource.mdk
+++ b/docs/design/general/OpenSource.mdk
@@ -30,8 +30,8 @@ use the [Microsoft CLA](https://cla.opensource.microsoft.com/). Microsoft makes 
 include a copyright header at the top of every source file (including samples). The expected copyright header is as follows:
 
 ```fundamental
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
 ```
 ~
 

--- a/docs/design/general/OpenSource.mdk
+++ b/docs/design/general/OpenSource.mdk
@@ -27,7 +27,12 @@ use the [Microsoft CLA](https://cla.opensource.microsoft.com/). Microsoft makes 
 ~
 
 ~ Must {#github-source-headers}
-include a copyright header at the top of every source file (including samples). See the [Microsoft Open Source Guidelines](https://docs.opensource.microsoft.com/releasing/copyright-headers.html) for example headers in various languages.
+include a copyright header at the top of every source file (including samples). The expected copyright header is as follows:
+
+```fundamental
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+```
 ~
 
 ## CONTRIBUTING.md

--- a/docs/design/typescript/APIShape.mdk
+++ b/docs/design/typescript/APIShape.mdk
@@ -204,10 +204,6 @@ export interface ContainerGetPropertiesHeaders {
 name service client types with the _Client_ suffix.
 ~
 
-~ Should
-use one of the approved verbs in Table [#ts-approved-verbs] when referring to service operations
-~
-
 ~ TableFigure {#ts-approved-verbs}
 |Verb|Parameters|Returns|Comments|
 |-|-|-|-|

--- a/docs/design/typescript/Logging.mdk
+++ b/docs/design/typescript/Logging.mdk
@@ -1,14 +1,14 @@
 #### Logging in JavaScript
 
-~ Must
+~ Must {#ts-logging-debug}
 use the `debug` module to log to stderr or the browser console.
 ~
 
-~ Must
+~ Must {#ts-logging-channel-names}
 prefix channel names with `azure:<service-name>`.
 ~
 
-~ Must
+~ Must {#ts-logging-levels}
 create log channels for the following log levels with the following channel name suffixes:
 
 * Error: `:error`
@@ -16,11 +16,11 @@ create log channels for the following log levels with the following channel name
 * Info: `:info`
 ~
 
-~ May
+~ May {#ts-logging-additional-channels}
 have additional log channels, for example, to log from separate components. However, these channels MUST still provide the three log levels from above for each subchannel.
 ~
 
-~ Must
+~ Must {#ts-logging-visibility}
 expose all log channels as top-level exports of your package, allowing the consumer to configure how the logging happens and integrate with 3rd-party loggers.
 ~
 

--- a/docs/design/typescript/NPMPackage.mdk
+++ b/docs/design/typescript/NPMPackage.mdk
@@ -246,23 +246,23 @@ An ESM distribution is consumed by tools such as [Webpack](https://webpack.js.or
 
 #### Browser Builds {#ts-source-distros-browser}
 
-~ Should
+~ Should {#ts-browser-build}
 provide a browser build for your library.
 ~
 
-~ Must
+~ Must {#ts-browser-umd}
 be in UMD module format.
 ~
 
-~ Must
+~ Must {#ts-browser-global-name}
 name the UMD global according to the [namespace guidelines](#ts-namespace).
 ~
 
-~ Must
+~ Must {#ts-browser-minification}
 provide both minified and non-minified versions, both with source mapping.
 ~
 
-~ Must
+~ Must {#ts-browser-folder}
 place browser builds in a top level `browser` folder. The name of the file should be the service name. Append `.min` to the name of minified files. For example, Storage Blob should have `storage-blob.min.js` and `storage-blob.js` under `./browser`.
 ~
 

--- a/docs/design/typescript/Pagination.mdk
+++ b/docs/design/typescript/Pagination.mdk
@@ -2,19 +2,19 @@
 
 Most developers will want to process a list one item at a time. Higher-level APIs (for example, async iterators) are preferred in the majority of use cases.  Finer-grained control over handling paginated result sets is sometimes required (for example, to handle over-quota or throttling).  
 
-~ Must
+~ Must {#ts-pagination-list}
 provide a `list` method that returns a `PagedAsyncIterableIterator` from the module `@azure/core-paging`.
 ~
 
-~ Must
+~ Must {ts-pagination-bypage}
 provide page-related settings to the `byPage()` iterator and not the per-item iterator.
 ~
 
-~ Must
+~ Must {ts-pagination-continuationtoken}
 take a `continuationToken` option in the `byPage()` method. You must rename other parameters that perform a similar function (for example, `nextMarker`).  If your page type has a continuation token, it must be named `continuationToken`.
 ~
 
-~ Must
+~ Must {ts-pagination-maxpagesize}
 take a `maxPageSize` option in the `byPage()` method.
 ~
 

--- a/docs/design/typescript/Pagination.mdk
+++ b/docs/design/typescript/Pagination.mdk
@@ -6,15 +6,15 @@ Most developers will want to process a list one item at a time. Higher-level API
 provide a `list` method that returns a `PagedAsyncIterableIterator` from the module `@azure/core-paging`.
 ~
 
-~ Must {ts-pagination-bypage}
+~ Must {#ts-pagination-bypage}
 provide page-related settings to the `byPage()` iterator and not the per-item iterator.
 ~
 
-~ Must {ts-pagination-continuationtoken}
+~ Must {#ts-pagination-continuationtoken}
 take a `continuationToken` option in the `byPage()` method. You must rename other parameters that perform a similar function (for example, `nextMarker`).  If your page type has a continuation token, it must be named `continuationToken`.
 ~
 
-~ Must {ts-pagination-maxpagesize}
+~ Must {#ts-pagination-maxpagesize}
 take a `maxPageSize` option in the `byPage()` method.
 ~
 


### PR DESCRIPTION
Addresses the following issues:

The copyright header examples in the [Microsoft OSS docs](https://docs.opensource.microsoft.com/releasing/copyright-headers.html) are out of date (heard from an email forwarded from Larry, not sure if this is officially posted anywhere) and should actually be the following:

```fundamental
Copyright (c) Microsoft Corporation.
Licensed under the MIT license.
```

Additionally, many guidelines are missing guideline IDs, which allow [linking to specific rules](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-use-typescript) and provide naming conventions for rules used in [@azure/eslint-plugin-azure-sdk](https://www.npmjs.com/package/@azure/eslint-plugin-azure-sdk).

The ID names I've added here are only my ideas and any improvements/changes are welcome.