### PR TITLE
Added links for Android and iOS in the October release notes index.

### DIFF
--- a/releases/2020-10/index.md
+++ b/releases/2020-10/index.md
@@ -26,3 +26,5 @@ You can find links to packages, code, and docs on our [Azure SDK Releases page](
 * [Python release notes](python.md)
 * [C++ release notes](cpp.md)
 * [Embedded C release notes](c.md)
+* [Android release notes](android.md)
+* [iOS C release notes](ios.md)


### PR DESCRIPTION
I noticed that links to the release notes for mobile libraries had not been included in the latest [release blog](https://devblogs.microsoft.com/azure-sdk/october-2020-release/). They already exist in the `index.md` template located at `eng/scripts/release-template` so future releases won't be impacted, but the changes were added after the October's index file had already been generated. @jongio will update October's blog after these changes are included :)