### PR TITLE
[Package Versions] Updating Event Hubs GA Packages

### DIFF
--- a/_data/releases/latest/dotnet-packages.csv
+++ b/_data/releases/latest/dotnet-packages.csv
@@ -1,16 +1,16 @@
-"Service","Package","Version","RepoPath","MissingDocs"
-"App Configuration","Azure.Data.AppConfiguration","1.0.0","appconfiguration","False"
-"Core","Azure.Core","1.0.1","core","False"
-"Event Hubs","Azure.Messaging.EventHubs","5.0.0-preview.6","eventhub","False"
-"Event Hubs - Processor","Azure.Messaging.EventHubs.Processor","5.0.0-preview.6","eventhub","False"
-"Identity","Azure.Identity","1.1.0","identity","False"
-"Key Vault - Certificates","Azure.Security.KeyVault.Certificates","4.0.0","keyvault","False"
-"Key Vault - Keys","Azure.Security.KeyVault.Keys","4.0.1","keyvault","False"
-"Key Vault - Secrets","Azure.Security.KeyVault.Secrets","4.0.1","keyvault","False"
-"Storage - Blobs","Azure.Storage.Blobs","12.2.0","storage","False"
-"Storage - Blobs Batch","Azure.Storage.Blobs.Batch","12.1.1","storage","False"
-"Storage - Common","Azure.Storage.Common","12.1.1","storage","False"
-"Storage - DataLake","Azure.Storage.Files.DataLake","12.0.0-preview.8","storage","False"
-"Storage - File Shares","Azure.Storage.Files.Shares","12.0.1","storage","False"
-"Storage - Queues","Azure.Storage.Queues","12.1.1","storage","False"
-"Text Analytics","Azure.AI.TextAnalytics","1.0.0-preview.1","textanalytics","False"
+Service,Package,Version,RepoPath,MissingDocs
+App Configuration,Azure.Data.AppConfiguration,1.0.0,appconfiguration,FALSE
+Core,Azure.Core,1.0.1,core,FALSE
+Event Hubs,Azure.Messaging.EventHubs,5.0.1,eventhub,FALSE
+Event Hubs - Processor,Azure.Messaging.EventHubs.Processor,5.0.1,eventhub,FALSE
+Identity,Azure.Identity,1.1.0,identity,FALSE
+Key Vault - Certificates,Azure.Security.KeyVault.Certificates,4.0.0,keyvault,FALSE
+Key Vault - Keys,Azure.Security.KeyVault.Keys,4.0.1,keyvault,FALSE
+Key Vault - Secrets,Azure.Security.KeyVault.Secrets,4.0.1,keyvault,FALSE
+Storage - Blobs,Azure.Storage.Blobs,12.2.0,storage,FALSE
+Storage - Blobs Batch,Azure.Storage.Blobs.Batch,12.1.1,storage,FALSE
+Storage - Common,Azure.Storage.Common,12.1.1,storage,FALSE
+Storage - DataLake,Azure.Storage.Files.DataLake,12.0.0-preview.8,storage,FALSE
+Storage - File Shares,Azure.Storage.Files.Shares,12.0.1,storage,FALSE
+Storage - Queues,Azure.Storage.Queues,12.1.1,storage,FALSE
+Text Analytics,Azure.AI.TextAnalytics,1.0.0-preview.1,textanalytics,FALSE


### PR DESCRIPTION
# Summary

The purpose of these changes is to update the version numbers for the Event Hubs packages post-GA release.

# Last Upstream Rebase

Monday, February 3,  3:55pm (EST)