### PR TITLE
update the testing guidelines.

### DIFF
--- a/docs/clang/design.md
+++ b/docs/clang/design.md
@@ -703,8 +703,6 @@ do so using user-overridable functions.
 
 {% include requirement/SHOULDNOT id="clang-no-ms-secure-functions" %} use [Microsoft security enhanced versions of CRT functions](https://docs.microsoft.com/cpp/c-runtime-library/security-enhanced-versions-of-crt-functions) to implement APIs that need to be portable across many platforms. Such code is not portable and is not C99 compatible. Adding that code to your API will complicate the implementation with little to no gain from the security side. See [arguments against]( http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1967.htm). 
 
-> TODO: Verify with the security team, and what are the alternatives?
-
 ## Object model
 
 C doesn't have object oriented programming built in, but most programs end up implementing some kind of ad-hoc object model. 

--- a/docs/clang/implementation.md
+++ b/docs/clang/implementation.md
@@ -260,7 +260,7 @@ We believe testing is a part of the development process, so we expect unit and i
 
 All code should contain, at least, requirements, unit tests, end-to-end tests, and samples. The requirements description should be placed in the unit test file, on top of the test function that verifies the requirement. The unit test name should be placed in the code as a comment, together with the code that implements that functionality. For example:
 
-In general, each group of tests will be in it's own file and implement a function like `int test_<group_name>()` that will call cmocka_run_group_tests_name for all the tests in that group. The client library will have
+In general, each group of tests will be in it's own file and implement a function like `int test_<group_name>()` that will call `cmocka_run_group_tests_name` for all the tests in that group. The client library will have
 one main testing file that contains the test entry point (`int main()`).
 
 _*API source code file:*_


### PR DESCRIPTION
a lot of this is renames to make the testing examples reflect the rest of the guidelines. Also moved tests to cmocka (as agreed to by the native and iot teams) and added examples of how to deal with "test groups" and multiple test files. I also removed the whole section about testing each "requirement", since at this point we don't have explicit requirements, instead enforcing good test coverage through code review.

Sidenote: I don't really love the current testing example because it's testing a negative ("destroying a null handle doesn't do anything") which is not really something testable.