### PR TITLE
[Preview Two] .NET Release Notes

### DIFF
--- a/_posts/2019-08-06-dotnet-preview2.md
+++ b/_posts/2019-08-06-dotnet-preview2.md
@@ -43,7 +43,8 @@ Detailed changelogs are linked from the [Quick Links](#quick-links) below. Here 
 ### Event Hubs
 
 - Expanded support for sending multiple messages in a single call by adding the ability to create a batch which avoids the error scenario of exceeding size limits. Users having bandwidth concerns can control the batch size as desired.
-- Introduced a new model for consuming events via the EventProcessor class. This simplifies the process of checkpointing today and will handle load balancing across partitions in upcoming updates.
+- Introduced a new model for consuming events via the `EventProcessor` class. This simplifies the process of checkpointing today and will handle load balancing across partitions in upcoming updates.
+- Enabled the ability to subscribe to the events exposed by an `EventHubConsumer` in the form of an asynchronous iterator. With the iterator, consumers are able to use the familiar `foreach` pattern to receive events as they are available and to process them.
 
 ### Key Vault
 


### PR DESCRIPTION
# Summary

The intent of these changes is to provide an additional bullet in the Event Hubs section, highlighting  the new iterator pattern for consuming events.

# Last Upstream Rebase

Wednesday, August 7, 2019  3:13pm (EDT)