### PR TITLE
Add notes about pipeline structure.

### DIFF
--- a/_data/sidebars/android_sidebar.yml
+++ b/_data/sidebars/android_sidebar.yml
@@ -23,6 +23,8 @@ entries:
         url: /policies_repostructure.html
       - title: Repository branching
         url: /policies_repobranching.html
+      - title: Pipelines
+        url: /policies_pipelines.html
       - title: Review Process
         url: /policies_reviewprocess.html
       - title: Releases

--- a/_data/sidebars/clang_sidebar.yml
+++ b/_data/sidebars/clang_sidebar.yml
@@ -23,6 +23,8 @@ entries:
         url: /policies_repostructure.html
       - title: Repository branching
         url: /policies_repobranching.html
+      - title: Pipelines
+        url: /policies_pipelines.html
       - title: Review Process
         url: /policies_reviewprocess.html
       - title: Releases

--- a/_data/sidebars/cpp_sidebar.yml
+++ b/_data/sidebars/cpp_sidebar.yml
@@ -23,6 +23,8 @@ entries:
         url: /policies_repostructure.html
       - title: Repository branching
         url: /policies_repobranching.html
+      - title: Pipelines
+        url: /policies_pipelines.html
       - title: Review Process
         url: /policies_reviewprocess.html
       - title: Releases

--- a/_data/sidebars/dotnet_sidebar.yml
+++ b/_data/sidebars/dotnet_sidebar.yml
@@ -41,6 +41,8 @@ entries:
         url: /policies_repostructure.html
       - title: Repository branching
         url: /policies_repobranching.html
+      - title: Pipelines
+        url: /policies_pipelines.html
       - title: Review Process
         url: /policies_reviewprocess.html
       - title: Releases

--- a/_data/sidebars/general_sidebar.yml
+++ b/_data/sidebars/general_sidebar.yml
@@ -49,6 +49,8 @@ entries:
         url: /policies_repostructure.html
       - title: Repository branching
         url: /policies_repobranching.html
+      - title: Pipelines
+        url: /policies_pipelines.html
       - title: Review Process
         url: /policies_reviewprocess.html
       - title: Releases

--- a/_data/sidebars/golang_sidebar.yml
+++ b/_data/sidebars/golang_sidebar.yml
@@ -19,6 +19,8 @@ entries:
         url: /policies_repostructure.html
       - title: Repository branching
         url: /policies_repobranching.html
+      - title: Pipelines
+        url: /policies_pipelines.html
       - title: Review Process
         url: /policies_reviewprocess.html
       - title: Releases

--- a/_data/sidebars/home_sidebar.yml
+++ b/_data/sidebars/home_sidebar.yml
@@ -93,6 +93,8 @@ entries:
         url: /policies_repostructure.html
       - title: Repository branching
         url: /policies_repobranching.html
+      - title: Pipelines
+        url: /policies_pipelines.html
       - title: Review Process
         url: /policies_reviewprocess.html
       - title: Releases

--- a/_data/sidebars/ios_sidebar.yml
+++ b/_data/sidebars/ios_sidebar.yml
@@ -23,6 +23,8 @@ entries:
         url: /policies_repostructure.html
       - title: Repository branching
         url: /policies_repobranching.html
+      - title: Pipelines
+        url: /policies_pipelines.html
       - title: Review Process
         url: /policies_reviewprocess.html
       - title: Releases

--- a/_data/sidebars/java_sidebar.yml
+++ b/_data/sidebars/java_sidebar.yml
@@ -41,6 +41,8 @@ entries:
         url: /policies_repostructure.html
       - title: Repository branching
         url: /policies_repobranching.html
+      - title: Pipelines
+        url: /policies_pipelines.html
       - title: Review Process
         url: /policies_reviewprocess.html
       - title: Releases

--- a/_data/sidebars/js_sidebar.yml
+++ b/_data/sidebars/js_sidebar.yml
@@ -39,6 +39,8 @@ entries:
         url: /policies_repostructure.html
       - title: Repository branching
         url: /policies_repobranching.html
+      - title: Pipelines
+        url: /policies_pipelines.html
       - title: Review Process
         url: /policies_reviewprocess.html
       - title: Releases

--- a/_data/sidebars/python_sidebar.yml
+++ b/_data/sidebars/python_sidebar.yml
@@ -39,6 +39,8 @@ entries:
         url: /policies_repostructure.html
       - title: Repository branching
         url: /policies_repobranching.html
+      - title: Pipelines
+        url: /policies_pipelines.html
       - title: Review Process
         url: /policies_reviewprocess.html
       - title: Releases

--- a/docs/policies/pipelines.md
+++ b/docs/policies/pipelines.md
@@ -20,9 +20,3 @@ Creation of the pipeline within Azure Pipelines is automated. When a ```ci.yml``
 In general each pipeline that ships a library (or set of libraries) to customers should be optimized to perform necessary build, test and static analysis steps for just that set of libraries. Where it is desirable to run analysis across the entire repository, these tasks should be pulled out into special case pipelines.
 
 The reason for this is that we don't want a static analysis failure in one part of the code base blocking the release of an unrelated library. Additionally, repo-wide analysis steps generally take a long time and it is inappropriate to bog down the pipelines for this activity.
-
-# Ship Readiness and Dependency Management
-
-Our aim is to keep the state of the ```master``` branch in a constantly shippable state. This means that as much as possible internal dependencies between different parts of the SDK should be "binary dependencies" where the dependency is sourced from a public registry. Source dependencies across ```sdk/[service]``` folders should be avoided if possible.
-
-This also helps avoid taking dependencies on unreleased APIs which can block release if not detected early.

--- a/docs/policies/pipelines.md
+++ b/docs/policies/pipelines.md
@@ -1,0 +1,28 @@
+---
+title: "Policies: Pipelines"
+permalink: policies_pipelines.html
+folder: policies
+sidebar: general_sidebar
+---
+
+Whilst the Azure SDK is considered a unified set of libraries, each group of libraries ships on a seperate cadence with varying levels of change as dictated by the needs of the service that those libraries support.
+
+# Pipeline per "Service"
+
+Our pipelines are derived by the way that we ship our libraries to customers. For example we would generally expect to ship some or all of the storage libraries together, so there is a set of pipelines for PR validation, CI and release which operate on code located in the ```sdk/storage/``` path within the repo.
+
+This means that for each language/runtime mono-repo we have multiple pipelines, with each pipeline focused on building and releasing those packages. The entry point to each pipeline is located at ```sdk/[service]/ci.yml``` which defines any custom variables and selects appropriate templates for that pipeline.
+
+Creation of the pipeline within Azure Pipelines is automated. When a ```ci.yml``` file is added to the repository, an automated process runs (every hour, unless manually triggered) which creates a public and internal pipeline.
+
+# Pipeline Optimization and Special Case Pipelines
+
+In general each pipeline that ships a library (or set of libraries) to customers should be optimized to perform necessary build, test and static analysis steps for just that set of libraries. Where it is desirable to run analysis across the entire repository, these tasks should be pulled out into special case pipelines.
+
+The reason for this is that we don't want a static analysis failure in one part of the code base blocking the release of an unrelated library. Additionally, repo-wide analysis steps generally take a long time and it is inappropriate to bog down the pipelines for this activity.
+
+# Ship Readiness and Dependency Management
+
+Our aim is to keep the state of the ```master``` branch in a constantly shippable state. This means that as much as possible internal dependencies between different parts of the SDK should be "binary dependencies" where the dependency is sourced from a public registry. Source dependencies across ```sdk/[service]``` folders should be avoided if possible.
+
+This also helps avoid taking dependencies on unreleased APIs which can block release if not detected early.


### PR DESCRIPTION
This PR adds some notes about our pipeline structure. One thing that it calls out specifically is some guidance around what should be in and what should be out of the pipelines. Mostly inspired by lessons learned about having repo-wide analysis steps.