### PR TITLE
[April Release Notes] Event Hubs Client

### DIFF
--- a/releases/2020-04/dotnet.md
+++ b/releases/2020-04/dotnet.md
@@ -17,6 +17,7 @@ The Azure SDK team is pleased to announce our April 2020 client library releases
 
 #### Preview
 
+- Event Hubs
 - Service Bus
 - Text Analytics
 
@@ -42,15 +43,25 @@ Detailed changelogs are linked from the [Quick Links](#quick-links) below. Here 
 - Response trace messages are properly identified.
 - Content type "application/x-www-form-urlencoded" is decoded in trace messages.
 
+### Event Hubs [Changelog](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md)
+
+- A new primitive, `EventProcessor<TPartition>`, has been implemented to serve as an extensibility point for creating a custom event processor instance.  More detail can be found in the [design proposal](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/design/event-processor%7BT%7D-proposal.md).
+
+- A new primitive, `PartitionProcessor`, has been implemented to serve as a low-level means of reading batches of events from a single partition with greater control over network configuration.  More detail can be found in the [design proposal](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/design/partition-receiver-proposal.md).
+
+### Event Hubs Processor [Changelog](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md)
+
+- The `EventProcessorClient` has been enhanced to derive from the new `EventProcessor<TPartition>` primitive, brining improvements to stability, resilience, and performance.
+
+### Service Bus [Changelog](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md)
+
+- Initial preview of the Azure.Messaging.ServiceBus library enabling you to send/receive/settle messages from queues/topics and session support.
+
 ### Text Analytics [Changelog](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/textanalytics/Azure.AI.TextAnalytics/CHANGELOG.md#100-preview4-2020-04-07)
 
 - Remove the `RecognizePiiEntities` endpoint and all related models.
 - Add mock support for the Text Analytics client with respective samples.
 - Add integration for ASP.NET Core.
-
-### Service Bus [Changelog](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Azure.Messaging.ServiceBus/CHANGELOG.md)
-
-- Initial preview of the Azure.Messaging.ServiceBus library enabling you to send/receive/settle messages from queues/topics and session support.
 
 ## Latest Releases
 


### PR DESCRIPTION
# Summary

The focus of these changes is to update the April milestone release notes with the Event Hubs details.

# Last Upstream Rebase

Friday, April 3, 4:12pm (EDT)

