### PR TITLE
Change Quick Links to Latest Releases

### DIFF
--- a/releases/2019-12/2019-12-dotnet.md
+++ b/releases/2019-12/2019-12-dotnet.md
@@ -69,7 +69,7 @@ _(A community contribution, courtesy of [albertodenatale](https://github.com/alb
 
 - The API for the `EventProcessorClient` has been revised, adopting an event-driven model that aligns to many of the .NET base class library types and reduces complexity when constructing the client.
 
-## Quick Links
+## Latest Releases
 
 {% assign packages = site.data.releases.latest.dotnet-packages %}
 {% include dotnet-packages.html %}

--- a/releases/2019-12/2019-12-java.md
+++ b/releases/2019-12/2019-12-java.md
@@ -182,7 +182,7 @@ Detailed changelogs are linked from the [Quick Links](#quick-links) below. Here 
 * File an issue via [Github Issues](https://github.com/Azure/azure-sdk-for-java/issues/new/choose).
 * Check [previous questions](https://stackoverflow.com/questions/tagged/azure-java-sdk) or ask new ones on StackOverflow using `azure-java-sdk` tag.
 
-## Quick Links
+## Latest Releases
 
 {% assign packages = site.data.releases.latest.java-packages %}
 {% include java-packages.html %}

--- a/releases/2019-12/2019-12-js.md
+++ b/releases/2019-12/2019-12-js.md
@@ -53,7 +53,7 @@ of the load balancing and checkpointing features, you will need to update it to 
 - Checkpoint store is now meant to be passed to the constructor of the `EventHubConsumerClient` class rather than the
 `subscribe()` method on it.
 
-## Quick Links
+## Latest Releases
 
 {% assign packages = site.data.releases.latest.js-packages %}
 {% include js-packages.html %}

--- a/releases/2019-12/2019-12-python.md
+++ b/releases/2019-12/2019-12-python.md
@@ -70,8 +70,7 @@ Detailed change logs are linked to in the Quick Links below. Here are some criti
 - `EventHubProducerClient.send` has been renamed to `send_batch` which will only accept `EventDataBatch` object as input.
 - Receive event callback parameter has been renamed to `on_event` and now operates on a single event rather than a list of events.
 
-
-## Quick Links
+## Latest Releases
 
 {% assign packages = site.data.releases.latest.python-packages %}
 {% include python-packages.html %}

--- a/releases/2020-01/dotnet.md
+++ b/releases/2020-01/dotnet.md
@@ -84,7 +84,7 @@ Detailed changelogs are linked from the [Quick Links](#quick-links) below. Here 
   - Identification of Personally Identifiable Information.
   - Analyze Sentiment APIs including analysis for mixed sentiment.
 
-## Quick Links
+## Latest Releases
 
 {% assign packages = site.data.releases.latest.dotnet-packages %}
 {% include dotnet-packages.html %}

--- a/releases/2020-01/java.md
+++ b/releases/2020-01/java.md
@@ -184,7 +184,7 @@ For more details, please see the detailed [changelog](https://github.com/Azure/a
 * File an issue via [Github Issues](https://github.com/Azure/azure-sdk-for-java/issues/new/choose).
 * Check [previous questions](https://stackoverflow.com/questions/tagged/azure-java-sdk) or ask new ones on StackOverflow using `azure-java-sdk` tag.
 
-## Quick Links
+## Latest Releases
 
 {% assign packages = site.data.releases.latest.java-packages %}
 {% include java-packages.html %}

--- a/releases/2020-01/js.md
+++ b/releases/2020-01/js.md
@@ -29,7 +29,7 @@ If you have a bug or feature request for one of the libraries, please post an is
 ## Changelog
 Detailed change logs are linked to in the Quick Links below.
 
-## Quick Links
+## Latest Releases
 
 {% assign packages = site.data.releases.latest.js-packages %}
 {% include js-packages.html %}

--- a/releases/2020-01/python.md
+++ b/releases/2020-01/python.md
@@ -106,7 +106,7 @@ on Windows
 - Keyword argument `model_version` can be used to specify the model version used to analyze documents
 - Keyword arguments `default_country_hint` and `default_language` allow users to specify the defaults at client instantiation
 
-## Quick Links
+## Latest Releases
 
 {% assign packages = site.data.releases.latest.python-packages %}
 {% include python-packages.html %}


### PR DESCRIPTION
Less confusing for 2019-12 and 2020-01 that use the latest data source.