### PR TITLE
Event Hubs: Update reference example

### DIFF
--- a/releases/2019-10-11/2019-10-11-dotnet-preview4.md
+++ b/releases/2019-10-11/2019-10-11-dotnet-preview4.md
@@ -22,7 +22,7 @@ To install any of our packages, please search for them via `Manage NuGet Package
     $> dotnet add package Azure.Security.KeyVault.Keys --version 4.0.0-preview.4
     $> dotnet add package Azure.Security.KeyVault.Certificates --version 4.0.0-preview.4
 
-    $> dotnet add package Azure.Messaging.EventHubs --version 5.0.0-preview.3
+    $> dotnet add package Azure.Messaging.EventHubs --version 5.0.0-preview.4
 
     $> dotnet add package Azure.Identity --version 1.0.0-preview.4
 


### PR DESCRIPTION
# Summary

The focus of these changes is to update the Event Hubs package version in the example snippet for adding references.  It was overlooked when submitting the change log.

# Last Upstream Rebase

Friday, October 11, 5:03pm (EDT)