### PR TITLE
Add December release to home page, fix typo

### DIFF
--- a/_posts/2019-11-11-november-ga-release.md
+++ b/_posts/2019-11-11-november-ga-release.md
@@ -6,7 +6,7 @@ sidebar: releases_sidebar
 repository: azure/azure-sdk
 ---
 
-The Azure SDK team is pleased to announce the Novemeber 2019 release of the Azure client libraries.  We have some libraries that have reached General Availability and others that we have provided a new preview.
+The Azure SDK team is pleased to announce the November 2019 release of the Azure client libraries.  We have some libraries that have reached General Availability and others that we have provided a new preview.
 
 The following libraries have reached our general availability level.  This requires support from all four languages (.NET, Java, Python, and TypeScript).
 

--- a/_posts/2019-12-13-december-release.md
+++ b/_posts/2019-12-13-december-release.md
@@ -8,7 +8,7 @@ repository: azure/azure-sdk
 
 The Azure SDK team is pleased to announce the December 2019 release of the Azure client libraries.  We have some libraries that have reached General Availability and others that we have provided a new preview.
 
-The following libraries have reached our general availability level.  This requires support from all four languages (.NET, Java, Python, and TypeScript).
+The following libraries have reached our general availability level.  This requires support from all four languages (.NET, Java, Python, and JavaScript).
 
 * Storage Files (SMB and other file shares)
 
@@ -20,13 +20,15 @@ We also updated the following libraries with a new preview:
 * KeyVault Certificates
 * Storage DataLake Files
 
+You can find a complete list of all our SDK packages here: https://aka.ms/sdkrel
+
 We recommend that you use the generally available client libraries for all new projects, and consider upgrading existing projects to use the new libraries as time permits.
 
-We also encourage you to try out the new previews and give us your feedback by opening an issue on the appropriate GitHub repository.
+We are always looking for developer feedback. When you have feedback, open an issue on the GitHub repository for the language of the library you're using.
 
 You can find all the details in our release notes for each language:
 
 * [.NET release notes]({{site.baseurl}}/releases/2019-12/dotnet.html)
 * [Java release notes]({{site.baseurl}}/releases/2019-12/java.html)
 * [Python release notes]({{site.baseurl}}/releases/2019-12/python.html)
-* [TypeScript release notes]({{site.baseurl}}/releases/2019-12/js.html)
+* [JavaScript release notes]({{site.baseurl}}/releases/2019-12/js.html)

--- a/_posts/2019-12-13-december-release.md
+++ b/_posts/2019-12-13-december-release.md
@@ -1,0 +1,32 @@
+---
+title: Azure SDK Releases (December 2019)
+layout: post
+date: 13 Dec 2019
+sidebar: releases_sidebar
+repository: azure/azure-sdk
+---
+
+The Azure SDK team is pleased to announce the December 2019 release of the Azure client libraries.  We have some libraries that have reached General Availability and others that we have provided a new preview.
+
+The following libraries have reached our general availability level.  This requires support from all four languages (.NET, Java, Python, and TypeScript).
+
+* Storage Files (SMB and other file shares)
+
+We also updated the following libraries with a new preview:
+
+* App Configuration
+* Cosmos
+* Event Hubs
+* KeyVault Certificates
+* Storage DataLake Files
+
+We recommend that you use the generally available client libraries for all new projects, and consider upgrading existing projects to use the new libraries as time permits.
+
+We also encourage you to try out the new previews and give us your feedback by opening an issue on the appropriate GitHub repository.
+
+You can find all the details in our release notes for each language:
+
+* [.NET release notes]({{site.baseurl}}/releases/2019-12/dotnet.html)
+* [Java release notes]({{site.baseurl}}/releases/2019-12/java.html)
+* [Python release notes]({{site.baseurl}}/releases/2019-12/python.html)
+* [TypeScript release notes]({{site.baseurl}}/releases/2019-12/js.html)


### PR DESCRIPTION
Added a page describing what was completed in December with pointers to the latest release notes for December to appear as the top item on the homepage.

Fixed a typo in the November post at the same time.