### PR TITLE
[July Release Notes for .NET] Event Hubs

### DIFF
--- a/releases/2020-07/dotnet.md
+++ b/releases/2020-07/dotnet.md
@@ -18,6 +18,7 @@ The Azure SDK team is pleased to announce our July 2020 client library releases.
 
 #### Preview
 
+- Event Hubs
 - Management Library - Compute
 - Management Library - Network
 - Management Library - Resources
@@ -32,6 +33,9 @@ To install any of our packages, please search for them via `Manage NuGet Package
 
 ```bash
  $> dotnet add package Azure.AI.TextAnalytics 
+ 
+ $> dotnet add package Azure.Messaging.EventHubs --version 5.2.0-preview.1
+ $> dotnet add package Azure.Messaging.EventHubs.Processor --version 5.2.0-preview.1
 
  $> dotnet add package Azure.ResourceManager.Compute --version 1.0.0-preview.1
  $> dotnet add package Azure.ResourceManager.Network --version 1.0.0-preview.1
@@ -42,7 +46,6 @@ To install any of our packages, please search for them via `Manage NuGet Package
  $> dotnet add package Azure.ResourceManager.AppConfiguration --version 1.0.0-preview.1
 ```
 
-
 ## Feedback
 
 If you have a bug or feature request for one of the libraries, please [file an issue in our repo](https://github.com/Azure/azure-sdk-for-net/issues/new/choose).
@@ -50,6 +53,16 @@ If you have a bug or feature request for one of the libraries, please [file an i
 ## Changelog
 
 Detailed changelogs are linked from the [Quick Links](#quick-links) below. Here are some of the highlights:
+
+### Event Hubs [Changelog](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md)
+
+- The `EventHubConsumerClient` now supports configuring the `PrefetchCount` and `CacheEventCount` for more control over performance tuning.
+
+- The `EventProcessor<TPartition>` now supports configuring a `LoadBalancingStrategy` for more control over performance tuning.
+
+### Event Hubs Processor [Changelog](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md)
+
+- The `EventProcessorClient` now supports configuring the `PrefetchCount`, `CacheEventCount`, and `LoadBalancingStrategy` for more control over performance tuning.
 
 ### New Management Libraries
 A new set of management libraries that follow the [Azure SDK Design Guidelines for .NET](https://azure.github.io/azure-sdk/dotnet_introduction.html) and based on [Azure.Core libraries](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/core/Azure.Core) are now in Public Preview. These new libraries provide a number of core capabilities that are shared amongst all Azure SDKs, including the intuitive Azure Identity library, an HTTP Pipeline with custom policies, error-handling, distributed tracing, and much more. You can find the list of new packages [on this page](https://azure.github.io/azure-sdk/releases/latest/dotnet.html).


### PR DESCRIPTION
# Summary

The focus of these changes is to add the Event Hubs details to the July release notes for .NET.

# Last Upstream Rebase

Wednesday, July 1, 5:27pm (EDT)

# References and Related Issues 

- [Review and update documentation (July Milestone)](https://github.com/Azure/azure-sdk-for-net/issues/11746) (#11746)