### PR TITLE
Deep links broken

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -2,7 +2,6 @@
 
 <ul id="mysidebar" class="nav">
 
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
   <script src="{{ "/js/tipuesearch_content.js" | relative_url }}"></script>
   <script src="{{ "/js/tipuesearch_set.js" | relative_url }}"></script>
   <script src="{{ "/js/tipuesearch.min.js" | relative_url }}"></script>


### PR DESCRIPTION
the new Search functionality dependency on a different Jquery package broke existing functionality on pages where the side bar exists such as deep links. the search functionality is compatible with the existing Jquery version included in the project.

You can test my changes deployed in my fork here:

https://salameer.github.io/azure-sdk/dotnet_introduction.html#dotnet-principles

Look for the anchor icon that disappeared when hovering over a section. you should now see it as in this snapshot

<img width="383" alt="Screen Shot 2020-10-23 at 11 20 21 PM" src="https://user-images.githubusercontent.com/18127647/97069669-971d1a80-1586-11eb-8820-8d3e576a26ec.png">
