### PR TITLE
Reactor is allowed in public API

### DIFF
--- a/docs/java/approved_dependencies.md
+++ b/docs/java/approved_dependencies.md
@@ -1,6 +1,6 @@
 | Name                                              | Role                | Allowed in public API | Notes |
 |---------------------------------------------------|-------------------- |:---------------------:|-------|
-| [`Reactor`](http://projectreactor.io)             | Reactive library    | No                    |       |
+| [`Reactor`](http://projectreactor.io)             | Reactive library    | Yes                   |       |
 | [`Netty`](http://netty.io)                        | HTTP client         | No                    |       |
 | [`slf4j`](http://slf4j.org)                       | Logging framework   | No                    | Use the azure core `ClientLogger` API rather than `slf4j` directly. |
 | [`Jackson`](https://github.com/FasterXML/jackson) | JSON parser         | No                    |       |

--- a/docs/java/design.md
+++ b/docs/java/design.md
@@ -535,7 +535,7 @@ Use a no-args constructor and a fluent setter API to configure the model class. 
 
 {% include requirement/MUSTNOT id="java-models-builder" %} offer a builder class for model classes.
 
-{% include requirement/MUST id="java-models-fluent" %} provide a fluent API where appropriate. Setter methods in model classes are encouraged to return `this` to enable method chaining.
+{% include requirement/MUST id="java-models-fluent" %} provide a fluent API where appropriate. Setter methods in model classes are required to return `this` to enable method chaining.
 
 {% include requirement/MUST id="java-models-fluent-annotation" %} apply the `@Fluent` annotation to the class.
 


### PR DESCRIPTION
Also, make fluent model classes return 'this' in the setter methods.