### PR TITLE
Updating logging guidance

### DIFF
--- a/docs/java/implementation.md
+++ b/docs/java/implementation.md
@@ -172,21 +172,43 @@ public final class ConfigurationAsyncClient {
 
 Don't create static logger instances. Static logger instances are shared among all client library instances running in a JVM instance.
 
-{% include requirement/MUST id="java-logging-levels" %} use one of the following log levels when emitting logs: `Logger.trace` (details), `Logger.info` (things happened), `Logger.warn` (might be a problem or not), and `Logger.error`.
+{% include requirement/MUST id="java-logging-levels" %} use one of the following log levels when emitting logs: `Verbose` (details), `Informational` (things happened), `Warning` (might be a problem or not), and `Error`.
 
-{% include requirement/MUST id="java-logging-errors" %} use the `Logger.error` logging level for failures that the application is unlikely to recover from (out of memory, etc.).
+{% include requirement/MUST id="java-logging-failure" %} use the `Error` logging level for failures that the application is unlikely to recover from (out of memory, etc.).
 
-{% include requirement/MUST id="java-logging-warn" %} use the `Logger.warn` logging level when a function fails to perform its intended task. This generally means that the function will raise an exception.  Do not include occurrences of self-healing events (for example, when a request will be automatically retried).
+{% include requirement/MUST id="java-logging-warning" %} use the `Warning` logging level when a function fails to perform its intended task. This generally means that the function will raise an exception.  Do not include occurrences of self-healing events (for example, when a request will be automatically retried).
 
-{% include requirement/MUST id="java-logging-info" %} use the `Logger.info` logging level when a function operates normally.
+{% include requirement/MAY id="java-logging-slowlinks" %} log the request and response (see below) at the `Warning` when a request/response cycle (to the start of the response body) exceeds a service-defined threshold.  The threshold should be chosen to minimize false-positives and identify service issues.
 
-{% include requirement/MUST id="java-logging-trace" %} use the `Logger.trace` logging level for detailed troubleshooting scenarios. This is primarily intended for developers or system administrators to diagnose specific failures.
+{% include requirement/MUST id="java-logging-info" %} use the `Informational` logging level when a function operates normally.
 
-{% include requirement/MUSTNOT id="java-logging-sensitive" %} send sensitive information in log levels other than `Logger.trace`. For example, remove account keys when logging headers.
+{% include requirement/MUST id="java-logging-verbose" %} use the `Verbose` logging level for detailed troubleshooting scenarios. This is primarily intended for developers or system administrators to diagnose specific failures.
 
-{% include requirement/MUST id="java-logging-request-line" %} log request line, response line, and headers, as a `Logger.info` message.
+{% include requirement/MUST id="java-logging-no-sensitive-info" %} only log headers and query parameters that are in a service-provided "allow-list" of approved headers and query parameters.  All other headers and query parameters must have their values redacted.
 
-{% include requirement/MUST id="java-logging-cancellation" %} use `Logger.info` if a service call is cancelled.
+{% include requirement/MUST id="java-logging-requests" %} log request line and headers as an `Informational` message. The log should include the following information:
+
+* The HTTP method.
+* The URL.
+* The query parameters (redacted if not in the allow-list).
+* The request headers (redacted if not in the allow-list).
+* An SDK provided request ID for correlation purposes.
+* The number of times this request has been attempted.
+
+{% include requirement/MUST id="java-logging-responses" %} log response line and headers as an `Informational` message.  The format of the log should be the following:
+
+* The SDK provided request ID (see above).
+* The status code.
+* Any message provided with the status code.
+* The response headers (redacted if not in the allow-list).
+* The time period between the first attempt of the request and the first byte of the body.
+
+{% include requirement/MUST id="java-logging-cancellations" %} log an `Informational` message if a service call is cancelled.  The log should include:
+
+* The SDK provided request ID (see above).
+* The reason for the cancellation (if available).
+
+{% include requirement/MUST id="java-logging-exceptions" %} log exceptions thrown as a `Warning` level message. If the log level set to `Verbose`, append stack trace information to the message.
 
 {% include requirement/MUST id="java-logging-log-and-throw" %} throw all exceptions created within the client library code through the `ClientLogger.logAndThrow()` API.
 

--- a/docs/java/implementation.md
+++ b/docs/java/implementation.md
@@ -174,9 +174,9 @@ Don't create static logger instances. Static logger instances are shared among a
 
 {% include requirement/MUST id="java-logging-levels" %} use one of the following log levels when emitting logs: `Verbose` (details), `Informational` (things happened), `Warning` (might be a problem or not), and `Error`.
 
-{% include requirement/MUST id="java-logging-failure" %} use the `Error` logging level for failures that the application is unlikely to recover from (out of memory, etc.).
+{% include requirement/MUST id="java-logging-errors" %} use the `Error` logging level for failures that the application is unlikely to recover from (out of memory, etc.).
 
-{% include requirement/MUST id="java-logging-warning" %} use the `Warning` logging level when a function fails to perform its intended task. This generally means that the function will raise an exception.  Do not include occurrences of self-healing events (for example, when a request will be automatically retried).
+{% include requirement/MUST id="java-logging-warn" %} use the `Warning` logging level when a function fails to perform its intended task. This generally means that the function will raise an exception.  Do not include occurrences of self-healing events (for example, when a request will be automatically retried).
 
 {% include requirement/MAY id="java-logging-slowlinks" %} log the request and response (see below) at the `Warning` logging level when a request/response cycle (to the start of the response body) exceeds a service-defined threshold.  The threshold should be chosen to minimize false-positives and identify service issues.
 

--- a/docs/java/implementation.md
+++ b/docs/java/implementation.md
@@ -178,7 +178,7 @@ Don't create static logger instances. Static logger instances are shared among a
 
 {% include requirement/MUST id="java-logging-warning" %} use the `Warning` logging level when a function fails to perform its intended task. This generally means that the function will raise an exception.  Do not include occurrences of self-healing events (for example, when a request will be automatically retried).
 
-{% include requirement/MAY id="java-logging-slowlinks" %} log the request and response (see below) at the `Warning` when a request/response cycle (to the start of the response body) exceeds a service-defined threshold.  The threshold should be chosen to minimize false-positives and identify service issues.
+{% include requirement/MAY id="java-logging-slowlinks" %} log the request and response (see below) at the `Warning` logging level when a request/response cycle (to the start of the response body) exceeds a service-defined threshold.  The threshold should be chosen to minimize false-positives and identify service issues.
 
 {% include requirement/MUST id="java-logging-info" %} use the `Informational` logging level when a function operates normally.
 
@@ -194,6 +194,8 @@ Don't create static logger instances. Static logger instances are shared among a
 * The request headers (redacted if not in the allow-list).
 * An SDK provided request ID for correlation purposes.
 * The number of times this request has been attempted.
+
+This happens within azure-core by default, but users can configure this through the builder `httpLogOptions` configuration setting.
 
 {% include requirement/MUST id="java-logging-responses" %} log response line and headers as an `Informational` message.  The format of the log should be the following:
 


### PR DESCRIPTION
Logging guidance in the Java design guidelines had fallen behind the general guidelines, and was inconsistent with the actual API being offered (which was based on the general guidance). This is a copy / paste of the general guidelines into the java guidelines, replacing the old guidance (particularly around level naming (trace -> verbose)).

Fixes #636 