### PR TITLE
Update Out of Band Release Notes Policy

### DIFF
--- a/docs/policies/releasenotes.md
+++ b/docs/policies/releasenotes.md
@@ -58,7 +58,14 @@ Release notes will locked for GA and beta libraries after the blog publication d
 
 ## What do I need to do for an out-of-band release?
 
-The release manager will merge and publish the release notes in the following month's on-time release folder.
+If you need to release a library after the official release notes release date has occurred but before the next month has been released, then add your release notes to the current month's release notes. The release manager will merge and publish the release notes in the current month's release folder.
+
+For example:
+1. The official release notes are announced on 9/18/2020.
+1. The library you need to ship does not ship by that date, say 9/22/2020.
+1. Submit a PR to add your release notes to September release notes and tag the Azure SDK release manager.
+
+If you have any questions, please reach out to the Azure SDK release manager.
 
 You may optionally provide social media outreach for out-of-band releases.  Contact the _Community Engagement Manager_ for details on this at least 7 working days prior to the release.
 

--- a/docs/policies/releasenotes.md
+++ b/docs/policies/releasenotes.md
@@ -58,15 +58,14 @@ Release notes will locked for GA and beta libraries after the blog publication d
 
 ## What do I need to do for an out-of-band release?
 
-If you need to release a library after the official release notes release date has occurred but before the next month has been released, then add your release notes to the current month's release notes. The release manager will merge and publish the release notes in the current month's release folder.
+If you need to release a library after the official release notes release date has occurred but before the next month has been released, then add your release notes to the current month's release notes. The _Azure SDK release manager_ will merge and publish the release notes in the current month's release folder.
 
 For example:
 1. The official release notes are announced on 9/18/2020.
 1. The library you need to ship does not ship by that date, say 9/22/2020.
-1. Submit a PR to add your release notes to September release notes and tag the Azure SDK release manager.
+1. Submit a PR to add your release notes to September release notes and tag the _Azure SDK release manager_.
 
-If you have any questions, please reach out to the Azure SDK release manager.
+If you have any questions, please reach out to the _Azure SDK release manager_.
 
 You may optionally provide social media outreach for out-of-band releases.  Contact the _Community Engagement Manager_ for details on this at least 7 working days prior to the release.
-
 

--- a/docs/policies/releasenotes.md
+++ b/docs/policies/releasenotes.md
@@ -51,10 +51,7 @@ The release manager will produce the point-in-time snapshot of the versions and 
 
 ## Who publishes the release notes and when are they published?
 
-* For all on-time releases, the release manager will merge and publish the release notes in the current month's on-time release folder.
-* For all out-of-band releases, the release notes in the following month's on-time release folder.
-
-Release notes will locked for GA and beta libraries after the blog publication date (1 week following release date). (Note: all changelogs should be done on release day)
+* For all releases, the release manager will merge and publish the release notes in the current month's release folder.
 
 ## What do I need to do for an out-of-band release?
 
@@ -68,4 +65,8 @@ For example:
 If you have any questions, please reach out to the _Azure SDK release manager_.
 
 You may optionally provide social media outreach for out-of-band releases.  Contact the _Community Engagement Manager_ for details on this at least 7 working days prior to the release.
+
+## Where do I go if I need help?
+
+The _Azure SDK release manager_ is best place to start when you need help with a release. They manage the Release channel in the Azure SDK Teams team.  If you need help you can post a message in that Teams channel here: <https://aka.ms/azsdk/teams/release>
 


### PR DESCRIPTION
We have confusion around where out of band release notes belong, from both our team and partner teams.  This update will hopefully make the guidance simple and solve a few problems that we are experiencing.

Our current guidance states that out of band releases go in the "next month's" release notes, but this creates a problem for us because:
1. In order to expose those notes, we have to publish the next month release files before the next month.  i.e., we need to release and announce something on 9/22, blog, tweet, etc.  But the release notes would be in Oct (under the current guidance)
2. This makes it look like we didn't ship much in October, because it only has the release notes of the out of band releases.

This update changes that guidance to put the out of band release notes in the current month's release notes instead of next month.

@czubair @weshaggard