### PR TITLE
(#1043) Updates to guidelines from arch.board meeting

### DIFF
--- a/docs/general/design.md
+++ b/docs/general/design.md
@@ -87,11 +87,11 @@ The purposes of the client library is to communicate with an Azure service.  Azu
 
 {% include requirement/MUST id="general-service-apiversion-1" %} only target generally available service API versions when releasing a GA version of the client library.
 
-{% include requirement/MUST id="general-service-apiversion-2" %} target the latest generally available service API version by default.
+{% include requirement/MUST id="general-service-apiversion-2" %} target the latest generally available service API version by default in GA versions of the client library.
 
 {% include requirement/MUST id="general-service-apiversion-5" %} document the service API version that is used by default.
 
-{% include requirement/MUST id="general-service-apiversion-3" %} target the latest public preview API version when releasing a public preview version of the client library.
+{% include requirement/MUST id="general-service-apiversion-3" %} target the latest public preview API version by default when releasing a public preview version of the client library.
 
 {% include requirement/MUST id="general-service-apiversion-4" %} include all service API versions that are supported by the client library in a `ServiceVersion` enumerated value.
 

--- a/docs/general/design.md
+++ b/docs/general/design.md
@@ -81,6 +81,24 @@ The following are standard verb prefixes.  You should have a good (articulated) 
 
 {% include requirement/MUST id="general-client-feature-support" %} support 100% of the features provided by the Azure service the client library represents. Gaps in functionality cause confusion and frustration among developers.
 
+## Service API versions
+
+The purposes of the client library is to communicate with an Azure service.  Azure services support multiple API versions.  To understand the capabilities of the service, the client library must be able to support multiple service API versions.
+
+{% include requirement/MUST id="general-service-apiversion-1" %} only target generally available service API versions when releasing a GA version of the client library.
+
+{% include requirement/MUST id="general-service-apiversion-2" %} target the latest generally available service API version by default.
+
+{% include requirement/MUST id="general-service-apiversion-5" %} document the service API version that is used by default.
+
+{% include requirement/MUST id="general-service-apiversion-3" %} target the latest public preview API version when releasing a public preview version of the client library.
+
+{% include requirement/MUST id="general-service-apiversion-4" %} include all service API versions that are supported by the client library in a `ServiceVersion` enumerated value.
+
+{% include requirement/MUST id="general-service-apiversion-6" %} ensure that the values of the `ServiceVersion` enumerated value "match" the version strings in the service Swagger definition.  
+
+For the purposes of this requirement, semantic changes are allowed.  For instance, many version strings are based on SemVer, which allows dots and dashes.  However, these characters are not allowed in identifiers.  The developer **MUST** be able to clearly understand what service API version will be used when the service version is set to each value in the `ServiceVersion` enumerated value.
+
 ## Model types
 
 Client libraries represent entities transferred to and from Azure services as model types.   Certain types are used for round-trips to the service.  They can be sent to the service (as an addition or update operation) and retrieved from the service (as a get operation).  These should be named according to the type.  For example, a `ConfigurationSetting` in App Configuration, or an `Event` on Event Grid.

--- a/docs/general/implementation.md
+++ b/docs/general/implementation.md
@@ -247,7 +247,7 @@ Software testing provides developers a safety net. Investing in tests upfront sa
 
 {% include requirement/MUST id="general-testing-7" %} write tests that use a mock service implementation, with a set of recorded tests per service version supported by the client library. This ensures that the service client continues to properly consume service responses as APIs and implementations evolve. Recorded tests must be run using the language-appropriate trigger to enable the specific service version support in the client library.
 
-{% include requirement/MUST id="general-testing-8" %} recreate recorded tests for a specific service version when notified by the service team of any changes to the endpoint APIs for that service version. In the absence of this notification, recordings should not be updated needlessly. When the service team requires recorded tests to be recreated, or when a recorded test begins to fail unexpectedly, notify the architecture board before recreating the tests.
+{% include requirement/MUST id="general-testing-8" %} recreate recorded tests for latest service version when notified by the service team of any changes to the endpoint APIs for that service version. In the absence of this notification, recordings should not be updated needlessly. When the service team requires recorded tests to be recreated, or when a recorded test begins to fail unexpectedly, notify the architecture board before recreating the tests.
 
 {% include requirement/MUST id="general-testing-9" %} enable all network-mocked tests to also connect to live Azure service. The test assertions should remain unchanged regardless of whether the service call is mocked or not.
 


### PR DESCRIPTION
From the arch board notes:

**ACTION**: Add the following requirements to general guidelines
* GA libraries MUST target GA service API versions.
* LATEST in GA library MUST point to the latest GA service API version.
* Public preview versions of the library MUST point to latest public preview service API version.
* Client libraries MUST include all versions of the service API that the client library supports in a ServiceVersion enum.
* Client libraries MUST document what "latest service API version" points to.
*ServiceVersion enum values MUST match the service version in swagger.

**ACTION**: Update the Recorded tests section as follows:
* Replace "DO recreate recorded tests for a specific service version" with "DO create recorded tests for the latest service version"