### PR TITLE
(#584) Added user-agent / telemetry additional requirements

### DIFF
--- a/docs/general/azurecore.md
+++ b/docs/general/azurecore.md
@@ -39,7 +39,7 @@ Client library usage telemetry is used by service teams (not consumers) to monit
 [<application_id> ]azsdk-<sdk_language>-<package_name>/<package_version> <platform_info>
 ```
 
-- `<application_id>`: optional application-specific string. May contain a slash, but must not contain a space. The string is supplied by the user of the client library, e.g. "AzCopy 10.0.4-Preview"
+- `<application_name>`: optional application-specific string. May contain a slash, but must not contain a space. The string is supplied by the user of the client library, e.g. "AzCopy/10.0.4-Preview"
 - `<sdk_language>`: SDK's language name (all lowercase): "net", "python", "java", or "js" 
 - `<package_name>`: client library package name as it appears to the developer, replacing slashes with dashes and removing the Azure indicator.  For example, "Security.KeyVault" (.NET), "security.keyvault" (Java), "keyvault" (JavaScript & Python)
 - `<package_version>`: the version of the package. Note: this is not the version of the service
@@ -52,12 +52,11 @@ For example, if we re-wrote `AzCopy` in each language using the Azure Blob Stora
 - (Java) `AzCopy/10.0.4-Preview azsdk-java-storage.blobs/11.0.0 (Java/1.8.0_45; Macintosh; Intel Mac OS X 10_10; rv:33.0)`
 - (Python) `AzCopy/10.0.4-Preview azsdk-python-storage/4.0.0 Python/3.7.3 (Ubuntu; Linux x86_64; rv:34.0)`
 
-{% include requirement/MUST id="azurecore-http-telemetry-appid" %} allow the consumer of the library to set the application ID.  This allows the consumer to obtain cross-service telemetry for their app.  The application ID will normally be set in the client options bag.
+{% include requirement/MUST id="azurecore-http-telemetry-appid" %} allow the consumer of the library to set the application name.  This allows the consumer to obtain cross-service telemetry for their app.  The application name should be settable in the relevant `ClientOptions` object.
 
-{% include requirement/MUST id="azurecore-http-telemetry-appid-length" %} enforce that application IDs are no more than 24 characters in length.  Supporting short application IDs allows service teams to include diagnostic information in the "platform information" section of the user agent, while still allowing the consumer to obtain telemetry information for their app.
+{% include requirement/MUST id="azurecore-http-telemetry-appid-length" %} enforce that application names are no more than 24 characters in length.  Shorter application names allows service teams to include diagnostic information in the "platform information" section of the user agent, while still allowing the consumer to obtain telemetry information for their own application.
 
 {% include requirement/SHOULD id="azurecore-http-telemetry-x-ms-useragent" %} send telemetry information that is normally sent in the `User-Agent` header in the `X-MS-UserAgent` header when the platform does not support changing the `User-Agent` header.  Note that services will need to configure log gathering to capture the `X-MS-UserAgent` header in such a way that it can be queried through normal analytics systems.
-
 
 {% include requirement/SHOULD id="azurecore-http-telemetry-dynamic" %} send additional (dynamic) telemetry information as a semi-colon separated set of key-value types in the `X-MS-AZSDK-Telemetry` header.  For example:
 

--- a/docs/general/azurecore.md
+++ b/docs/general/azurecore.md
@@ -39,7 +39,7 @@ Client library usage telemetry is used by service teams (not consumers) to monit
 [<application_id> ]azsdk-<sdk_language>-<package_name>/<package_version> <platform_info>
 ```
 
-- `<application_name>`: optional application-specific string. May contain a slash, but must not contain a space. The string is supplied by the user of the client library, e.g. "AzCopy/10.0.4-Preview"
+- `<application_id>`: optional application-specific string. May contain a slash, but must not contain a space. The string is supplied by the user of the client library, e.g. "AzCopy/10.0.4-Preview"
 - `<sdk_language>`: SDK's language name (all lowercase): "net", "python", "java", or "js" 
 - `<package_name>`: client library package name as it appears to the developer, replacing slashes with dashes and removing the Azure indicator.  For example, "Security.KeyVault" (.NET), "security.keyvault" (Java), "keyvault" (JavaScript & Python)
 - `<package_version>`: the version of the package. Note: this is not the version of the service
@@ -52,9 +52,9 @@ For example, if we re-wrote `AzCopy` in each language using the Azure Blob Stora
 - (Java) `AzCopy/10.0.4-Preview azsdk-java-storage.blobs/11.0.0 (Java/1.8.0_45; Macintosh; Intel Mac OS X 10_10; rv:33.0)`
 - (Python) `AzCopy/10.0.4-Preview azsdk-python-storage/4.0.0 Python/3.7.3 (Ubuntu; Linux x86_64; rv:34.0)`
 
-{% include requirement/MUST id="azurecore-http-telemetry-appid" %} allow the consumer of the library to set the application name.  This allows the consumer to obtain cross-service telemetry for their app.  The application name should be settable in the relevant `ClientOptions` object.
+{% include requirement/MUST id="azurecore-http-telemetry-appid" %} allow the consumer of the library to set the application ID.  This allows the consumer to obtain cross-service telemetry for their app.  The application ID should be settable in the relevant `ClientOptions` object.
 
-{% include requirement/MUST id="azurecore-http-telemetry-appid-length" %} enforce that application names are no more than 24 characters in length.  Shorter application names allows service teams to include diagnostic information in the "platform information" section of the user agent, while still allowing the consumer to obtain telemetry information for their own application.
+{% include requirement/MUST id="azurecore-http-telemetry-appid-length" %} enforce that the application ID is no more than 24 characters in length.  Shorter application IDs allows service teams to include diagnostic information in the "platform information" section of the user agent, while still allowing the consumer to obtain telemetry information for their own application.
 
 {% include requirement/SHOULD id="azurecore-http-telemetry-x-ms-useragent" %} send telemetry information that is normally sent in the `User-Agent` header in the `X-MS-UserAgent` header when the platform does not support changing the `User-Agent` header.  Note that services will need to configure log gathering to capture the `X-MS-UserAgent` header in such a way that it can be queried through normal analytics systems.
 

--- a/docs/general/azurecore.md
+++ b/docs/general/azurecore.md
@@ -54,7 +54,7 @@ For example, if we re-wrote `AzCopy` in each language using the Azure Blob Stora
 
 {% include requirement/MUST id="azurecore-http-telemetry-appid" %} allow the consumer of the library to set the application ID.  This allows the consumer to obtain cross-service telemetry for their app.  The application ID will normally be set in the client options bag.
 
-{% include requirement/MUST id="azurecore-http-telemetry-appid-length" %} support application IDs up to 24 characters in length.  Supporting short application IDs allows service teams to include diagnostic information in the "platform information" section of the user agent, while still allowing the consumer to obtain telemetry information for their app.
+{% include requirement/MUST id="azurecore-http-telemetry-appid-length" %} enforce that application IDs are no more than 24 characters in length.  Supporting short application IDs allows service teams to include diagnostic information in the "platform information" section of the user agent, while still allowing the consumer to obtain telemetry information for their app.
 
 {% include requirement/SHOULD id="azurecore-http-telemetry-x-ms-useragent" %} send telemetry information that is normally sent in the `User-Agent` header in the `X-MS-UserAgent` header when the platform does not support changing the `User-Agent` header.  Note that services will need to configure log gathering to capture the `X-MS-UserAgent` header in such a way that it can be queried through normal analytics systems.
 

--- a/docs/general/azurecore.md
+++ b/docs/general/azurecore.md
@@ -52,7 +52,12 @@ For example, if we re-wrote `AzCopy` in each language using the Azure Blob Stora
 - (Java) `AzCopy/10.0.4-Preview azsdk-java-storage.blobs/11.0.0 (Java/1.8.0_45; Macintosh; Intel Mac OS X 10_10; rv:33.0)`
 - (Python) `AzCopy/10.0.4-Preview azsdk-python-storage/4.0.0 Python/3.7.3 (Ubuntu; Linux x86_64; rv:34.0)`
 
+{% include requirement/MUST id="azurecore-http-telemetry-appid" %} allow the consumer of the library to set the application ID.  This allows the consumer to obtain cross-service telemetry for their app.  The application ID will normally be set in the client options bag.
+
+{% include requirement/MUST id="azurecore-http-telemetry-appid-length" %} support application IDs up to 24 characters in length.  Supporting short application IDs allows service teams to include diagnostic information in the "platform information" section of the user agent, while still allowing the consumer to obtain telemetry information for their app.
+
 {% include requirement/SHOULD id="azurecore-http-telemetry-x-ms-useragent" %} send telemetry information that is normally sent in the `User-Agent` header in the `X-MS-UserAgent` header when the platform does not support changing the `User-Agent` header.  Note that services will need to configure log gathering to capture the `X-MS-UserAgent` header in such a way that it can be queried through normal analytics systems.
+
 
 {% include requirement/SHOULD id="azurecore-http-telemetry-dynamic" %} send additional (dynamic) telemetry information as a semi-colon separated set of key-value types in the `X-MS-AZSDK-Telemetry` header.  For example:
 


### PR DESCRIPTION
Service teams (particularly Cosmos) requested some additional requirements around the application ID.  This request adds two requirements:

1) That the user be able to specify the application ID within the client options bag when constructing a service client

2) That we support up to 24 characters for the consumer selected application ID.