### PR TITLE
Update client parameter validation requirements

### DIFF
--- a/docs/general/implementation.md
+++ b/docs/general/implementation.md
@@ -59,7 +59,7 @@ where _ServiceName_ is the canonical shortname without spaces, and _Configuratio
 
 The service client will have several methods that perform requests on the service.  _Service parameters_ are directly passed across the wire to an Azure service.  _Client parameters_ are not passed directly to the service, but used within the client library to fulfill the request.  Examples of client parameters include values that are used to construct a URI, or a file that needs to be uploaded to storage.
 
-{% include requirement/MUST id="general-params-client-validation" %} validate client parameters.
+{% include requirement/MUST id="general-params-client-validation" %} validate client parameters.  This includes checks for null values for required path parameters, and checks for empty string values if a required path parameter declares a `minLength` greater than zero.
 
 {% include requirement/MUSTNOT id="general-params-server-validation" %} validate service parameters.  This includes null checks, empty strings, and other common validating conditions. Let the service validate any request parameters.
 


### PR DESCRIPTION
Resolves #1199

As called out in the bug, there are demonstrated cases where not validating null or empty path parameters can result in a request for a different resource(s) which can result in a confusing deserialization error or, at worst, deletion of other or more resources than desired.