### PR TITLE
.NET Release for November: Event Hubs Release Notes

### DIFF
--- a/releases/2019-11/2019-11-dotnet.md
+++ b/releases/2019-11/2019-11-dotnet.md
@@ -23,7 +23,7 @@ To install any of our packages, please search for them via `Manage NuGet Package
     $> dotnet add package Azure.Security.KeyVault.Key
     $> dotnet add package Azure.Security.KeyVault.Certificates --version 4.0.0-preview.6
 
-    $> dotnet add package Azure.Messaging.EventHubs --version 5.0.0-preview.4
+    $> dotnet add package Azure.Messaging.EventHubs --version 5.0.0-preview.5
 
     $> dotnet add package Azure.Identity
 
@@ -62,9 +62,13 @@ Detailed changelogs are linked from the [Quick Links](#quick-links) below. Here 
 
 ### Event Hubs
 
-- Fixed date parsing for time zones ahead of UTC in the Event Hub Consumer when tracking of the last event was disabled.
-- Improved stability and performance with refactorings around hot paths and areas of technical debt.  
-- Included the Event Hubs namespace as part of the checkpoint key, ensuring that there is no conflict between Event Hubs instances in different regions using the same Event Hub and consumer group names.
+- The early stages of a large refactoring of the Event Hub client type hierarchy are complete. For more details, please see the [Event Hubs changelog](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md#500-preview5-2019-11-04).
+- Cancellation tokens are now fully supported throughout the client hierarchy and across operations.
+- The information about the last event enqueued to a partition is now presented as an immutable object, if the tracking option was enabled.
+- Retry policies and timeouts have been made local to a specific client instance, making them easier to configure and reason about.
+- Client types using Azure identity for authorization should now be work properly; a bug was fixed to allow the proper authorization scopes to be requested.  
+  _(A community contribution, courtesy of [albertodenatale](https://github.com/albertodenatale))_
+
 
 ### Key Vault
 


### PR DESCRIPTION
# Summary

The focus of these changes is to update the release notes for the Event Hubs client with highlights from the fifth preview and to ensure that each of the associated asset links is valid.

# Last Upstream Rebase

Thursday, October 31, 9:428am (EDT)

# Related and Follow-Up Issues

- [Release Event Hubs Track 2 Library Preview 5 for .Net ](https://github.com/Azure/azure-sdk-for-net/issues/8190) (#8190) 
- [Review and update documentation ](https://github.com/Azure/azure-sdk-for-net/issues/8191) (#8191) 