### PR TITLE
linuxmint.com often times out so ignore checking it

### DIFF
--- a/eng/ci.yml
+++ b/eng/ci.yml
@@ -36,6 +36,7 @@ steps:
     --no-follow-url "https://azure.github.io/azure-sdk-for-*"
     --no-follow-url "https://azure.github.io/azure-cosmos-*"
     --ignore-url "https://github.com/Azure/azure-sdk-pr"
+    --ignore-url "https://www.linuxmint.com/download_all.php"
   displayName: 'azure-sdk link check'
   continueOnError: true
 

--- a/eng/githubio-linkcheck.yml
+++ b/eng/githubio-linkcheck.yml
@@ -15,6 +15,7 @@ steps:
     --no-follow-url "https://azure.github.io/azure-sdk-for-*"
     --no-follow-url "https://azure.github.io/azure-cosmos-*"
     --ignore-url "https://github.com/Azure/azure-sdk-pr"
+    --ignore-url "https://www.linuxmint.com/download_all.php"
   displayName: 'azure-sdk link check'
   continueOnError: true
 


### PR DESCRIPTION
Added --ignore-url "https://www.linuxmint.com/download_all.php"
to help with the reliability of our linkchecking task as it seems
to timeout often.