### PR TITLE
Clarified ServiceVersion Guidelines

### DIFF
--- a/docs/dotnet/introduction.md
+++ b/docs/dotnet/introduction.md
@@ -672,17 +672,20 @@ Use a constructor parameter called `version` on the client options type.
 * The `version` parameter must be the first parameter to all constructor overloads.
 * The `version` parameter must be required, and default to the latest supported service version.
 * The type of the `version` parameter must be `ServiceVersion`; an enum nested in the options type.
-* The `ServiceVersion` enum must use explicit values.
+* The `ServiceVersion` enum must use explicit values starting from 1. 
+* `ServiceVersion` enum value 0 is reserved. When 0 is passed into APIs, ArgumentException should be thrown.
 
 For example, the following is a code snippet from the `ConfigurationClientOptions`:
 
 ```csharp
 public class ConfigurationClientOptions : HttpPipelineOptions {
 
-    public ConfigurationClientOptions(ServiceVersion version = ServiceVersion.V2019_05_09)
+    public ConfigurationClientOptions(ServiceVersion version = ServiceVersion.V2019_05_09) {
+        if (value == default) throw new ArgumentException(...);
+    }
 
     public enum ServiceVersion {
-        V2019_05_09 = 0,
+        V2019_05_09 = 1,
     }
     ...
 }

--- a/docs/dotnet/introduction.md
+++ b/docs/dotnet/introduction.md
@@ -681,7 +681,9 @@ For example, the following is a code snippet from the `ConfigurationClientOption
 public class ConfigurationClientOptions : HttpPipelineOptions {
 
     public ConfigurationClientOptions(ServiceVersion version = ServiceVersion.V2019_05_09) {
-        if (value == default) throw new ArgumentException(...);
+        if (version == default) 
+            throw new ArgumentException($"The service version {version} is not supported by this library.");
+        }
     }
 
     public enum ServiceVersion {


### PR DESCRIPTION
This guideline update clarifies what we have been doing already, i.e. we reserved the ServiceVersion value 0, mainly so people don't accidentally pass in the default value.