### PR TITLE
Update java-packages.csv to include Digital Twins

### DIFF
--- a/_data/releases/latest/java-packages.csv
+++ b/_data/releases/latest/java-packages.csv
@@ -1,6 +1,6 @@
 "Package","GroupId","VersionGA","VersionPreview","DisplayName","ServiceName","RepoPath","MSDocs","GHDocs","Type","Hide","Notes"
 "azure-ai-anomalydetector","com.azure","","3.0.0-beta.1","Anomaly Detector","Anomaly Detector","anomalydetector","","","client","",""
-"azure-digitaltwins-core","com.azure","","1.0.0-beta.1","Digital Twins","Digital Twins","digitaltwins","","","client","",""
+"azure-digitaltwins-core","com.azure","","1.0.0-beta.1","Digital Twins","Digital Twins","digitaltwins","NA","","client","",""
 "azure-data-appconfiguration","com.azure","1.1.5","","App Configuration","App Configuration","appconfiguration","","","client","",""
 "azure-search-documents","com.azure","11.1.0","11.2.0-beta.1","Cognitive Search","Search","search","","","client","","Replaces: azure-search"
 "azure-core","com.azure","1.8.1","","Core","Core","core","","","client","",""

--- a/_data/releases/latest/java-packages.csv
+++ b/_data/releases/latest/java-packages.csv
@@ -1,6 +1,5 @@
 "Package","GroupId","VersionGA","VersionPreview","DisplayName","ServiceName","RepoPath","MSDocs","GHDocs","Type","Hide","Notes"
 "azure-ai-anomalydetector","com.azure","","3.0.0-beta.1","Anomaly Detector","Anomaly Detector","anomalydetector","","","client","",""
-"azure-communication-chat","com.azure","","1.0.0-beta.1","Communication","Communication","communication","","","client","",""
 "azure-digitaltwins-core","com.azure","","1.0.0-beta.1","Digital Twins","Digital Twins","digitaltwins","","","client","",""
 "azure-data-appconfiguration","com.azure","1.1.5","","App Configuration","App Configuration","appconfiguration","","","client","",""
 "azure-search-documents","com.azure","11.1.0","11.2.0-beta.1","Cognitive Search","Search","search","","","client","","Replaces: azure-search"

--- a/_data/releases/latest/java-packages.csv
+++ b/_data/releases/latest/java-packages.csv
@@ -1,5 +1,7 @@
 "Package","GroupId","VersionGA","VersionPreview","DisplayName","ServiceName","RepoPath","MSDocs","GHDocs","Type","Hide","Notes"
 "azure-ai-anomalydetector","com.azure","","3.0.0-beta.1","Anomaly Detector","Anomaly Detector","anomalydetector","","","client","",""
+"azure-communication-chat","com.azure","","1.0.0-beta.1","Communication","Communication","communication","","","client","",""
+"azure-digitaltwins-core","com.azure","","1.0.0-beta.1","Digital Twins","Digital Twins","digitaltwins","","","client","",""
 "azure-data-appconfiguration","com.azure","1.1.5","","App Configuration","App Configuration","appconfiguration","","","client","",""
 "azure-search-documents","com.azure","11.1.0","11.2.0-beta.1","Cognitive Search","Search","search","","","client","","Replaces: azure-search"
 "azure-core","com.azure","1.8.1","","Core","Core","core","","","client","",""


### PR DESCRIPTION
This PR adds newer client libraries of Digital Twins service to track in releases.
https://azure.github.io/azure-sdk-for-java/communication.html