### PR TITLE
Add authority host to list of environment variables

### DIFF
--- a/_includes/tables/environment_variables.md
+++ b/_includes/tables/environment_variables.md
@@ -13,6 +13,7 @@
 | AZURE_CLIENT_ID               | Azure Active Directory                 |
 | AZURE_CLIENT_SECRET           | Azure Active Directory                 |
 | AZURE_TENANT_ID               | Azure Active Directory                 |
+| AZURE_AUTHORITY_HOST          | Azure Active Directory                 |
 | **Pipeline Configuration**                                            ||
 | AZURE_TELEMETRY_DISABLED      | Disables telemetry                     |
 | AZURE_LOG_LEVEL               | Enable logging by setting a log level. |


### PR DESCRIPTION
All SDKs now support the AZURE_AUTHORITY_HOST environment variable, which allows developers to override the default 'https://login.microsoftonline.com' value with an endpoint appropriate for their environment.