### PR TITLE
[Sepember Release Notes] Event Hubs

### DIFF
--- a/releases/2020-09/dotnet.md
+++ b/releases/2020-09/dotnet.md
@@ -10,6 +10,7 @@ The Azure SDK team is pleased to announce our September 2020 client library rele
 
 #### GA
 
+- Event Hubs
 - Form Recognizer
 
 #### Updates
@@ -26,6 +27,9 @@ To install any of our packages, please search for them via `Manage NuGet Package
 
 ```bash
 $> dotnet install Azure.AI.FormRecognizer --version 3.0.0
+
+$> dotnet add package Azure.Messaging.EventHubs
+$> dotnet add package Azure.Messaging.EventHubs.Processor
 ```
 
 ## Feedback
@@ -35,6 +39,26 @@ If you have a bug or feature request for one of the libraries, please [file an i
 ## Changelog
 
 Detailed changelogs are linked from the [Quick Links](#quick-links) below. Here are some of the highlights:
+
+### Event Hubs [Changelog](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md)
+
+#### New Features
+
+- The `EventProcessor<TPartition>` now supports a configurable strategy for load balancing, allowing control over whether it claims ownership of partitions in a balanced manner _(default)_ or more aggressively.  The strategy may be set in the `EventProcessorOptions` when creating the processor.  More details about strategies can be found in the associated [documentation](https://docs.microsoft.com/dotnet/api/azure.messaging.eventhubs.processor.loadbalancingstrategy?view=azure-dotnet).
+
+- The `EventHubConsumerClient` now allows for performance tuning by setting the `PrefetchCount` and `CacheEventCount` values in its associated options.
+
+### Event Hubs Processor [Changelog](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs.Processor/CHANGELOG.md)
+
+#### New Features
+
+- The `EventProcessorClient` now supports a configurable strategy for load balancing, allowing control over whether it claims ownership of partitions in a balanced manner _(default)_ or more aggressively.  The strategy may be set in the `EventProcessorClientOptions` when creating the processor.  More details about strategies can be found in the associated [documentation](https://docs.microsoft.com/dotnet/api/azure.messaging.eventhubs.processor.loadbalancingstrategy?view=azure-dotnet).
+
+- The `EventProcessorClient` now allows for performance tuning by setting the `PrefetchCount` and `CacheEventCount` values in its associated options.
+
+#### Key Bug Fixes
+
+- The approach used for creation of checkpoints has been updated to interact with Azure Blob storage more efficiently.  This will yield major performance improvements when soft delete was enabled and minor improvements otherwise.
 
 ### Form Recognizer [Changelog](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/formrecognizer/Azure.AI.FormRecognizer/CHANGELOG.md#300-2020-08-20)
 


### PR DESCRIPTION
# Summary

Adding the Event Hubs content to the release notes for September.

# Last Upstream Rebase

Thursday, September 3, 5:48pm (EDT)