### PR TITLE
Add requirement that pipeline policies be public API for consumer reuse.

### DIFF
--- a/docs/java/design.md
+++ b/docs/java/design.md
@@ -1007,5 +1007,27 @@ There are two annotations of note that should be applied on model classes, when 
 
 Breaking changes should happen rarely, if ever.  Register your intent to do a breaking change with [adparch]. You'll need to have a discussion with the language architect before approval.
 
+### Version Numbers {#java-versionnumbers}
+
+Consistent version number scheme allows consumers to determine what to expect from a new version of the library.
+
+{% include requirement/MUST id="java-version-semver" %} use _MAJOR_._MINOR_._PATCH_ format for the library version.
+
+Use `-beta.N` suffix for beta package versions. For example, `1.0.0-beta.2`.
+
+{% include requirement/MUST id="java-version-change-on-release" %} change the version number of the client library when **ANYTHING** changes in the client library.
+
+{% include requirement/MUST id="java-version-patching" %} increment the patch version when fixing a bug.
+
+{% include requirement/MUSTNOT id="java-version-features-in-patch" %} include new APIs in a patch release.
+
+{% include requirement/MUST id="java-version-add-feature" %} increment the major or minor version when adding support for a service API version.
+
+{% include requirement/MUST id="java-version-add-api" %} increment the major or minor version when adding a new method to the public API.
+
+{% include requirement/SHOULD id="java-version-major-changes" %} increment the major version when making large feature changes.
+
+{% include requirement/MUST id="java-version-change-on-release" %} select a version number greater than the highest version number of any other released Track 1 packages for the service.
+
 {% include refs.md %}
 {% include_relative refs.md %}

--- a/docs/java/implementation.md
+++ b/docs/java/implementation.md
@@ -83,7 +83,7 @@ The HTTP pipeline consists of a HTTP transport that is wrapped by multiple polic
 
 {% include requirement/SHOULD id="java-network-azure-core-policies" %} use the policy implementations in Azure Core whenever possible. Do not try to "write your own" policy unless it is doing something unique to your service. If you need another option to an existing policy, engage with the [Architecture Board] to add the option.
 
-{% include requirement/MUST id="java-network-azure-core-policies-public" %} make all custom policies (HTTP or otherwise) available as public API. This enables developers who chose to implement their own pipeline to reuse the policy rather than write it themselves.
+{% include requirement/MUST id="java-network-azure-core-policies-public" %} make all custom policies (HTTP or otherwise) available as public API. This enables developers who choose to implement their own pipeline to reuse the policy rather than write it themselves.
 
 ## Authentication
 

--- a/docs/java/implementation.md
+++ b/docs/java/implementation.md
@@ -67,7 +67,7 @@ The service client will have several methods that perform requests on the servic
 
 Each supported language has an Azure Core library that contains common mechanisms for cross cutting concerns such as configuration and doing HTTP requests.
 
-{% include requirement/MUST id="java-network-use-http-pipeline" %} use the HTTP pipeline component within `com.azure.core` library for communicating to service REST endpoints.
+{% include requirement/MUST id="java-network-use-http-pipeline" %} use the HTTP pipeline component within `azure-core` library for communicating to service REST endpoints.
 
 The HTTP pipeline consists of a HTTP transport that is wrapped by multiple policies. Each policy is a control point during which the pipeline can modify either the request and/or response. We prescribe a default set of policies to standardize how client libraries interact with Azure services. The order in the list is the most sensible order for implementation.
 
@@ -82,6 +82,8 @@ The HTTP pipeline consists of a HTTP transport that is wrapped by multiple polic
 - Logging
 
 {% include requirement/SHOULD id="java-network-azure-core-policies" %} use the policy implementations in Azure Core whenever possible. Do not try to "write your own" policy unless it is doing something unique to your service. If you need another option to an existing policy, engage with the [Architecture Board] to add the option.
+
+{% include requirement/MUST id="java-network-azure-core-policies-public" %} make all custom policies (HTTP or otherwise) available as public API. This enables developers who chose to implement their own pipeline to reuse the policy rather than write it themselves.
 
 ## Authentication
 


### PR DESCRIPTION
 * Updated Java spec to spell out expectation that all pipeline policies be public API to allow for end users to reuse them in other pipelines.
 * Added version numbering guidelines (from C# guidelines).