### PR TITLE
Add all packages page and refactor

### DIFF
--- a/_includes/releases/all/dotnet.md
+++ b/_includes/releases/all/dotnet.md
@@ -1,0 +1,13 @@
+{% if page.header %}
+{% include releases/header.md %}
+{% endif %}
+
+## .NET
+
+{% assign packages = site.data.allpackages.dotnet-packages %}
+
+There are {{ packages.size }} total Azure library packages published to nuget from the [azure-sdk account](https://www.nuget.org/profiles/azure-sdk).
+
+[New Libraries]({% link releases/latest/dotnet.md %}) | **All Libraries**
+
+{% include dotnet-allpackages.html %}

--- a/_includes/releases/all/java.md
+++ b/_includes/releases/all/java.md
@@ -1,0 +1,13 @@
+{% if page.header %}
+{% include releases/header.md %}
+{% endif %}
+
+## Java
+
+{% assign packages = site.data.allpackages.java-packages %}
+
+There are {{ packages.size }} total Azure library packages published to maven central from the [azure-sdk account](https://search.maven.org/search?q=g:com.microsoft.azure%20OR%20g:com.azure).
+
+[New Libraries]({% link releases/latest/java.md %}) | **All Libraries**
+
+{% include java-allpackages.html %}

--- a/_includes/releases/all/js.md
+++ b/_includes/releases/all/js.md
@@ -1,0 +1,13 @@
+{% if page.header %}
+{% include releases/header.md %}
+{% endif %}
+
+## JavaScript
+
+{% assign packages = site.data.allpackages.js-packages %}
+
+There are {{ packages.size }} total Azure library packages published to npm from the [azure-sdk account](https://www.npmjs.com/~azure-sdk).
+
+[New Libraries]({% link releases/latest/js.md %}) | **All Libraries**
+
+{% include js-allpackages.html %}

--- a/_includes/releases/all/python.md
+++ b/_includes/releases/all/python.md
@@ -1,0 +1,13 @@
+{% if page.header %}
+{% include releases/header.md %}
+{% endif %}
+
+## Python
+
+{% assign packages = site.data.allpackages.python-packages %}
+
+There are {{ packages.size }} total Azure library packages published to npm from the [azure-sdk account](https://pypi.org/user/azure-sdk/).
+
+[New Libraries]({% link releases/latest/python.md %}) | **All Libraries**
+
+{% include python-allpackages.html %}

--- a/_includes/releases/dotnet.md
+++ b/_includes/releases/dotnet.md
@@ -1,0 +1,11 @@
+{% if page.header %}
+{% include releases/header.md %}
+{% endif %}
+
+## .NET
+
+{% assign packages = site.data.releases.latest.dotnet-packages %}
+
+**New Libraries** | [All Libraries]({% link releases/latest/all/dotnet.md %})
+
+{% include dotnet-packages.html %}

--- a/_includes/releases/header.md
+++ b/_includes/releases/header.md
@@ -1,0 +1,1 @@
+# Azure SDK Latest Releases

--- a/_includes/releases/java.md
+++ b/_includes/releases/java.md
@@ -1,0 +1,11 @@
+{% if page.header %}
+{% include releases/header.md %}
+{% endif %}
+
+## Java
+
+{% assign packages = site.data.releases.latest.java-packages %}
+
+**New Libraries** | [All Libraries]({% link releases/latest/all/java.md %})
+
+{% include java-packages.html %}

--- a/_includes/releases/js.md
+++ b/_includes/releases/js.md
@@ -1,0 +1,11 @@
+{% if page.header %}
+{% include releases/header.md %}
+{% endif %}
+
+## JavaScript
+
+{% assign packages = site.data.releases.latest.js-packages %}
+
+**New Libraries** | [All Libraries]({% link releases/latest/all/js.md %})
+
+{% include js-packages.html %}

--- a/_includes/releases/python.md
+++ b/_includes/releases/python.md
@@ -1,0 +1,11 @@
+{% if page.header %}
+{% include releases/header.md %}
+{% endif %}
+
+## Python
+
+{% assign packages = site.data.releases.latest.python-packages %}
+
+**New Libraries** | [All Libraries]({% link releases/latest/all/python.md %})
+
+{% include python-packages.html %}

--- a/releases/latest/all/dotnet.md
+++ b/releases/latest/all/dotnet.md
@@ -3,15 +3,6 @@ title: Azure SDK for .NET (Latest)
 layout: default
 tags: dotnet
 sidebar: releases_sidebar
+header: true
 ---
-# .NET Packages
-
-{% assign packages = site.data.allpackages.dotnet-packages %}
-
-There are {{ packages.size }} total Azure library packages published to nuget from the [azure-sdk account](https://www.nuget.org/profiles/azure-sdk).
-
-[New Libraries](../dotnet.md) | All Libraries
-
-{% include dotnet-allpackages.html %}
-
-{% include refs.md %}
+{% include releases/all/dotnet.md %}

--- a/releases/latest/all/index.md
+++ b/releases/latest/all/index.md
@@ -1,0 +1,12 @@
+---
+title: Azure SDK Latest Releases
+layout: default
+sidebar: releases_sidebar
+permalink: /releases/latest/all/index.html
+---
+{% include releases/header.md %}
+{% include releases/all/dotnet.md %}
+{% include releases/all/java.md %}
+{% include releases/all/js.md %}
+{% include releases/all/python.md %}
+{% include refs.md %}

--- a/releases/latest/all/java.md
+++ b/releases/latest/all/java.md
@@ -3,16 +3,7 @@ title: Azure SDK for Java (Latest)
 layout: default
 tags: java
 sidebar: releases_sidebar
+header: true
 ---
-
-# Java Packages
-
-{% assign packages = site.data.allpackages.java-packages %}
-
-There are {{ packages.size }} total Azure library packages published to maven central from the [azure-sdk account](https://search.maven.org/search?q=g:com.microsoft.azure%20OR%20g:com.azure).
-
-[New Libraries](../java.md) | All Libraries
-
-{% include java-allpackages.html %}
-
+{% include releases/all/java.md %}
 {% include refs.md %}

--- a/releases/latest/all/js.md
+++ b/releases/latest/all/js.md
@@ -3,16 +3,7 @@ title: Azure SDK for JavaScript (Latest)
 layout: default
 tags: javascript typescript
 sidebar: releases_sidebar
+header: true
 ---
-
-# JavaScript Packages
-
-{% assign packages = site.data.allpackages.js-packages %}
-
-There are {{ packages.size }} total Azure library packages published to npm from the [azure-sdk account](https://www.npmjs.com/~azure-sdk).
-
-[New Libraries](../js.md) | All Libraries
-
-{% include js-allpackages.html %}
-
+{% include releases/all/js.md %}
 {% include refs.md %}

--- a/releases/latest/all/python.md
+++ b/releases/latest/all/python.md
@@ -3,16 +3,7 @@ title: Azure SDK for Python (Latest)
 layout: default
 tags: python
 sidebar: releases_sidebar
+header: true
 ---
-
-# Python Packages
-
-{% assign packages = site.data.allpackages.python-packages %}
-
-There are {{ packages.size }} total Azure library packages published to npm from the [azure-sdk account](https://pypi.org/user/azure-sdk/).
-
-[New Libraries](../python.md) | All Libraries
-
-{% include python-allpackages.html %}
-
+{% include releases/all/python.md %}
 {% include refs.md %}

--- a/releases/latest/dotnet.md
+++ b/releases/latest/dotnet.md
@@ -3,13 +3,7 @@ title: Azure SDK for .NET (Latest)
 layout: default
 tags: dotnet
 sidebar: releases_sidebar
+header: true
 ---
-# .NET Packages
-
-{% assign packages = site.data.releases.latest.dotnet-packages %}
-
-New Libraries | [All Libraries](all/dotnet.md)
-
-{% include dotnet-packages.html %}
-
+{% include releases/dotnet.md %}
 {% include refs.md %}

--- a/releases/latest/index.md
+++ b/releases/latest/index.md
@@ -4,37 +4,9 @@ layout: default
 sidebar: releases_sidebar
 permalink: /releases/latest/index.html
 ---
-
-# Azure SDK Latest Releases
-
-## .NET packages
-
-{% assign packages = site.data.releases.latest.dotnet-packages %}
-
-[New Libraries](dotnet.md) | [All Libraries](all/dotnet.md)
-
-{% include dotnet-packages.html %}
-
-## Java packages
-
-{% assign packages = site.data.releases.latest.java-packages %}
-
-[New Libraries](java.md) | [All Libraries](all/java.md)
-
-{% include java-packages.html %}
-
-## JavaScript packages
-
-{% assign packages = site.data.releases.latest.js-packages %}
-
-[New Libraries](js.md) | [All Libraries](all/js.md)
-
-{% include js-packages.html %}
-
-## Python packages
-
-{% assign packages = site.data.releases.latest.python-packages %}
-
-[New Libraries](python.md) | [All Libraries](all/python.md)
-
-{% include python-packages.html %}
+{% include releases/header.md %}
+{% include releases/dotnet.md %}
+{% include releases/java.md %}
+{% include releases/js.md %}
+{% include releases/python.md %}
+{% include refs.md %}

--- a/releases/latest/java.md
+++ b/releases/latest/java.md
@@ -3,14 +3,7 @@ title: Azure SDK for Java (Latest)
 layout: default
 tags: java
 sidebar: releases_sidebar
+header: true
 ---
-
-# Java Packages
-
-{% assign packages = site.data.releases.latest.java-packages %}
-
-New Libraries | [All Libraries](all/java.md)
-
-{% include java-packages.html %}
-
+{% include releases/java.md %}
 {% include refs.md %}

--- a/releases/latest/js.md
+++ b/releases/latest/js.md
@@ -3,14 +3,7 @@ title: Azure SDK for JavaScript (Latest)
 layout: default
 tags: javascript typescript
 sidebar: releases_sidebar
+header: true
 ---
-
-# JavaScript Packages
-
-{% assign packages = site.data.releases.latest.js-packages %}
-
-New Libraries | [All Libraries](all/js.md)
-
-{% include js-packages.html %}
-
+{% include releases/js.md %}
 {% include refs.md %}

--- a/releases/latest/python.md
+++ b/releases/latest/python.md
@@ -3,14 +3,7 @@ title: Azure SDK for Python (Latest)
 layout: default
 tags: python
 sidebar: releases_sidebar
+header: true
 ---
-
-# Python Packages
-
-{% assign packages = site.data.releases.latest.python-packages %}
-
-New Libraries | [All Libraries](all/python.md)
-
-{% include python-packages.html %}
-
+{% include releases/python.md %}
 {% include refs.md %}


### PR DESCRIPTION
1. Added /releases/latest/all page so we can easily link to via aka.ms links (i.e. aka.ms/azsdk#java)
1. Removed "Packages" from header to get simplified language only anchor tags #java instead of #java-packages
1. Refactored to put package lists in include files
1. Added "Azure SDK Latest Releases" to each page to be consistent
1. Changed language headings from # to ## to be consistent across pages