### PR TITLE
Update link to post

### DIFF
--- a/_posts/2020-03-31-aspnet-core-integration.md
+++ b/_posts/2020-03-31-aspnet-core-integration.md
@@ -15,7 +15,7 @@ The advice comes down to three best practices:
 
 1. Centrally configure services during app startup.
 2. Store your configuration separately from code.
-3. Use the [`DefaultAzureCredential`]({% post_url 2020-02-25-defaultazurecredentials %}).
+3. Use the [`DefaultAzureCredential`](https://azure.github.io/azure-sdk/posts/2020-02-25/defaultazurecredentials.html).
 
 Let's take each of these in turn.
 


### PR DESCRIPTION
cc @adrianhall @pakrym 

For whatever reason this link doesn't correctly resolve in the live site. It resolves to https://azure.github.io/posts/2020-02-25/defaultazurecredentials.html instead of https://azure.github.io/azure-sdk/posts/2020-02-25/defaultazurecredentials.html so I'm just going to put the full link. 

