### PR TITLE
Adding guidance about how to use internal structures on public headers

### DIFF
--- a/docs/clang/implementation.md
+++ b/docs/clang/implementation.md
@@ -376,14 +376,14 @@ typedef struct {
 typedef struct {
       int y; // Public field in a public struct.
       struct {
-            _az_internal_structure nested; // This is OK
+            _az_internal_structure nested; // This is OK.
       } _internal;
 } az_public_struct;
 {% endhighlight %}
 
 On the contrary, the following **cannot** be part of a public header.
 {% highlight c %}
-// Public structure with a nested `_internal` structure
+// Public structure with an internal struct exposed as a public field rather than within a nested `_internal` struct.
 typedef struct {
       int y; // Public field in a public struct.
       _az_internal_structure nested; // This is not OK. Exposing internal field as public.

--- a/docs/clang/implementation.md
+++ b/docs/clang/implementation.md
@@ -361,6 +361,8 @@ the `internal` directory (a sibling of `src` and `inc`).
 
 {% include requirement/MUSTNOT id="clang-style-publicapi-hdr-includes" %} include internal or private headers in public headers.
 
+{% include requirement/MUSTNOT id="clang-style-publicapi-hdr-expose" %} expose internal implementation details (fields, types, or methods) within the public surface area and header files. The following **note** issues one exception to this guidance.
+
 > **Note**: It is allowed for a public header to declare internal structures to be used **only** within another internal structure or API. See example below.
 
 For example, the following **can** be part of a public header.

--- a/docs/clang/implementation.md
+++ b/docs/clang/implementation.md
@@ -361,37 +361,30 @@ the `internal` directory (a sibling of `src` and `inc`).
 
 {% include requirement/MUSTNOT id="clang-style-publicapi-hdr-includes" %} include internal or private headers in public headers.
 
-> **Note**: It is allowed to a public header to declare internal structures to be used **only** within another internal structure/API. See example below.
+> **Note**: It is allowed for a public header to declare internal structures to be used **only** within another internal structure or API. See example below.
 
-Below code **can** be part of a public header.
-
+For example, the following **can** be part of a public header.
 {% highlight c %}
 // internal structure only used by another _internal field
 typedef struct {
       int x;
 } _az_internal_structure;
 
-// Public structure with one internal field `_internal`
+// Public structure with a nested `_internal` structure
 typedef struct {
-      int y;
+      int y; // Public field in a public struct.
       struct {
-            _az_private_struct; // This is OK
+            _az_internal_structure nested; // This is OK
       } _internal;
 } az_public_struct;
 {% endhighlight %}
 
-Below code **can not** be part of a public header.
-
+On the contrary, the following **cannot** be part of a public header.
 {% highlight c %}
-// internal structure only used by another _internal field
+// Public structure with a nested `_internal` structure
 typedef struct {
-      int x;
-} _az_internal_structure;
-
-// Public structure with one internal field `_internal`
-typedef struct {
-      int y;
-      _az_private_struct; // This is not OK. Exposing internal field as public.
+      int y; // Public field in a public struct.
+      _az_internal_structure nested; // This is not OK. Exposing internal field as public.
 } az_public_struct;
 {% endhighlight %}
 

--- a/docs/clang/implementation.md
+++ b/docs/clang/implementation.md
@@ -361,6 +361,40 @@ the `internal` directory (a sibling of `src` and `inc`).
 
 {% include requirement/MUSTNOT id="clang-style-publicapi-hdr-includes" %} include internal or private headers in public headers.
 
+> **Note**: It is allowed to a public header to declare internal structures to be used **only** within another internal structure/API. See example below.
+
+Below code **can** be part of a public header.
+
+{% highlight c %}
+// internal structure only used by another _internal field
+typedef struct {
+      int x;
+} _az_internal_structure;
+
+// Public structure with one internal field `_internal`
+typedef struct {
+      int y;
+      struct {
+            _az_private_struct; // This is OK
+      } _internal;
+} az_public_struct;
+{% endhighlight %}
+
+Below code **can not** be part of a public header.
+
+{% highlight c %}
+// internal structure only used by another _internal field
+typedef struct {
+      int x;
+} _az_internal_structure;
+
+// Public structure with one internal field `_internal`
+typedef struct {
+      int y;
+      _az_private_struct; // This is not OK. Exposing internal field as public.
+} az_public_struct;
+{% endhighlight %}
+
 {% include requirement/MUSTNOT id="clang-style-install-internal-private-headers" %} install internal or private headers with `make install` or equivalent.
 
 {% include requirement/MUST id="clang-style-filenames" %} use characters in the range `[a-z0-9_]` for the name portion (before the file extension).  No other characters are permitted.


### PR DESCRIPTION
Explicitly adding documentation about how to declare and use an internal structure in a public header 

This is how it looks:
![image](https://user-images.githubusercontent.com/24213737/89088160-bf142d80-d34b-11ea-915a-e6004d5fe4d5.png)
