### PR TITLE
Update the single line of links to a list for better visibility

### DIFF
--- a/docs/policies/README-EXAMPLE.md
+++ b/docs/policies/README-EXAMPLE.md
@@ -13,7 +13,7 @@ Use the Cosmos DB client library for Python to manage databases and the JSON doc
 - [Package (PyPi)][pypi] 
 - [API reference documentation][ref_cosmos_sdk] 
 - [Product documentation][cosmos_docs] 
-- [Examples to get Started][samples]
+- [Examples][samples]
 
 ## Getting started
 

--- a/docs/policies/README-EXAMPLE.md
+++ b/docs/policies/README-EXAMPLE.md
@@ -4,12 +4,16 @@ Azure Cosmos DB is a globally distributed, multi-model database service that sup
 
 Use the Cosmos DB client library for Python to manage databases and the JSON documents they contain in this NoSQL database service:
 
-* Create Cosmos DB databases and modify their settings
-* Create and modify containers to store collections of JSON documents
-* Create, read, update, and delete the items (JSON documents) in your containers
-* Query the documents in your database using SQL-like syntax
+    * Create Cosmos DB databases and modify their settings
+    * Create and modify containers to store collections of JSON documents
+    * Create, read, update, and delete the items (JSON documents) in your containers
+    * Query the documents in your database using SQL-like syntax
 
-[Source code][source_code] | [Package (PyPi)][pypi] | [API reference documentation][ref_cosmos_sdk] | [Product documentation][cosmos_docs] | [Samples][samples]
+- [Source code][source_code] 
+- [Package (PyPi)][pypi] 
+- [API reference documentation][ref_cosmos_sdk] 
+- [Product documentation][cosmos_docs] 
+- [Examples to get Started][samples]
 
 ## Getting started
 

--- a/docs/policies/README-TEMPLATE.md
+++ b/docs/policies/README-TEMPLATE.md
@@ -12,7 +12,7 @@ Use the guidelines in each section of this template to ensure consistency and re
 * **DO NOT** use an "Introduction" or "Overview" heading (H2) for this section.
 * First sentence: **Describe the service** briefly. You can usually use the first line of the service's docs landing page for this (Example: [Cosmos DB docs landing page](https://docs.microsoft.com/azure/cosmos-db/)).
 * Next, add a **bulleted list** of the **most common tasks** supported by the package or library, prefaced with "Use the client library for [Product Name] to:". Then, provide code snippets for these tasks in the [Examples](#examples) section later in the document. Keep the task list short but include those tasks most developers need to perform with your package.
-* Include this bullet-ed list of links targeting your product's content at the bottom of the introduction, making any adjustments as necessary (for example, NuGet instead of PyPi):
+* Include this bullet list of links targeting your product's content at the bottom of the introduction, making any adjustments as necessary (for example, NuGet instead of PyPi):
 
     -  [Source code](https://github.com/Azure/azure-sdk-for-python/tree/master/azure-batch)
     -  [Package (PyPi)](https://pypi.org/project/azure-batch/)

--- a/docs/policies/README-TEMPLATE.md
+++ b/docs/policies/README-TEMPLATE.md
@@ -12,9 +12,13 @@ Use the guidelines in each section of this template to ensure consistency and re
 * **DO NOT** use an "Introduction" or "Overview" heading (H2) for this section.
 * First sentence: **Describe the service** briefly. You can usually use the first line of the service's docs landing page for this (Example: [Cosmos DB docs landing page](https://docs.microsoft.com/azure/cosmos-db/)).
 * Next, add a **bulleted list** of the **most common tasks** supported by the package or library, prefaced with "Use the client library for [Product Name] to:". Then, provide code snippets for these tasks in the [Examples](#examples) section later in the document. Keep the task list short but include those tasks most developers need to perform with your package.
-* Include this single line of links targeting your product's content at the bottom of the introduction, making any adjustments as necessary (for example, NuGet instead of PyPi):
+* Include this bullet-ed list of links targeting your product's content at the bottom of the introduction, making any adjustments as necessary (for example, NuGet instead of PyPi):
 
-  [Source code](https://github.com/Azure/azure-sdk-for-python/tree/master/azure-batch) | [Package (PyPi)](https://pypi.org/project/azure-batch/) | [API reference documentation](https://docs.microsoft.com/python/api/overview/azure/batch?view=azure-python) | [Product documentation](https://docs.microsoft.com/azure/batch/) | [Samples][samples]
+    -  [Source code](https://github.com/Azure/azure-sdk-for-python/tree/master/azure-batch)
+    -  [Package (PyPi)](https://pypi.org/project/azure-batch/)
+    -  [API reference documentation](https://docs.microsoft.com/python/api/overview/azure/batch?view=azure-python) 
+    -  [Product documentation](https://docs.microsoft.com/azure/batch/) 
+    -  [Examples to get started][samples]
 
 > TIP: Your README should be as **brief** as possible but **no more brief** than necessary to get a developer new to Azure, the service, or the package up and running quickly. Keep it brief, but include everything a developer needs to make their first API call successfully.
 

--- a/docs/policies/README-TEMPLATE.md
+++ b/docs/policies/README-TEMPLATE.md
@@ -18,7 +18,7 @@ Use the guidelines in each section of this template to ensure consistency and re
     -  [Package (PyPi)](https://pypi.org/project/azure-batch/)
     -  [API reference documentation](https://docs.microsoft.com/python/api/overview/azure/batch?view=azure-python) 
     -  [Product documentation](https://docs.microsoft.com/azure/batch/) 
-    -  [Examples to get started][samples]
+    -  [Examples][samples]
 
 > TIP: Your README should be as **brief** as possible but **no more brief** than necessary to get a developer new to Azure, the service, or the package up and running quickly. Keep it brief, but include everything a developer needs to make their first API call successfully.
 


### PR DESCRIPTION
UX Study Feedback 
- Samples link is hidden in the initial set of 6 things(API Ref. Documentation, npm LINK, etc) - should be more discoverable
This PR proposes to consider `Examples to get started` over of `Samples`
- Most people failed to notice the single line of links, proposing to update that to bullet points for better visibility.

cc - @ramya-rao-a @jeremymeng 
