### PR TITLE
Updated Gem bundle for security updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,3 @@ gem 'wdm', '>= 0.1.0' if Gem.win_platform?
 gem 'tzinfo-data'
 
 # Explicit versions for reported security issue
-gem 'dnsruby', '>= 1.61.3'
-gem 'nokogiri', '>= 1.10.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,8 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.6.0)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -26,13 +26,13 @@ GEM
     eventmachine (1.2.7)
     eventmachine (1.2.7-x64-mingw32)
     execjs (2.7.0)
-    faraday (0.15.4)
+    faraday (0.16.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
     ffi (1.11.1-x64-mingw32)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
-    github-pages (198)
+    github-pages (200)
       activesupport (= 4.2.11.1)
       github-pages-health-check (= 1.16.1)
       jekyll (= 3.8.5)
@@ -49,7 +49,7 @@ GEM
       jekyll-readme-index (= 0.2.0)
       jekyll-redirect-from (= 0.14.0)
       jekyll-relative-links (= 0.6.0)
-      jekyll-remote-theme (= 0.3.1)
+      jekyll-remote-theme (= 0.4.0)
       jekyll-sass-converter (= 1.5.2)
       jekyll-seo-tag (= 2.5.0)
       jekyll-sitemap (= 1.2.0)
@@ -74,7 +74,7 @@ GEM
       listen (= 3.1.5)
       mercenary (~> 0.3)
       minima (= 2.5.0)
-      nokogiri (>= 1.8.5, < 2.0)
+      nokogiri (>= 1.10.4, < 2.0)
       rouge (= 2.2.1)
       terminal-table (~> 1.4)
     github-pages-health-check (1.16.1)
@@ -135,7 +135,8 @@ GEM
       jekyll (~> 3.3)
     jekyll-relative-links (0.6.0)
       jekyll (~> 3.3)
-    jekyll-remote-theme (0.3.1)
+    jekyll-remote-theme (0.4.0)
+      addressable (~> 2.0)
       jekyll (~> 3.5)
       rubyzip (>= 1.2.1, < 3.0)
     jekyll-sass-converter (1.5.2)
@@ -205,7 +206,7 @@ GEM
       jekyll (~> 3.5)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    minitest (5.11.3)
+    minitest (5.12.2)
     multipart-post (2.1.1)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
@@ -223,7 +224,7 @@ GEM
     ruby-enum (0.7.2)
       i18n
     ruby_dep (1.5.0)
-    rubyzip (1.2.3)
+    rubyzip (2.0.0)
     safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -240,7 +241,7 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    tzinfo-data (1.2019.2)
+    tzinfo-data (1.2019.3)
       tzinfo (>= 1.0.0)
     unicode-display_width (1.6.0)
     wdm (0.1.1)
@@ -250,10 +251,8 @@ PLATFORMS
   x64-mingw32
 
 DEPENDENCIES
-  dnsruby (>= 1.61.3)
   github-pages
   jekyll-relative-links
-  nokogiri (>= 1.10.4)
   tzinfo-data
   wdm (>= 0.1.0)
 


### PR DESCRIPTION
1) dnsruby & nokogiri are now included in latest Jekyll, so removed explicit reference.
2) bundle update fixes the rubyzip security issue