### PR TITLE
Add PROXY_USERNAME and PROXY_PASSWORD

### DIFF
--- a/_includes/tables/environment_variables.md
+++ b/_includes/tables/environment_variables.md
@@ -4,6 +4,8 @@
 | HTTP_PROXY                    | Proxy for HTTP connections             |
 | HTTPS_PROXY                   | Proxy for HTTPS connections            |
 | NO_PROXY                      | Hosts which must not use a proxy       |
+| PROXY_USERNAME                | Username for proxy authentication      |
+| PROXY_PASSWORD                | Password for proxy authentication      |
 | **Identity**                                                          ||
 | MSI_ENDPOINT                  | Azure AD MSI Credentials               |
 | MSI_SECRET                    | Azure AD MSI Credentials               |


### PR DESCRIPTION
Adds `PROXY_USERNAME` and `PROXY_PASSWORD` to the list of well-known environment variables which are used to authenticate the SDK to the proxy. This resolves a gap in functionality left in the list of environment variables to handle Proxy-Authentication requests returned by a proxy, this should enable environment support of Basic and Digest authentication schemes if supported.

Link to Proxy requirements: https://azure.github.io/azure-sdk/general_azurecore.html#proxy-policy