### PR TITLE
clang, prohibit first level const in function signatures

### DIFF
--- a/docs/clang/design.md
+++ b/docs/clang/design.md
@@ -203,8 +203,8 @@ static int64_t compute_hash(int32_t a, int32_t b) {
 
 {% include requirement/SHOULD id="clang-design-naming-paramnames" %} use a meaningful name for parameters and local variable names.  Parameters and local variable names should be named as all lower-case words, separated by underscores (snake-casing).
 
-{% include requirements/MUSTNOT id="clang-design-const-parameters" %} use first level const for parameters or return types. Pointers to const are fine. First level const on function parameters does not
-provide any additional grantees to the caller, and can be confusing. For example:
+{% include requirements/MUSTNOT id="clang-design-const-parameters" %} use first level const for parameters or return types. Pointers to const are fine. First level const on function parameters do not
+provide any additional guarantees to the caller, and can be confusing. For example:
 
 This is not OK:
 ```c

--- a/docs/clang/design.md
+++ b/docs/clang/design.md
@@ -203,8 +203,8 @@ static int64_t compute_hash(int32_t a, int32_t b) {
 
 {% include requirement/SHOULD id="clang-design-naming-paramnames" %} use a meaningful name for parameters and local variable names.  Parameters and local variable names should be named as all lower-case words, separated by underscores (snake-casing).
 
-{% include requirement/MUSTNOT id="clang-design-const-parameters" %} use first level const for parameters or return types. Pointers to const are fine. First level const on function parameters do not
-provide any additional guarantees to the caller, and can be confusing. For example:
+{% include requirement/MUSTNOT id="clang-design-const-parameters" %} use first level const for parameters or return types for function signatures. 
+Pointers to const are fine. First level const on function parameters do not provide any additional guarantees to the caller, and can be confusing. For example:
 
 This is not OK:
 ```c
@@ -225,6 +225,9 @@ Instead write:
 ```c
 int az_iot_client_get(az_iot_client const *client, int *id);
 ```
+
+Note: You may use first level const when _defining_ a function, if you want to ensure you don't modify the value. Similarly you may use first level const on
+definitions of inline functions (which are in headers).
 
 ### Callbacks
 

--- a/docs/clang/design.md
+++ b/docs/clang/design.md
@@ -203,6 +203,29 @@ static int64_t compute_hash(int32_t a, int32_t b) {
 
 {% include requirement/SHOULD id="clang-design-naming-paramnames" %} use a meaningful name for parameters and local variable names.  Parameters and local variable names should be named as all lower-case words, separated by underscores (snake-casing).
 
+{% include requirements/MUSTNOT id="clang-design-const-parameters" %} use first level const for parameters or return types. Pointers to const are fine. First level const on function parameters does not
+provide any additional grantees to the caller, and can be confusing. For example:
+
+This is not OK:
+```c
+const int az_iot_client_set_widget_id(az_iot_client *client, const int id);
+```
+
+Instead write:
+```c
+int az_iot_client_set_widget_id(az_iot_client *client, int id);
+```
+
+This is also not OK
+```c
+const int az_iot_client_get_widget_id(az_iot_client const *const client, int *const id);
+```
+
+Instead write:
+```c
+int az_iot_client_get(az_iot_client const *client, int *id);
+```
+
 ### Callbacks
 
 Functions that request a callback with a context should order the callback first and then the context.  For example:

--- a/docs/clang/design.md
+++ b/docs/clang/design.md
@@ -203,7 +203,7 @@ static int64_t compute_hash(int32_t a, int32_t b) {
 
 {% include requirement/SHOULD id="clang-design-naming-paramnames" %} use a meaningful name for parameters and local variable names.  Parameters and local variable names should be named as all lower-case words, separated by underscores (snake-casing).
 
-{% include requirements/MUSTNOT id="clang-design-const-parameters" %} use first level const for parameters or return types. Pointers to const are fine. First level const on function parameters do not
+{% include requirement/MUSTNOT id="clang-design-const-parameters" %} use first level const for parameters or return types. Pointers to const are fine. First level const on function parameters do not
 provide any additional guarantees to the caller, and can be confusing. For example:
 
 This is not OK:


### PR DESCRIPTION
This is more of an implementation detail, it doesn't affect the actual API, but it appears in the API function signatures so I put it in the API design section, since that's where the programmer will be looking when this question comes up.

This prohibits all "first level" const in function signatures and return types, since they don't really do anything and have persistently caused confusion.