### PR TITLE
We dont have quick links anymore

### DIFF
--- a/eng/scripts/release-template/android.md
+++ b/eng/scripts/release-template/android.md
@@ -47,9 +47,7 @@ To use the latest GA and beta libraries, refer to the dependency information bel
 
 If you have a bug or feature request for one of the libraries, please post an issue to [GitHub](https://github.com/azure/azure-sdk-for-android/issues).
 
-## Changelog
-
-Detailed changelogs are linked from the [Quick Links](#quick-links) below. Here are some of the highlights:
+## Release highlights
 
 ### _Package name_
 

--- a/eng/scripts/release-template/c.md
+++ b/eng/scripts/release-template/c.md
@@ -32,7 +32,7 @@ $>
 
 If you have a bug or feature request for one of the libraries, please post an issue to [GitHub](https://github.com/azure/azure-sdk-for-c/issues).
 
-## Changelog
+## Release highlights
 
 ### _Package name_
 

--- a/eng/scripts/release-template/cpp.md
+++ b/eng/scripts/release-template/cpp.md
@@ -32,7 +32,7 @@ $>
 
 If you have a bug or feature request for one of the libraries, please post an issue to [GitHub](https://github.com/azure/azure-sdk-for-cpp/issues).
 
-## Changelog
+## Release highlights
 
 ### _Package name_
 

--- a/eng/scripts/release-template/dotnet.md
+++ b/eng/scripts/release-template/dotnet.md
@@ -32,10 +32,6 @@ $> dotnet install PACKAGE --version whatever
 
 If you have a bug or feature request for one of the libraries, please [file an issue in our repo](https://github.com/Azure/azure-sdk-for-net/issues/new/choose).
 
-## Changelog
-
-Detailed changelogs are linked from the [Quick Links](#quick-links) below. Here are some of the highlights:
-
 ### _Package name_ 
 
 - Major changes only!!!

--- a/eng/scripts/release-template/dotnet.md
+++ b/eng/scripts/release-template/dotnet.md
@@ -32,6 +32,8 @@ $> dotnet install PACKAGE --version whatever
 
 If you have a bug or feature request for one of the libraries, please [file an issue in our repo](https://github.com/Azure/azure-sdk-for-net/issues/new/choose).
 
+## Release highlights
+
 ### _Package name_ 
 
 - Major changes only!!!

--- a/eng/scripts/release-template/ios.md
+++ b/eng/scripts/release-template/ios.md
@@ -50,6 +50,8 @@ Next, add each client library you wish to use in a target to the target's array 
 
 If you have a bug or feature request for one of the libraries, please post an issue to [GitHub](https://github.com/azure/azure-sdk-for-ios/issues).
 
+## Release highlights
+
 ### _Package name_
 
 - Major changes only!

--- a/eng/scripts/release-template/ios.md
+++ b/eng/scripts/release-template/ios.md
@@ -50,10 +50,6 @@ Next, add each client library you wish to use in a target to the target's array 
 
 If you have a bug or feature request for one of the libraries, please post an issue to [GitHub](https://github.com/azure/azure-sdk-for-ios/issues).
 
-## Changelog
-
-Detailed changelogs are linked from the [Quick Links](#quick-links) below. Here are some of the highlights:
-
 ### _Package name_
 
 - Major changes only!

--- a/eng/scripts/release-template/java.md
+++ b/eng/scripts/release-template/java.md
@@ -32,6 +32,8 @@ To use the GA and beta libraries, refer to the Maven dependency information belo
 
 If you have a bug or feature request for one of the libraries, please post an issue to [GitHub](https://github.com/azure/azure-sdk-for-java/issues).
 
+## Release highlights
+
 ### _Package name_
 
 - Major changes only!

--- a/eng/scripts/release-template/java.md
+++ b/eng/scripts/release-template/java.md
@@ -32,10 +32,6 @@ To use the GA and beta libraries, refer to the Maven dependency information belo
 
 If you have a bug or feature request for one of the libraries, please post an issue to [GitHub](https://github.com/azure/azure-sdk-for-java/issues).
 
-## Changelog
-
-Detailed changelogs are linked from the [Quick Links](#quick-links) below. Here are some of the highlights:
-
 ### _Package name_
 
 - Major changes only!

--- a/eng/scripts/release-template/js.md
+++ b/eng/scripts/release-template/js.md
@@ -32,6 +32,8 @@ $> npm install @azure/package-name
 
 If you have a bug or feature request for one of the libraries, please post an issue at the [azure-sdk-for-js repository](https://github.com/azure/azure-sdk-for-js/issues)
 
+## Release highlights
+
 ### _Package name_
 
 - Major changes only!

--- a/eng/scripts/release-template/js.md
+++ b/eng/scripts/release-template/js.md
@@ -32,10 +32,6 @@ $> npm install @azure/package-name
 
 If you have a bug or feature request for one of the libraries, please post an issue at the [azure-sdk-for-js repository](https://github.com/azure/azure-sdk-for-js/issues)
 
-## Changelog
-
-Detailed changelogs are linked from the [Quick Links](#quick-links) below. Here are some of the highlights:
-
 ### _Package name_
 
 - Major changes only!

--- a/eng/scripts/release-template/python.md
+++ b/eng/scripts/release-template/python.md
@@ -32,6 +32,8 @@ $> pip install azure-packagename
 
 If you have a bug or feature request for one of the libraries, please post an issue to [GitHub](https://github.com/azure/azure-sdk-for-python/issues).
 
+## Release highlights
+
 ### _Package name_
 
 - Major changes only!

--- a/eng/scripts/release-template/python.md
+++ b/eng/scripts/release-template/python.md
@@ -32,10 +32,6 @@ $> pip install azure-packagename
 
 If you have a bug or feature request for one of the libraries, please post an issue to [GitHub](https://github.com/azure/azure-sdk-for-python/issues).
 
-## Changelog
-
-Detailed changelogs are linked from the [Quick Links](#quick-links) below. Here are some of the highlights:
-
 ### _Package name_
 
 - Major changes only!

--- a/releases/2020-10/js.md
+++ b/releases/2020-10/js.md
@@ -41,11 +41,6 @@ $> npm install @azure/storage-blob@next
 
 If you have a bug or feature request for one of the libraries, please post an issue at the [azure-sdk-for-js repository](https://github.com/azure/azure-sdk-for-js/issues)
 
-## Changelog
-
-Detailed changelogs are linked from the [Quick Links](#quick-links) below. Here are some of the highlights:
-
-
 ### Azure Identity
 
 #### @azure/identity  [Changelog](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/identity/identity/CHANGELOG.md)


### PR DESCRIPTION
Updating the release notes for JS to not have quick links as we dont render these anymore