### PR TITLE
Move general config env variables out of Identitiy

### DIFF
--- a/_includes/tables/environment_variables.md
+++ b/_includes/tables/environment_variables.md
@@ -7,16 +7,17 @@
 | **Identity**                                                          ||
 | MSI_ENDPOINT                  | Azure AD MSI Credentials               |
 | MSI_SECRET                    | Azure AD MSI Credentials               |
-| AZURE_SUBSCRIPTION_ID         | Azure subscription                     |
 | AZURE_USERNAME                | Azure username for U/P Auth            |
 | AZURE_PASSWORD                | Azure password for U/P Auth            |
 | AZURE_CLIENT_CERTIFICATE_PATH | Azure Active Directory                 |
 | AZURE_CLIENT_ID               | Azure Active Directory                 |
 | AZURE_CLIENT_SECRET           | Azure Active Directory                 |
 | AZURE_TENANT_ID               | Azure Active Directory                 |
-| AZURE_RESOURCE_GROUP          | Azure Resource Group                   |
-| AZURE_CLOUD                   | Name of the sovereign cloud            |
 | **Pipeline Configuration**                                            ||
 | AZURE_TELEMETRY_DISABLED      | Disables telemetry                     |
 | AZURE_LOG_LEVEL               | Enable logging by setting a log level. |
 | AZURE_TRACING_DISABLED        | Disables tracing                       |
+| **General SDK Configuration**                                         ||
+| AZURE_CLOUD                   | Name of the sovereign cloud            |
+| AZURE_SUBSCRIPTION_ID         | Azure subscription                     |
+| AZURE_RESOURCE_GROUP          | Azure Resource Group                   |


### PR DESCRIPTION
The environment variables AZURE_CLOUD, AZURE_SUBSCRIPTION_ID, and AZURE_RESOURCE_GROUP are environment variables which impact multiple client libraries across the SDK and are not Identity specific. Furthermore AZURE_SUBSCRIPTION_ID and AZURE_RESOURCE_GROUP don't apply to Identity at all.