### PR TITLE
Add automation for generating a new month's release structure

### DIFF
--- a/eng/pipelines/generate-release-structure.yml
+++ b/eng/pipelines/generate-release-structure.yml
@@ -1,0 +1,34 @@
+trigger:
+- master
+
+pool:
+  vmImage: 'windows-2019'
+
+resources:
+  repositories:
+    - repository: azure-sdk-tools
+      type: github
+      name: Azure/azure-sdk-tools
+      endpoint: azure
+
+steps:
+- checkout: self
+- checkout: azure-sdk-tools
+
+- task: PowerShell@2
+  displayName: 'Generate Release Structure'
+  inputs:
+    pwsh: true
+    filePath: $(System.DefaultWorkingDirectory)/azure-sdk/eng/scripts/Generate-Release-Structure.ps1
+    arguments: > 
+      -ReleaseDateString "$(ReleaseDate)"
+
+- template: eng/common/pipelines/templates/steps/create-pull-request.yml@azure-sdk-tools
+  parameters:
+    RepoName: azure-sdk
+    PRBranchName: AddReleaseStructure
+    CommitMsg: "Add new release folder structure"
+    PRTitle: "Add new release folder structure"
+    PushArgs: -f
+    WorkingDirectory: $(System.DefaultWorkingDirectory)/azure-sdk
+    ScriptDirectory: $(System.DefaultWorkingDirectory)/azure-sdk-tools/eng/common/scripts

--- a/eng/scripts/Generate-Release-Structure.ps1
+++ b/eng/scripts/Generate-Release-Structure.ps1
@@ -1,0 +1,75 @@
+param (
+  [string]$releaseDateString = "",
+  [string]$releaseTemplate = "$PSScriptRoot\release-template",
+  [string]$releaseRootFolder = "$PSScriptRoot\..\..\releases"
+)
+
+if ($releaseDateString -eq "") {
+  $releaseDate = [DateTime]::Now
+}
+else {
+  $releaseDate = [DateTime]$releaseDateString
+}
+
+$releaseString = $releaseDate.ToString("yyyy-MM")
+$releaseFolder = Join-Path (Resolve-Path $releaseRootFolder) $releaseString
+$releaseSidebar = Resolve-Path "$PSScriptRoot\..\..\_data\sidebars\releases_sidebar.yml"
+
+if (!(Test-Path $releaseFolder)) {
+  New-Item -Type Directory $releaseFolder | Out-Null
+}
+
+### Copy template files for ones that don't exist
+foreach ($file in (Get-ChildItem $releaseTemplate/*)) {
+  $newFile = Join-Path $releasefolder $file.Name
+  if (Test-Path $newFile) {
+    Write-Host "Skipping $newFile because it already exists"
+  }
+  else {
+    Copy-Item $file $newFile
+  }
+}
+
+### Update template files with date
+foreach ($file in (Get-ChildItem $releaseFolder)) {
+  $fileContent = Get-Content $file
+
+  $fileContent = $fileContent | ForEach-Object {
+    if ($_ -match "%%(?<format>.*?)%%") {
+      try {
+        $_ -replace $matches[0], $releaseDate.ToString($matches["format"]) 
+      }
+      catch {
+        Write-Host ("Date format " + $matches["format"] + " in file $file is invalid.")
+      }
+    } else {
+      $_
+    }
+  }
+  $fileContent | Set-Content $file
+}
+
+### Update release sidebar
+Install-Module -Name powershell-yaml -RequiredVersion 0.4.2 -Force -Scope CurrentUser
+
+$yml = Get-Content $releaseSidebar | ConvertFrom-Yaml -Ordered
+
+$yearGroupName = $releaseDate.ToString("yyyy") + " Releases"
+$yearGroup = $yml.entries.folders | Where-Object { $_.title -eq $yearGroupName }
+
+if (!$yearGroup) {
+  $yearGroup = [ordered]@{ title = "$yearGroupName"; folderitems = @() }
+
+  # insert in spot 1 as spot 0 is reserved for Latest
+  $yml.entries.folders.Insert(1, $yearGroup)
+}
+
+$monthGroupName = $releaseDate.ToString("MMMM")
+$monthGroup = $yearGroup.folderitems | Where-Object { $_.title -eq $monthGroupName }
+
+if (!$monthGroup) {
+  $monthGroup = [ordered]@{ title = $monthGroupName; url = "/releases/$releaseString/index.html" }
+  $yearGroup.folderitems.Insert(0, $monthGroup)
+}
+
+$yml | ConvertTo-Yaml -OutFile $releaseSidebar -Force

--- a/eng/scripts/release-template/dotnet.md
+++ b/eng/scripts/release-template/dotnet.md
@@ -1,13 +1,12 @@
 ---
-title: Azure SDK for .NET (%%MONTH%% %%YEAR%%)
+title: Azure SDK for .NET (%%MMMM yyyy%%)
 layout: post
-date: %%RELEASEDATE%%
 tags: dotnet
 sidebar: releases_sidebar
 repository: azure/azure-sdk-for-net
 ---
 
-The Azure SDK team is pleased to announce our {{ page.date | date: "%B %Y" }} client library releases.
+The Azure SDK team is pleased to announce our %%MMMM yyyy%% client library releases.
 
 #### GA
 

--- a/eng/scripts/release-template/index.md
+++ b/eng/scripts/release-template/index.md
@@ -1,7 +1,6 @@
 ---
-title: Azure SDK (%%MONTH%% %%YEAR%%)
+title: Azure SDK (%%MMMM yyyy%%)
 layout: post
-date: %%RELEASEDATE%%
 tags: release
 sidebar: releases_sidebar
 ---

--- a/eng/scripts/release-template/java.md
+++ b/eng/scripts/release-template/java.md
@@ -1,13 +1,12 @@
 ---
-title: Azure SDK for Java (%%MONTH%% %%YEAR%%)
+title: Azure SDK for Java (%%MMMM yyyy%%)
 layout: post
-date: %%RELEASEDATE%%
 tags: java azure
 sidebar: releases_sidebar
 repository: azure/azure-sdk-for-java
 ---
 
-The Azure SDK team is pleased to announce our {{ page.date | date: "%B %Y" }} client library releases.
+The Azure SDK team is pleased to announce our %%MMMM yyyy%% client library releases.
 
 #### GA
 

--- a/eng/scripts/release-template/js.md
+++ b/eng/scripts/release-template/js.md
@@ -1,13 +1,12 @@
 ---
-title: Azure SDK for JavaScript (%%MONTH%% %%YEAR%%)
+title: Azure SDK for JavaScript (%%MMMM yyyy%%)
 layout: post
-date: %%RELEASEDATE%%
 tags: javascript typescript
 sidebar: releases_sidebar
 repository: azure/azure-sdk-for-js
 ---
 
-The Azure SDK team is pleased to make available the {{ page.date | date: "%B %Y" }} client library release.
+The Azure SDK team is pleased to make available the %%MMMM yyyy%% client library release.
 
 #### GA
 

--- a/eng/scripts/release-template/python.md
+++ b/eng/scripts/release-template/python.md
@@ -1,13 +1,12 @@
 ---
-title: Azure SDK for Python (%%MONTH%% %%YEAR%%)
+title: Azure SDK for Python (%%MMMM yyyy%%)
 layout: post
-date: %%RELEASEDATE%%
 tags: python
 sidebar: releases_sidebar
 repository: azure/azure-sdk-for-python
 ---
 
-The Azure SDK team is pleased to make available the {{ page.date | date: "%B %Y" }} client library release.
+The Azure SDK team is pleased to make available the %%MMMM yyyy%% client library release.
 
 #### GA
 


### PR DESCRIPTION
PTAL @czubair @adrianhall 

This adds some automation for generating a new release folder for the next month. 

Running the [pipeline ](https://dev.azure.com/azure-sdk/internal/_build?definitionId=1745&_a=summary) will generate a PR like https://github.com/Azure/azure-sdk/pull/1375