### PR TITLE
Add guideline about using a common argument validator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem 'github-pages', group: :jekyll_plugins
+gem 'jekyll-relative-links'
 gem 'wdm', '>= 0.1.0' if Gem.win_platform?
 gem 'tzinfo-data'
 

--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,7 @@ plugins:
   - jekyll-sitemap
   - jekyll-gist
   - jekyll-seo-tag
+  - jekyll-relative-links
   - jemoji
 
 # Files and directories that Jekyll will exclude from the build

--- a/_data/sidebars/dotnet_sidebar.yml
+++ b/_data/sidebars/dotnet_sidebar.yml
@@ -29,6 +29,8 @@ entries:
         url: /dotnet_introduction.html#general-azure-sdk-library-design
       - title: Common Type Usage
         url: /dotnet_introduction.html#dotnet-commontypes
+      - title: Implementation
+        url: /dotnet_implementation.html
   - title: Policies
     folderitems:
       - title: Open source

--- a/docs/dotnet/implementation.md
+++ b/docs/dotnet/implementation.md
@@ -1,0 +1,31 @@
+---
+title: "C#.NET Guidelines: Implementation"
+keywords: guidelines dotnet
+permalink: dotnet_implementation.html
+folder: dotnet
+sidebar: dotnet_sidebar
+---
+
+## Parameter validation
+
+In addition to [general parameter validation guidelines](introduction.md#dotnet-parameters):
+
+{% include requirement/MUSTNOT id="dotnet-parameter-validation-class" %} define your own parameter validation class.
+
+Use the `Argument` class in Azure.Core or even "extend" it (it's a partial class included as source) with project-specific argument assertions.
+Just add the following to your project to include it:
+
+```xml
+  <!-- Import Azure.Core properties if not already imported. -->
+  <Import Project="$(MSBuildThisFileDirectory)..\..\..\core\Azure.Core\src\Azure.Core.props" />
+  <ItemGroup>
+    <Compile Include="$(AzureCoreSharedSources)Argument.cs" />
+  </ItemGroup>
+```
+
+See remarks on the `Argument` class for more detail.
+
+<!-- Links -->
+
+{% include refs.md %}
+{% include_relative refs.md %}

--- a/docs/dotnet/introduction.md
+++ b/docs/dotnet/introduction.md
@@ -60,10 +60,6 @@ The guidelines provide a robust methodology for communicating with Azure service
 
 The pipeline can be found in the [Azure.Core] package, and it takes care of many [General Azure SDK Guidelines][general-guidelines]. Details of the pipeline design and usage are described in section [Using HttpPipeline](#dotnet-usage-httppipeline) below. If you can't use the pipeline, you must implement [all the general requirements of Azure SDK]({{ "/general_azurecore.html" | relative_url }}) manually.
 
-{% include requirement/MUSTNOT id="dotnet-general-parameter-validation" %} define your own parameter validation class.
-
-Use the `Argument` class in Azure.Core or even "extend" it (it's a partial class included as source) with project-specific argument assertions. See remarks on the `Argument` class for more information.
-
 # API Design {#dotnet-api}
 
 ## Service Client Design {#dotnet-client}
@@ -926,10 +922,4 @@ Some .NET Design Guidelines have been notoriously overlooked in existing Azure S
 <!-- Links -->
 
 {% include refs.md %}
-[.NET Framework Design Guidelines]: https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/
-[Azure Application Configuration service]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/appconfiguration/Azure.ApplicationModel.Configuration
-[Azure.Core]: https://www.nuget.org/packages/Azure.Core/
-[Moq]: https://github.com/moq/moq4
-[adparch]: https://github.com/azure/azure-sdk/issues
-[.NET Standard 2.0]: https://github.com/dotnet/standard/blob/master/docs/versions/netstandard2.0.md
-[azure/azure-sdk-for-net]: https://github.com/azure/azure-sdk-for-net
+{% include_relative refs.md %}

--- a/docs/dotnet/introduction.md
+++ b/docs/dotnet/introduction.md
@@ -62,18 +62,7 @@ The pipeline can be found in the [Azure.Core] package, and it takes care of many
 
 {% include requirement/MUSTNOT id="dotnet-general-parameter-validation" %} define your own parameter validation class.
 
-Use the `Argument` class in Azure.Core or even "extend" it (it's a partial class included as source) with project-specific argument assertions.
-Just add the following to your project to include it:
-
-```xml
-  <!-- Import Azure.Core properties if not already imported. -->
-  <Import Project="$(MSBuildThisFileDirectory)..\..\..\core\Azure.Core\src\Azure.Core.props" />
-  <ItemGroup>
-    <Compile Include="$(AzureCoreSharedSources)Argument.cs" />
-  </ItemGroup>
-```
-
-See remarks on the `Argument` class for more detail.
+Use the `Argument` class in Azure.Core or even "extend" it (it's a partial class included as source) with project-specific argument assertions. See remarks on the `Argument` class for more information.
 
 # API Design {#dotnet-api}
 

--- a/docs/dotnet/introduction.md
+++ b/docs/dotnet/introduction.md
@@ -60,6 +60,21 @@ The guidelines provide a robust methodology for communicating with Azure service
 
 The pipeline can be found in the [Azure.Core] package, and it takes care of many [General Azure SDK Guidelines][general-guidelines]. Details of the pipeline design and usage are described in section [Using HttpPipeline](#dotnet-usage-httppipeline) below. If you can't use the pipeline, you must implement [all the general requirements of Azure SDK]({{ "/general_azurecore.html" | relative_url }}) manually.
 
+{% include requirement/MUSTNOT id="dotnet-general-parameter-validation" %} define your own parameter validation class.
+
+Use the `Argument` class in Azure.Core or even "extend" it (it's a partial class included as source) with project-specific argument assertions.
+Just add the following to your project to include it:
+
+```xml
+  <!-- Import Azure.Core properties if not already imported. -->
+  <Import Project="$(MSBuildThisFileDirectory)..\..\..\core\Azure.Core\src\Azure.Core.props" />
+  <ItemGroup>
+    <Compile Include="$(AzureCoreSharedSources)Argument.cs" />
+  </ItemGroup>
+```
+
+See remarks on the `Argument` class for more detail.
+
 # API Design {#dotnet-api}
 
 ## Service Client Design {#dotnet-client}

--- a/docs/dotnet/refs.md
+++ b/docs/dotnet/refs.md
@@ -1,0 +1,7 @@
+[.NET Framework Design Guidelines]: https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/
+[Azure Application Configuration service]: https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/appconfiguration/Azure.ApplicationModel.Configuration
+[Azure.Core]: https://www.nuget.org/packages/Azure.Core/
+[Moq]: https://github.com/moq/moq4
+[adparch]: https://github.com/azure/azure-sdk/issues
+[.NET Standard 2.0]: https://github.com/dotnet/standard/blob/master/docs/versions/netstandard2.0.md
+[azure/azure-sdk-for-net]: https://github.com/azure/azure-sdk-for-net


### PR DESCRIPTION

Relates to Azure/azure-sdk-for-net#7547 and should be merged only after PR Azure/azure-sdk-for-net#7569 is merged.