### PR TITLE
Update the guideline for Spring

### DIFF
--- a/docs/java/spring.md
+++ b/docs/java/spring.md
@@ -18,9 +18,11 @@ Providing the Spring ecosystem with a first-class experience is of the utmost im
 
 ### Maven
 
-{% include requirement/MUST id="java-spring-maven-groupid" %} use the group ID of `com.azure`.
+{% include requirement/MUST id="java-spring-maven-groupid" %} use the group ID of `com.azure.spring`.
 
-{% include requirement/MUST id="java-spring-maven-artifactid" %} specify the `artifactId` to be of the form `azure-spring-boot-starter-<group>-<service>[-<feature>]`, for example, `azure-spring-boot-starter-storage-blob` or `azure-spring-boot-starter-security-keyvault-secrets`.
+{% include requirement/MUST id="java-spring-maven-artifactid" %} specify the `artifactId` to be of the form `azure-spring-boot-starter-<group>-<service>[-<feature>]`, for example, `azure-spring-boot-starter-storage-blob` or `azure-spring-boot-starter-security-keyvault-secrets`. 
+For Spring data abstraction, the `artifactId` should be of the form `azure-spring-data-<group>-<service>[-<feature>]`.
+For Spring cloud starters, the `artifactId` should be of the form `azure-spring-cloud-starter-<group>-<service>[-<feature>]`.
 
 {% include requirement/MUST id="java-spring-azure-sdk-bom" %} include a `dependencyManagement` dependency on the Azure Java SDK BOM, so that users who use Azure Spring libraries can bring in additional dependencies on other Azure Java client libraries without needing to choose versions.
 
@@ -34,15 +36,13 @@ Spring integration modules must be versioned in a way that enables the following
 
 {% include requirement/MUST id="java-spring-supported-versions" %} ensure that all releases of a Spring integration module support all active versions (as of the time of release) of the corresponding Spring API.
 
-{% include requirement/MUST id="java-spring-deps-provided" %} add Spring API dependencies as `provided` in the Spring integration module POM files, so that it is the users responsibility to provide a specific dependency in their own codebase.
+{% include requirement/MUST id="java-spring-deps" %} add latest release version of Spring API dependencies in the Spring integration module POM files, it is the users responsibility to override the Spring API version via Spring BOM.
 
 {% include requirement/MUST id="java-spring-classifiers" %} add Maven classifiers to releases if a Spring integration module cannot support all active versions of the corresponding Spring API. For example, if a Spring integration module needs to support Spring Boot 2.2.x and 2.3.x, but cannot due to technical contraints, two versions of the Spring integration module must be released, with classifiers `springboot_2_2` and `springboot_2_3`.
 
-{% include requirement/MUST id="java-spring-bom" %} provide a Spring-specific BOM for users. This BOM must contain versions of all Spring integration modules that are known to work together (and have a single set of dependency versions). It must also include appropriate references to Azure Java SDK and Spring BOMs.
+{% include requirement/MUST id="java-spring-bom" %} provide a Spring integration modules BOM for users. This BOM must contain versions of all Spring integration modules that are known to work together (and have a single set of dependency versions). It must also include appropriate references to Azure Java SDK.
 
-{% include requirement/MUST id="java-spring-bom-naming" %} name the Spring-specific BOM specifically after the corresponding Spring version, e.g. `azure-spring-boot-2-2-bom`.
-
-{% include requirement/MUST id="java-spring-bom-docs" %} encourage users to use the Spring-specific BOM for their chosen version of Spring rather than specific versions of each Spring integration module, such that they need not worry about Maven classifiers and other versioning issues.
+{% include requirement/MUST id="java-spring-bom-docs" %} encourage users to use the Spring integration modules BOM for their chosen version of Spring rather than specific versions of each Spring integration module, such that they need not worry about Maven classifiers and other versioning issues.
 
 ## Dependencies
 


### PR DESCRIPTION
Following are the updates in this PR:
- Use group id of `com.azure.spring`
- Some changes for version schema

During our implementation of version schema, some changes are made:
- Spring module depends on latest released Spring API version
  - From Spring application's view, the Spring API dependency is indirect dependency, and can be controlled by dependency management
  - Once Spring application include BOM of specific Spring API version, the dependency version brought by Spring module is overridden

Because of this, the BOM also don't need to include Spring API version, thus it can just contains the Spring module and SDK library.