### PR TITLE
December Release Notes for .NET

### DIFF
--- a/releases/2019-12/2019-12-dotnet.md
+++ b/releases/2019-12/2019-12-dotnet.md
@@ -23,7 +23,7 @@ To install any of our packages, please search for them via `Manage NuGet Package
     $> dotnet add package Azure.Security.KeyVault.Key
     $> dotnet add package Azure.Security.KeyVault.Certificates --version 4.0.0-preview.6
 
-    $> dotnet add package Azure.Messaging.EventHubs --version 5.0.0-preview.5
+    $> dotnet add package Azure.Messaging.EventHubs --version 5.0.0-preview.6
 
     $> dotnet add package Azure.Identity
 
@@ -37,10 +37,22 @@ If you have a bug or feature request for one of the libraries, please [file an i
 
 ## Changelog
 
-Detailed change logs are linked to in the Quick Links below. Here are some critical call outs.
+Detailed changelogs are linked from the [Quick Links](#quick-links) below. Here are some of the highlights:
 
+### Event Hubs
 
-**TODO** 
+- A large portion of the public API surface, including members and parameters, have had adjustments to their naming and organization in order to improve discoverability, provide better context to developers, and better conform to the [Azure SDK Design Guidelines for .NET](https://azure.github.io/azure-sdk/dotnet_introduction.html).  For more details, please see the [Event Hubs](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md#500-preview6) and [Event Processor](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md#500-preview6) changelogs.
+
+- The `EventProcessorClient` has been moved into its own [package](./../Azure.Messaging.EventHubs.Processor) and evolved into an opinionated implementation on top of Azure Storage Blobs.  This is intended to offer a more streamlined developer experience for the majority of scenarios and allow developers to more easily take advantage of the processor.
+
+- A bug with the use of Azure.Identity credential scopes has been fixed; Azure identities should now allow for proper authorization with Event Hubs resources.   
+_(A community contribution, courtesy of [albertodenatale](https://github.com/albertodenatale))_
+
+- The `EventHubsConsumerClient` and `EventHubProducerClient` types are no longer bound to a partition; the partition and other attibutes may now be requested at the opreation-level to allow for more granular control over behavior without the need to create multiple clients.
+
+- Events may now be read across all partitions of an Event Hub using the `ReadEvents` method of the consumer client.  This is intened for exploring Event Hubs and not recommended for production use; for production scenarios, please consider using the `EventProcessorClient` as a more robust alternative.
+
+- The API for the `EventProcessorClient` has been revised, adopting an event-driven model that aligns to many of the .NET base class library types and reduces complexity when constructing the client.
 
 ## Quick Links
 


### PR DESCRIPTION
# Summary

The focus of these changes it to provide changelog details for the Event Hubs client library for .NET.

# Last Upstream Rebase

Wednesday, December 4, 3:12pm (EST)