### PR TITLE
Updated Java README for the KeyVault May 2020 release.

### DIFF
--- a/releases/2020-05/java.md
+++ b/releases/2020-05/java.md
@@ -76,7 +76,7 @@ To use the GA and beta libraries, refer to the Maven dependency information belo
 <dependency>
   <groupId>com.azure</groupId>
   <artifactId>azure-security-keyvault-certificates</artifactId>
-  <version>4.0.2</version>
+  <version>4.0.3</version>
 </dependency>
 <dependency>
   <groupId>com.azure</groupId>
@@ -87,7 +87,7 @@ To use the GA and beta libraries, refer to the Maven dependency information belo
 <dependency>
   <groupId>com.azure</groupId>
   <artifactId>azure-security-keyvault-secrets</artifactId>
-  <version>4.1.2</version>
+  <version>4.1.3</version>
 </dependency>
 <dependency>
   <groupId>com.azure</groupId>
@@ -98,7 +98,7 @@ To use the GA and beta libraries, refer to the Maven dependency information belo
 <dependency>
   <groupId>com.azure</groupId>
   <artifactId>azure-security-keyvault-keys</artifactId>
-  <version>4.1.2</version>
+  <version>4.1.3</version>
 </dependency>
 <dependency>
   <groupId>com.azure</groupId>


### PR DESCRIPTION
This month we only updated the azure-core versions and fixed a bug, hence why no changelog section was added.