### PR TITLE
Event Hubs: Fixing typo in release notes

### DIFF
--- a/releases/2019-11/2019-11-dotnet.md
+++ b/releases/2019-11/2019-11-dotnet.md
@@ -66,7 +66,7 @@ Detailed changelogs are linked from the [Quick Links](#quick-links) below. Here 
 - Cancellation tokens are now fully supported throughout the client hierarchy and across operations.
 - The information about the last event enqueued to a partition is now presented as an immutable object, if the tracking option was enabled.
 - Retry policies and timeouts have been made local to a specific client instance, making them easier to configure and reason about.
-- Client types using Azure identity for authorization should now be work properly; a bug was fixed to allow the proper authorization scopes to be requested.  
+- Client types using Azure identity for authorization should now be working properly; a bug was fixed to allow the proper authorization scopes to be requested.  
   _(A community contribution, courtesy of [albertodenatale](https://github.com/albertodenatale))_
 
 


### PR DESCRIPTION
Small typo fix in the release notes for EventHubs