### PR TITLE
Remove the PackageOverridePath from python template

### DIFF
--- a/_includes/python-packages.html
+++ b/_includes/python-packages.html
@@ -16,11 +16,7 @@
   <td><a href="https://azuresdkdocs.blob.core.windows.net/$web/python/{{ item.Package }}/{{ item.Version }}/index.html"><img alt="{{ item.Package }} Docs" src="https://img.shields.io/static/v1?label=github.io&message={{ item.Version }}&color=blue" /></a></td>
   {% endif %}
 
-  {% assign pkgpath = item.Package %}
-  {% if item.PackagePathOverride %}
-    {% assign pkgpath = item.PackagePathOverride %}
-  {% endif %}
-  <td><a href="https://github.com/Azure/azure-sdk-for-python/tree/{{ item.Package }}_{{ item.Version }}/sdk/{{ item.RepoPath }}/{{ pkgpath }}/"><img alt="{{ item.Package }} Source" src="https://img.shields.io/static/v1?label=github&message={{ item.Version }}&color=blue" /></a></td>
+  <td><a href="https://github.com/Azure/azure-sdk-for-python/tree/{{ item.Package }}_{{ item.Version }}/sdk/{{ item.RepoPath }}/{{ item.Package }}/"><img alt="{{ item.Package }} Source" src="https://img.shields.io/static/v1?label=github&message={{ item.Version }}&color=blue" /></a></td>
 </tr>
 {% endfor %}
 </table>

--- a/eng/scripts/Update-Release-Versions.ps1
+++ b/eng/scripts/Update-Release-Versions.ps1
@@ -153,12 +153,8 @@ function Update-python-Packages($packageList, $tf)
   {
     $version = $versions[$pkg.Package].Latest;
 
-    # Need to have an override for an invalid package path for azure-eventhub package lives in sdk/eventhub/azure-eventhubs path. We should fix that.
-    $pkgPath = $pkg.Package
-    if ($pkg.PackagePathOverride -ne $nul) { $pkgPath = $pkg.PackagePathOverride}
-
     $valid = $true;
-    $valid = $valid -and (CheckLink ("https://github.com/Azure/azure-sdk-for-python/tree/{0}_{1}/sdk/{2}/{3}/" -f $pkg.Package, $version, $pkg.RepoPath, $pkgPath))
+    $valid = $valid -and (CheckLink ("https://github.com/Azure/azure-sdk-for-python/tree/{0}_{1}/sdk/{2}/{3}/" -f $pkg.Package, $version, $pkg.RepoPath, $$pkg.Package))
     $valid = $valid -and (CheckLink ("https://pypi.org/project/{0}/{1}" -f $pkg.Package, $version))
 
     $pkg.MissingDocs = !(CheckLink ("https://azuresdkdocs.blob.core.windows.net/`$web/python/{0}/{1}/index.html" -f $pkg.Package, $version))


### PR DESCRIPTION
We fixed the packages that needed this hack/workaround so
we can remove the workaround now.