### PR TITLE
[August Release Notes] Event Hubs

### DIFF
--- a/releases/2020-08/dotnet.md
+++ b/releases/2020-08/dotnet.md
@@ -18,14 +18,15 @@ The Azure SDK team is pleased to announce our August 2020 client library release
 
 #### Preview
 
-- _Add packages_
+- Event Hubs
 
 ## Installation Instructions
 
 To install any of our packages, please search for them via `Manage NuGet Packages...` in Visual Studio (with `Include prerelease` checked) or copy these commands into your terminal:
 
 ```bash
-$> dotnet install PACKAGE --version whatever
+ $> dotnet add package Azure.Messaging.EventHubs --version 5.2.0-preview.2
+ $> dotnet add package Azure.Messaging.EventHubs.Processor --version 5.2.0-preview.2
 ```
 
 ## Feedback
@@ -34,11 +35,13 @@ If you have a bug or feature request for one of the libraries, please [file an i
 
 ## Changelog
 
-Detailed changelogs are linked from the [Quick Links](#quick-links) below. Here are some of the highlights:
+### Event Hubs [Changelog](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md)
 
-### _Package name_ 
+- This release contains several fixes for minor issues as well as a collection of performance enhancements.
 
-- Major changes only!!!
+### Event Hubs Processor [Changelog](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md)
+
+- This release contains several fixes for minor issues as well as a collection of performance enhancements.
 
 ## Latest Releases
 


### PR DESCRIPTION
# Summary

The focus of these changes is to add the Event Hubs content for the August release notes.

# Last Upstream Rebase

Friday, August 7, 12:23pm (EDT)