### PR TITLE
Ban Const members of structs

### DIFF
--- a/_includes/tables/environment_variables.md
+++ b/_includes/tables/environment_variables.md
@@ -13,6 +13,7 @@
 | AZURE_CLIENT_ID               | Azure Active Directory                 |
 | AZURE_CLIENT_SECRET           | Azure Active Directory                 |
 | AZURE_TENANT_ID               | Azure Active Directory                 |
+| AZURE_AUTHORITY_HOST          | Azure Active Directory                 |
 | **Pipeline Configuration**                                            ||
 | AZURE_TELEMETRY_DISABLED      | Disables telemetry                     |
 | AZURE_LOG_LEVEL               | Enable logging by setting a log level. |

--- a/docs/clang/design.md
+++ b/docs/clang/design.md
@@ -147,7 +147,7 @@ The reason to avoid such members is that it makes it impossible to ever _reassig
 ```c
 typedef struct az_iot_client {
     int retry_timeout;
-    char const *const api_version;
+    char const* const api_version;
 };
 
 az_iot_client az_iot_create_client() {

--- a/docs/clang/design.md
+++ b/docs/clang/design.md
@@ -127,6 +127,21 @@ typedef struct az_iot_client {
 } az_iot_client;
 {% endhighlight %}
 
+{% include requirement/MUSTNOT id="clang-design-naming-struct-no-const %} declare const fields within structs. Pointers to const are fine, however. For example:
+```c
+// bad
+typedef struct az_iot_client {
+    const int retry_timeout;
+    char * const api_version;
+} az_iot_client;
+
+// good
+typedef struct az_iot_client {
+    int retry_timeout;
+    char const * api_version;
+} az_iot_client;
+```
+
 ### Enums
 
 {% include requirement/MUST id="clang-design-naming-enum" %} use snake-casing to name enum types, and include the az_<svcname>_<shortenumname> prefix.

--- a/docs/clang/design.md
+++ b/docs/clang/design.md
@@ -132,7 +132,7 @@ typedef struct az_iot_client {
 // bad
 typedef struct az_iot_client {
     const int retry_timeout;
-    char * const api_version;
+    char* const api_version;
 } az_iot_client;
 
 // good

--- a/docs/clang/design.md
+++ b/docs/clang/design.md
@@ -163,7 +163,6 @@ int main(void) {
     // done, need to connect to some other service endpoint
     client = az_iot_create_client(); // <--- does not compile
     // do things with the other client
-
 }
 
 ```

--- a/docs/clang/design.md
+++ b/docs/clang/design.md
@@ -142,6 +142,32 @@ typedef struct az_iot_client {
 } az_iot_client;
 ```
 
+The reason to avoid such members is that it makes it impossible to ever _reassign_ a variable of the struct type. For example:
+
+```c
+typedef struct az_iot_client {
+    int retry_timeout;
+    char const *const api_version;
+};
+
+az_iot_client az_iot_create_client() {
+    az_iot_client result = {4, "some version"};
+    return result;
+}
+
+void az_iot_client_do_operation(az_iot_client const * client);
+
+int main(void) {
+    az_iot_client client = az_iot_create_client();
+    az_iot_client_do_operation(&client);
+    // done, need to connect to some other service endpoint
+    client = az_iot_create_client(); // <--- does not compile
+    // do things with the other client
+
+}
+
+```
+
 ### Enums
 
 {% include requirement/MUST id="clang-design-naming-enum" %} use snake-casing to name enum types, and include the az_<svcname>_<shortenumname> prefix.


### PR DESCRIPTION
Const members in structs make initialization much harder, and don't offer much in the way of added safety. Issues with them have come up multiple times during development.