### PR TITLE
Allow link checker to open other file types

### DIFF
--- a/eng/scripts/Verify-Links.ps1
+++ b/eng/scripts/Verify-Links.ps1
@@ -142,7 +142,8 @@ function GetLinks([System.Uri]$pageUri)
         $content = Get-Content ($file + "index.html")
       }
       else {
-        Write-Error "Don't know how to process file $pageUri"
+        # Fallback to just reading the content directly
+        $content = Get-Content $file
       }
     }
   }


### PR DESCRIPTION
If the file exists read the contents even if it
is not a known file extension.