### PR TITLE
Use standard npm distribution tags

### DIFF
--- a/docs/typescript/design.md
+++ b/docs/typescript/design.md
@@ -32,11 +32,13 @@ While consumers are fast at adopting new versions of TypeScript, version 3.1 is 
 
 {% include requirement/MUST id="ts-register-dropped-platforms" %} get approval from the [Architecture Board] to drop support for any platform (except IE11 and Node 6) even if support isn't required.
 
-## Namespaces and NPM scopes {#ts-namespace}
+## Namespaces, NPM Scopes, and Distribution Tags {#ts-namespace}
 
 {% include requirement/MUST id="ts-azure-scope" %} publish your library to the `@azure` npm scope.
 
 {% include requirement/MUST id="ts-namespace-serviceclient" %} pick a package name that allows the consumer to tie the namespace to the service being used.  As a default, use the compressed service name at the end of the namespace.  The namespace does **NOT** change when the branding of the product changes. Avoid the use of marketing names that may change.
+
+{% include requirement/MUST id="ts-npm-dist-tags" %} publish GA packages using the npm distribution tag `latest` and preview packages using `next`.
 
 {% include requirement/MUST id="ts-namespace-in-browsers" %} use one of the appropriate namespaces (see below) for browser globals when producing UMD builds.
 

--- a/docs/typescript/design.md
+++ b/docs/typescript/design.md
@@ -38,7 +38,9 @@ While consumers are fast at adopting new versions of TypeScript, version 3.1 is 
 
 {% include requirement/MUST id="ts-namespace-serviceclient" %} pick a package name that allows the consumer to tie the namespace to the service being used.  As a default, use the compressed service name at the end of the namespace.  The namespace does **NOT** change when the branding of the product changes. Avoid the use of marketing names that may change.
 
-{% include requirement/MUST id="ts-npm-dist-tags" %} publish GA packages using the npm distribution tag `latest` and preview packages using `next`.
+{% include requirement/MUST id="ts-npm-dist-tag-preview" %} tag preview packages with the npm distribution tag `next`. If there is no generally available release of this package, it should also be tagged `latest`.
+
+{% include requirement/MUST id="ts-npm-dist-tag-next" %} tag generally available npm packages `latest`. Generally available packages may also be tagged `next` if they include the changes from the most recent preview.
 
 {% include requirement/MUST id="ts-namespace-in-browsers" %} use one of the appropriate namespaces (see below) for browser globals when producing UMD builds.
 


### PR DESCRIPTION
This is still using `preview` nomenclature as I've yet to update to `prerelease` globally.