### PR TITLE
[TypeScript] Adding a guideline on naming the type of the options bag

### DIFF
--- a/docs/typescript/design.md
+++ b/docs/typescript/design.md
@@ -176,6 +176,8 @@ class ExampleClient {
 
 The guidelines in this section apply to options passed in options bags to clients, whether methods or constructors. When referring to option names, this means the key of the object users must use to specify that option when passing it into a method or constructor.
 
+{% include requirement/MUST id="ts-naming-options" %} name the type of the options bag as `<class name>Options` and `<function name>Options` for constructors and methods respectively
+
 {% include requirement/MUST id="ts-options-abortSignal" %} name abort signal options `abortSignal`
 
 {% include requirement/MUST id="ts-options-suffix-durations" %} suffix durations with `In<Unit>`. Unit should be `ms` for milliseconds, and otherwise the name of the unit. Examples include `timeoutInMs` and `delayInSeconds`.

--- a/docs/typescript/design.md
+++ b/docs/typescript/design.md
@@ -176,9 +176,9 @@ class ExampleClient {
 
 The guidelines in this section apply to options passed in options bags to clients, whether methods or constructors. When referring to option names, this means the key of the object users must use to specify that option when passing it into a method or constructor.
 
-{% include requirement/MUST id="ts-naming-options" %} name the type of the options bag as `<class name>Options` and `<function name>Options` for constructors and methods respectively
+{% include requirement/MUST id="ts-naming-options" %} name the type of the options bag as `<class name>Options` and `<method name>Options` for constructors and methods respectively.
 
-{% include requirement/MUST id="ts-options-abortSignal" %} name abort signal options `abortSignal`
+{% include requirement/MUST id="ts-options-abortSignal" %} name abort signal options `abortSignal`.
 
 {% include requirement/MUST id="ts-options-suffix-durations" %} suffix durations with `In<Unit>`. Unit should be `ms` for milliseconds, and otherwise the name of the unit. Examples include `timeoutInMs` and `delayInSeconds`.
 


### PR DESCRIPTION
This new guideline is consistent with what we have been doing so far and our ESLint plugin implements it.