### PR TITLE
.NET Release for Preview 4: Updating Event Hubs Release Notes

### DIFF
--- a/releases/2019-10-11/2019-10-11-dotnet-preview4.md
+++ b/releases/2019-10-11/2019-10-11-dotnet-preview4.md
@@ -45,9 +45,9 @@ Detailed changelogs are linked from the [Quick Links](#quick-links) below. Here 
 
 ### Event Hubs
 
-- Expanded support for sending multiple messages in a single call by adding the ability to create a batch which avoids the error scenario of exceeding size limits. Users having bandwidth concerns can control the batch size as desired.
-- Introduced a new model for consuming events via the `EventProcessor` class. This simplifies the process of checkpointing today and will handle load balancing across partitions in upcoming updates.
-- Enabled the ability to subscribe to the events exposed by an `EventHubConsumer` in the form of an asynchronous iterator. With the iterator, consumers are able to use the familiar `foreach` pattern to receive events as they are available and to process them.
+- Fixed date parsing for time zones ahead of UTC in the Event Hub Consumer when tracking of the last event was disabled.
+- Improved stability and performance with refactorings around hot paths and areas of technical debt.  
+- Included the Event Hubs namespace as part of the checkpoint key, ensuring that there is no conflict between Event Hubs instances in different regions using the same Event Hub and consumer group names.
 
 ### Key Vault
 


### PR DESCRIPTION
# Summary

The focus of these changes is to update the release notes for the Event Hubs client with highlights from the fourth preview and to ensure that each of the  associated asset links is valid.

# Last Upstream Rebase

Friday, October 11, 3:46pm (EDT)