### PR TITLE
Rename examples

### DIFF
--- a/docs/clang/design.md
+++ b/docs/clang/design.md
@@ -95,7 +95,7 @@ static uint32_t byte_counter = 0;
 const int Global_Foo = 5;
 
 // Good
-const int AZ_CATHERD_TIMEOUT_MSEC = 5;
+const int AZ_WIDGETS_TIMEOUT_MSEC = 5;
 {% endhighlight %}
 
 {% include requirement/MUST id="clang-design-naming-global-private-const" %} name private/internal global constants in all uppercase with the prefix `_az`. For example:
@@ -165,7 +165,7 @@ enum ServiceState {
 int64_t _az_compute_hash(int32_t a, int32_t b);
 
 // Part of the public API
-az_catherd_client_t az_catherd_create_client(char *herd_name);
+az_result az_widgets_client_init(az_widgets_client* self);
 
 // Bad - no leading underscore
 int64_t compute_hash(int32_t a, int32_t b);
@@ -777,7 +777,7 @@ The destruction function should follow this pattern:
 void az_widgets_client_destroy(az_widgets_client* client);
 {% endhighlight %}
 
-The following is a possible implementation of a destruction function for the cat herding object:
+The following is a possible implementation of a destruction function for the widgets client object:
 
 {% highlight c %}
 void az_widgets_client_destroy(az_widgets_client* client) {
@@ -796,11 +796,11 @@ To define a method on an object simply define a function taking a pointer to tha
 
 {% highlight c %}
 /**
- * @brief add a cat to the herd
+ * @brief add a side to the widget
  * @memberof az_widgets_client
  *
  * @param[in] herd - the herd
- * @param[in] __[transfer none]__ cat - the cat to add
+ * @param[in] __[transfer none]__ side - the side to add
  * @return Any errors
  * @retval AZ_OK on success
  * @retval AZ_ERROR_NO_MEMORY if a reallocation of the internal
@@ -851,7 +851,7 @@ If a function takes both optional and non-optional parameters then prefer passin
 
 ### Methods requiring allocation
 
-If a method could require allocating memory then it should use the most relevant set of allocation callbacks. For example the `az_widgets_client_add_side` method may need to allocate or re-allocate the array of cats.  It should use the `az_widgets_client` allocators.  On the other hand the method:
+If a method could require allocating memory then it should use the most relevant set of allocation callbacks. For example the `az_widgets_client_add_side` method may need to allocate or re-allocate the array of sides.  It should use the `az_widgets_client` allocators.  On the other hand the method:
 
 {% highlight c %}
 void az_widgets_client_set_str(az_widgets_client* herd, const char* str);

--- a/docs/clang/design.md
+++ b/docs/clang/design.md
@@ -541,11 +541,11 @@ Note: if your client library needs to be resilient to these kinds of errors you 
 For example:
 
 {% highlight c %}
-AZ_NODISCARD az_result az_catherding_count_cats(az_catherding_herd* herd, int* cats) {
-  if(herd->has_shy_cats) {
-    return AZ_RESULT_CATHERDING_HIDING_CATS;
+AZ_NODISCARD az_result az_widgets_count_widgets(az_widgets_client* client, int* widgets) {
+  if(client->no_widget_storage) {
+    return AZ_RESULT_WIDGETS_NO_STORAGE;
   }
-  *cats = herd->num_cats;
+  *widgets = clinet->num_widgets;
   return AZ_OK;
 }
 {% endhighlight %}
@@ -624,37 +624,35 @@ do so using user-overridable functions.
 
 C doesn't have object oriented programming built in, but most programs end up implementing some kind of ad-hoc object model. 
 
-Let's consider the object used to represent a herd of cats in the fictional Azure Catherding client library. Such a structure could be defined like this:
+Let's consider the object used to represent a widget in the fictional Azure Widgets service. Such a structure could be defined like this:
 
 {% highlight c %}
-typedef struct az_catherding_herd {
-  uint16_t num_cats;
-  az_catherding_cat* cats;
-  bool is_indoor;
-} az_catherding_herd;
+typedef struct az_widgets_widget {
+  uint16_t num_sides;
+  az_widget_side* sides;
+  bool was_frobnicated;
+} az_widgets_widget;
 {% endhighlight %}
 
 If you are defining an opaque type then the definition is placed in a `.c` file and the header file contains the following:
 
 {% highlight c %}
-typedef struct az_catherding_herd az_catherding_herd;
+typedef struct az_widgets_widget az_widgets_widget;
 {% endhighlight %}
 
 If you need to expose the type (for stack allocation), but would like to make it clear that some fields are private and should not be modified, place the type in the header file as follows::
 
 {% highlight c %}
-struct _az_catherding_herd_internal {
-  uint16_t num_cats;
-  az_catherding_cat* cats;
-  bool is_indoor;
-};
-
-typedef struct az_catherding_herd {
-  struct _az_catherding_herd_internal _internal;
-} az_catherding_herd;
+typedef struct az_widgets_widget {
+  struct {
+    uint16_t num_sides;
+    az_widgets_side* sides;
+    bool was_frobnicated;
+  } _internal;
+} az_widgets_widget;
 {% endhighlight %}
 
-{% include requirement/MUSTNOT id="clang-objmodel-nohiding" %} hide the members of a struct that supports stack allocation.  This can result in alignment problems and missed optimization opportunities.
+{% include requirement/MUSTNOT id="clang-objmodel-nohiding" %} hide the members of a struct that supports stack allocation, except in the above way.  This can result in alignment problems and missed optimization opportunities.
 
 ### Initialization and destruction
 
@@ -667,8 +665,8 @@ You must always have an initialization function. This function will take a block
 If there is more than one way to initialize an object, you should define multiple initialization functions with different names. For example:
 
 {% highlight c %}
-void az_catherding_herd_init(az_catherding_herd* herd);
-void az_catherding_herd_init_with_cats(az_catherding_herd* herd, int num_cats, az_catherding_cats* cats);
+void az_widgets_client_init(az_widgets_client* client);
+void az_kwidgets_client_init_with_sides(az_widgets_client* client, int num_sides, az_widgets_side* sides);
 {% endhighlight %}
 
 If initialization could fail (for example, during parameter validation), ensure the init function returns an `az_result` to indicate error conditions.
@@ -676,16 +674,16 @@ If initialization could fail (for example, during parameter validation), ensure 
 A possible implementation of these initialization functions would be:
 
 {% highlight c %}
-void az_catherding_herd_init(az_catherding_herd* herd) {
-  memset(herd, 0, sizeof(az_catherding_herd));
+void az_widgets_client_init(az_widgets_client* client) {
+  memset(client, 0, sizeof(az_widgets_client));
 }
 
 
-void az_catherding_herd_init_with_cats(az_catherding_herd* herd,
-				       int num_cats, az_catherding_cats* cats) {
-  az_catherding_herd_init(herd);
-  herd->cats = cats;
-  herd->num_cats = num_cats;
+void az_widgets_client_init_with_sides(az_widgets_client* client,
+				       int num_sides, az_widgets_side* sides) {
+  az_widgets_client_init(herd);
+  herd->sides = sides;
+  herd->num_sides = num_sides;
 }
 {% endhighlight %}
 
@@ -709,7 +707,7 @@ Note that this is the opposite of the pattern for other methods.  Allocation fun
 
 {% include requirement/SHOULDNOT id="clang-objmodel-alloc4" %} store a pointer to the allocation callbacks inside the memory returned by the allocation function.  You may store such a pointer for debugging purposes.
 
-The intent is to allow storing a pointed tot he allocation callbacks to ensure the same set of callbacks is used for allocation and deallocation.  However, it is not allowed to change the ABI of the returned object to do this.  You need to store the callbacks before or after the pointer returned to the called.
+The intent is to allow storing a pointer to the allocation callbacks to ensure the same set of callbacks is used for allocation and deallocation.  However, it is not allowed to change the ABI of the returned object to do this.  You need to store the callbacks before or after the pointer returned to the caller.
 
 > TODO: Rationalize this - do we store or not store?
 
@@ -719,38 +717,38 @@ For example:
 
 {% highlight c %}
 #include <stdint.h>
-typedef struct az_catherding_herd az_catherding_herd;
+typedef struct az_widget_client az_widget_client;
 
-az_result az_catherding_allocate_herd(az_catherding_herd** herd, az_allocation_callbacks* alloc);
-void az_catherding_deallocate_herd(az_catherding_herd* herd, az_allocation_callbacks* alloc);
+az_result az_widgets_allocate_client(az_widgets_client** herd, az_allocation_callbacks* alloc);
+void az_widgets_deallocate_client(az_widgets_client* herd, az_allocation_callbacks* alloc);
 {% endhighlight %}
 
 {% highlight c %}
 #include "herd.h"
-typedef struct az_catherding_herd {
-  uint16_t num_cats;
-  az_catherding_cat* cats;
-  bool is_indoor;
-} az_catherding_herd;
+typedef struct az_widgets_client {
+  uint16_t num_sides;
+  az_widgets_side* sides;
+  bool was_frobnicated;
+} az_widgets_client;
 
 
-az_result az_catherding_allocate_herd(az_catherding_herd** herd, az_allocation_callbacks* alloc) {
+az_result az_widgets_allocate_client(az_widgets_client** client, az_allocation_callbacks* alloc) {
 if(!alloc) {
-    *herd = az_default_alloc(sizeof(az_catherding_herd));
+    *client = az_default_alloc(sizeof(az_widgets_client));
 } else {
-    *herd = alloc->allocate(sizeof(az_catherding_herd));
+    *client = alloc->allocate(sizeof(az_widgets_herd));
 }
-if(!*herd) {
+if(!*client) {
     return AZ_ERROR_ALLOCATION_ERROR;
 }
-return AZ_SUCCESS;
+return AZ_OK;
 }
 
-void az_catherding_deallocate_herd(az_catherding_herd* herd, az_allocation_callbacks* alloc) {
+void az_widgets_deallocate_client(az_widgets_client* client, az_allocation_callbacks* alloc) {
 if(!alloc) {
-    az_default_deallocate(herd);
+    az_default_deallocate(client);
 } else {
-    alloc->deallocate(herd);
+    alloc->deallocate(client);
 }
 }
 {% endhighlight %}
@@ -776,19 +774,19 @@ The reason one would take an allocation callback parameter in the destruction fu
 The destruction function should follow this pattern:
 
 {% highlight c %}
-void az_catherding_herd_destroy(az_catherding_herd* herd);
+void az_widgets_client_destroy(az_widgets_client* client);
 {% endhighlight %}
 
 The following is a possible implementation of a destruction function for the cat herding object:
 
 {% highlight c %}
-void az_catherding_herd_destroy(az_catherding_herd* herd) {
-if(herd->alloc) {
-    herd->alloc->deallocate(cats);
+void az_widgets_client_destroy(az_widgets_client* client) {
+if(client->alloc) {
+    client->alloc->deallocate(sides);
 }
-az_string_destroy(herd->str);
-herd->num_cats = 0;
-herd->alloc = 0;
+az_string_destroy(client->str);
+client->num_sides = 0;
+client->alloc = 0;
 }
 {% endhighlight %}
 
@@ -799,7 +797,7 @@ To define a method on an object simply define a function taking a pointer to tha
 {% highlight c %}
 /**
  * @brief add a cat to the herd
- * @memberof az_catherding_herd
+ * @memberof az_widgets_client
  *
  * @param[in] herd - the herd
  * @param[in] __[transfer none]__ cat - the cat to add
@@ -808,7 +806,7 @@ To define a method on an object simply define a function taking a pointer to tha
  * @retval AZ_ERROR_NO_MEMORY if a reallocation of the internal
  *                            array failed
  */
-az_result az_catherding_herd_add_cat(az_catherding_herd* herd, cat* cat);
+az_result az_widgets_client_add_side(az_widgets_client* client, az_widgets_side* side);
 {% endhighlight %}
 
 {% include requirement/MUST id="clang-objmodel-memberof" %} use `@memberof` to indicate a function is associated with a class.
@@ -819,31 +817,31 @@ az_result az_catherding_herd_add_cat(az_catherding_herd* herd, cat* cat);
 
 Sometimes a function will take a large number of parameters, many of which have sane defaults.  In this case you should pass them via a struct. Default arguments should be represented by "zero". If the function is a method then the first parameter should still be a pointer to the object type the method is associated with.
 
-For example the previous `az_catherding_herd_init_with_cats` function could be better defined instead as:
+For example the previous `az_widgets_client_init_with_sides` function could be defined instead as:
 
 {% highlight c %}
-typedef struct az_catherding_herd_init_with_cats_params {
-  int num_cats;
-  az_catherding_cats* cats;
-  bool is_indoor;
-} az_catherding_herd_init_with_cats_params;
-void az_catherding_herd_init_with_params(az_catherding_herd* herd, const az_catherding_herd_init_with_cats_params* params);
+typedef struct az_widgets_client_init_with_sides_options {
+  int num_sides;
+  az_widgets_side* sides;
+  bool was_frobnicated;
+} az_widgets_client_init_with_sides_options;
+void az_widgets_client_init_with_sides(az_widgets_client* client, const az_widgets_client_init_with_sides_options* options);
 {% endhighlight %}
 
 and would be called from user code like:
 
 {% highlight c %}
 int main() {
-  az_catherding_herd herd;
-  az_catherding_herd_init_with_params(&herd, &(az_catherding_herd_init_with_cats_params){
-    .is_indoor = true
-  });
+  az_widgets_client client = { 0 };
+  az_widgets_client_init_with_sides_options options = 
+    az_widgets_client_init_with_sides_default_options();
+  az_widgets_client_init_with_sides(&client, NULL);
 }
 {% endhighlight %}
 
-Note that the `num_cats` and `cats` parameters are left as default.
+Note that the `num_sides` and `sides` parameters are left as default.
 
-If the `params` parameter is `NULL` then the `az_catherding_init_with_params` function should assume the defaults for all parameters.
+If the `params` parameter is `NULL` then the `az_widgets_client_init_with_sides` function should assume the defaults for all parameters.
 
 If a function takes both optional and non-optional parameters then prefer passing the non-optional ones as parameters and the optional ones by struct.
 
@@ -853,26 +851,26 @@ If a function takes both optional and non-optional parameters then prefer passin
 
 ### Methods requiring allocation
 
-If a method could require allocating memory then it should use the most relevant set of allocation callbacks. For example the `az_catherding_herd_add_cat` method may need to allocate or re-allocate the array of cats.  It should use the `az_catherding_herd` allocators.  On the other hand the method:
+If a method could require allocating memory then it should use the most relevant set of allocation callbacks. For example the `az_widgets_client_add_side` method may need to allocate or re-allocate the array of cats.  It should use the `az_widgets_client` allocators.  On the other hand the method:
 
 {% highlight c %}
-void az_catherding_herd_set_str(az_catherding_herd* herd, const char* str);
+void az_widgets_client_set_str(az_widgets_client* herd, const char* str);
 {% endhighlight %}
 
-would likely use the allocation callbacks inside the `herd->str` structure.
+would likely use the allocation callbacks inside the `client->str` structure.
 
 > TODO: Rationalize advice here.  Earlier, we said don't include allocators inside the structure.
 
 ### Callbacks
 
-Callback functions should be defined to take a pointer to the "sender" object as the first argument and a void pointer to user data as the last argument. Any additional arguments, if any, should be contextual data needed by the callback. For example say we had an object `az_catherding_client` that could make requests to be handled in a callback and we represent the response as an object `az_response`. We might define the following:
+Callback functions should be defined to take a pointer to the "sender" object as the first argument and a void pointer to user data as the last argument. Any additional arguments, if any, should be contextual data needed by the callback. For example say we had an object `az_widgets_client` that could make requests to be handled in a callback and we represent the response as an object `az_response`. We might define the following:
 
 {% highlight c %}
-typedef bool (*az_catherding_response_callback)(az_catherding_client* client,
+typedef bool (*az_widgets_response_callback)(az_widgets_client* client,
 						az_response* resp,
 						void* user_data);
-void az_catherding_client_set_response_callback(az_catherding_client* client,
-						az_catherding_response_callback callback,
+void az_widgets_client_set_response_callback(az_widgets_client* client,
+						az_widgets_response_callback callback,
 						void* user_data);
 {% endhighlight %}
 
@@ -884,7 +882,7 @@ typedef struct user_data {
 } user_data;
 
 
-bool handle_resp(az_catherding_client* client,
+bool handle_resp(az_widgets_client* client,
 		 az_response* resp,
 		 void* user) {
   user_data* data = user;
@@ -894,13 +892,13 @@ bool handle_resp(az_catherding_client* client,
 
 int main() {
   user_data d = {.some_int = 5};
-  az_catherding_client client;
-  az_catherding_client_init(&client);
-  az_catherding_client_set_response_callback(&client, &handle_resp, &d);
+  az_widgets_client client = { 0 };
+  az_widgets_client_init(&client);
+  az_widgets_client_set_response_callback(&client, &handle_resp, &d);
   /* do something that triggers the callback */
 
   /* unset the callback if we don't want to handle it anymore */
-  az_catherding_client_set_response_callback(&client, NULL, NULL);
+  az_widgets_client_set_response_callback(&client, NULL, NULL);
 }
 {% endhighlight %}
 

--- a/docs/clang/documentation.md
+++ b/docs/clang/documentation.md
@@ -112,9 +112,9 @@ For example:
 
 {% highlight c %}
 /**
- * @brief get properties of a cat (e.g. hair color, weight, floof)
+ * @brief get properties of a widget (e.g. place of manufacture, number of sides, material)
  *
- * @param[in] our_cat __[transfer none]__ the cat to operate on
+ * @param[in] self __[transfer none]__ the widget to operate on
  * @param[out] props __[nullable][caller-allocates]__ pointer to an array of num_props, or null
  * @param[in,out] num_props __[non nullable][caller-allocates]__ pointer to the number of properties to
  *                                                               retrieve or to a location to store the number of
@@ -123,7 +123,7 @@ For example:
  * If @p props is NULL then return the number of properties available in @p num_props,
  * otherwise return @p num_props into the array at @p props
  */
-az_error az_catherding_get_cat_properties(cat* our_cat, cat_properties* props, size_t* num_props);
+az_error az_widgets_get_widget_properties(az_widgets_widget* self, az_widgets_widget_properties* props, size_t* num_props);
 {% endhighlight %}
 
 This function returns an array using all caller-allocated memory. In order to figure out the size of the array the caller can pass NULL for the array `[out]` parameter. They can then allocate the required memory and call the function again.

--- a/docs/clang/implementation.md
+++ b/docs/clang/implementation.md
@@ -61,28 +61,28 @@ for one client constructor.
 For example,
 
 ```c
-typedef struct az_catherding_client_options {
-    uint32_t num_cats;
-    bool indoor_cats;
-} az_catherding_client_options;
+typedef struct az_widgets_client_options {
+    uint32_t num_sides;
+    bool was_frobnicated;
+} az_widgets_client_options;
 
-AZ_NODISCARD az_catherding_client_options az_catherding_client_default_options(void);
+AZ_NODISCARD az_widgets_client_options az_widgets_client_default_options(void);
 
-AZ_NODISCARD az_result az_catherding_client_init(az_catherding_client* self, const az_catherding_default_cat_options* options);
+AZ_NODISCARD az_result az_widgets_client_init(az_widgets_client* self, const az_widgets_default_client_options* options);
 ```
 
 The user can request the default with:
 
 ```c
-az_catherding_client client = {0};
-az_result res = az_catherding_client_init(&cat, NULL);
+az_widgets_client client = {0};
+az_result res = az_widgets_client_init(&client, NULL);
 ```
 or specify their own options with:
 ```c
-az_catherding_client client = {0};
-az_catherding_cat_options options = az_catherding_client_default_options();
-options.num_cats = 4;
-az_result res = az_catherding_client_init(&client, &options);
+az_widgets_client client = {0};
+az_widgets_client_options options = az_widgets_client_default_options();
+options.num_sides = 4;
+az_result res = az_widgets_client_init(&client, &options);
 ```
 
 {% include requirement/MUST id="clang-config-for-different-clients" %} allow different clients of the same type to use different configurations.
@@ -97,29 +97,29 @@ default buffer sizes based on the target platform or build settings is prohibite
 
 For example, consider the structure:
 ```c
-typedef struct az_catherding_herd {
-    int num_cats;
-    uint8_t cat_buffer[CAT_BUFFER_SIZE];
-} az_catherding_herd;
+typedef struct az_widgets_widget {
+    int num_sides;
+    uint8_t side_buffer[AZ_WIDGETS_SIDE_BUFFER_SIZE];
+} az_widgets_widget;
 ```
 
 This is OK:
 
 ```cmake
 ...
-set(AZ_CATHEREDING_CAT_BUFFER_SIZE 1024 CACHE STRING "default size of cat buffer")
-target_compile_definitions(az_catherding PUBLIC CAT_BUFFER_SIZE=${AZ_CATHERDING_CAT_BUFFER_SIZE})
+set(AZ_WIDGETS_SIDE_BUFFER_SIZE 1024 CACHE STRING "default size of side buffer")
+target_compile_definitions(az_widgets PUBLIC AZ_WIDGETS_SIDE_BUFFER_SIZE=${AZ_WIDGETS_SIDE_BUFFER_SIZE})
 ```
 
 This is not OK:
 
 ```cmake
 if(TARGETING_DESKTOP)
-    set(AZ_CATHERDING_CAT_BUFFER_SIZE 4096 CACHE STRING "default size of cat buffer")
+    set(AZ_WIDGETS_SIDE_BUFFER_SIZE 4096 CACHE STRING "default size of side buffer")
 else()
-    set(AZ_CATHERDING_CAT_BUFFER_SIZE 1024 CACHE STRING "default size of cat buffer")
+    set(AZ_WIDGETS_SIDE_BUFFER_SIZE 1024 CACHE STRING "default size of side buffer")
 endif()
-target_compile_definitions(az_catherding PUBLIC CAT_BUFFER_SIZE=${AZ_CATHERDING_CAT_BUFFER_SIZE})
+target_compile_definitions(az_widgets PUBLIC CAT_BUFFER_SIZE=${AZ_WIDGETS_SIDE_BUFFER_SIZE})
 ```
 
 {% include requirement/MUSTNOT id="clang-config-defaults-nochange" %} Change the default values of client configuration options based on runtime system or client state.


### PR DESCRIPTION
Jeffrey has expressed dislike for the catherding themed examples, and I think it's not a bad idea to be a bit consistent with out example naming. Some of the guidelines tend to use "real" examples, but for these draft guidelines that would rapidly get out of sync, so I tried to match the Go guidelines usage of widgets.