### PR TITLE
Add basic filtering to the all libaries package index pages

### DIFF
--- a/_includes/releases/all/pkgtable.md
+++ b/_includes/releases/all/pkgtable.md
@@ -4,11 +4,11 @@
   <th>Package</th>
   <th>Notes</th>
 </tr>
-
+<tbody id="myTable">
 {% for item in packages %}
 
 {% include releases/all/pkgrow.md %}
 
 {% endfor %}
-
+</tbody>
 </table>

--- a/_includes/releases/header.md
+++ b/_includes/releases/header.md
@@ -1,1 +1,4 @@
 # Azure SDK Latest Releases
+
+<input class="form-control" id="myInput" type="text" placeholder="Search...">
+<br>

--- a/_includes/releases/pkgtable.md
+++ b/_includes/releases/pkgtable.md
@@ -5,11 +5,11 @@
   <th>Documentation</th>
   <th>Source</th>
 </tr>
-
+<tbody id="myTable">
 {% for item in packages %}
 
 {% include releases/pkgrow.md %}
 
 {% endfor %}
-
+</tbody>
 </table>

--- a/js/customscripts.js
+++ b/js/customscripts.js
@@ -52,3 +52,12 @@ $(function() {
         }
     });
 });
+
+$(document).ready(function(){
+    $("#myInput").on("keyup", function() {
+      var value = $(this).val().toLowerCase();
+      $("#myTable tr").filter(function() {
+        $(this).toggle($(this).text().toLowerCase().indexOf(value) > -1)
+      });
+    });
+  });


### PR DESCRIPTION
PTAL @jongio I only did this for the all package indexes but we could just as easily add it everywhere. 

Here is a sample screenshot of the filtering at work.
![image](https://user-images.githubusercontent.com/9010698/83553540-2df61700-a4c0-11ea-84ad-bc9b639ee615.png)


