### PR TITLE
[cpp] Remove header guards from acceptable uses of macros 

### DIFF
--- a/docs/cpp/design.md
+++ b/docs/cpp/design.md
@@ -222,7 +222,6 @@ namespace Details {
 {% include requirement/SHOULD id="cpp-design-naming-macros-avoid" %} avoid use of macros. It is acceptable to use macros in the following situations. Use outside of these situations should contact the Azure Review Board.
 
 * Platform, compiler, or other environment detection (for example, `_WIN32` or `_MSC_VER`).
-* Header guards.
 * Emission or suppression of diagnostics.
 * Emission or supression of debugging asserts.
 * Import declarations. (`__declspec(dllimport)`, `__declspec(dllexport)`)


### PR DESCRIPTION
…following 2020-04-09 affirmation of always using pragma once.