### PR TITLE
Add more clarity to LRO guidelines regarding exception behavior

### DIFF
--- a/docs/dotnet/introduction.md
+++ b/docs/dotnet/introduction.md
@@ -505,19 +505,10 @@ BlobBaseClient client = ...
 
 {% include requirement/MUST id="dotnet-lro-return" %} return a subclass of ```Operation<T>``` from LRO methods.
 
-{% include requirement/MUST id="dotnet-lro-return" %} check the value of ```HasCompleted``` in subclass implementations of ```UpdateStatus``` and ```UpdateStatusAsync``` and immediately return the result of ```GetRawResponse``` if it is true.
-
 {% include requirement/MAY id="dotnet-lro-subclass" %} add additional APIs to subclasses of ```Operation<T>```.
 For example, some subclasses add a constructor allowing to create an operation instance from a previously saved operation ID. Also, some subclasses are more granular states besides the IsCompleted and HasValue states that are present on the base class.
 
-{% include requirement/MUST id="dotnet-lro-return" %} throw from ```Operation<T>``` subclasses in the following scenarios.
-
-* If the operation completes with a non-success result, throw ```RequestFailedException``` or its subtype from ```UpdateStatus```, ```WaitForCompletion```, or ```WaitForCompletionAsync```.
-  * Include any relevant error state information in the exception details.
-* If an underlying service operation call from ```UpdateStatus```, ```WaitForCompletion```, or ```WaitForCompletionAsync``` throws, re-throw ```RequestFailedException``` or its subtype.
-* If the ```Value``` property is evaluated after the operation failed (```HasValue``` is false and ```HasCompleted``` is true) throw the same exception as the one thrown when the operation failed.
-* If the ```Value``` property is evaluated before the operation is complete (```HasCompleted``` is false) throw ```InvalidOperationException```.
-  * The exception message should be: "The operation has not yet completed."
+Guidelines for implementing `Operation<T>` can be found in [Implementing Subtypes of Operation<T>](#dotnet-implement-operation) section below.
 
 ### Supporting Mocking {#dotnet-mocking}
 
@@ -959,6 +950,115 @@ using (JsonDocument json = await JsonDocument.ParseAsync(content, default, cance
 {% include requirement/MUST id="dotnet-json-serialization-resilience" %} make your serialization and deserialization code version resilient.
 
 Optional JSON properties should be deserialized into nullable model properties.
+
+### Implementing Subtypes of Operation<T> {#dotnet-implement-operation}
+
+{% include requirement/MUST id="dotnet-lro-return" %} check the value of ```HasCompleted``` in subclass implementations of ```UpdateStatus``` and ```UpdateStatusAsync``` and immediately return the result of ```GetRawResponse``` if it is true.
+
+```csharp
+public override Response UpdateStatus(
+    CancellationToken cancellationToken = default) =>
+    UpdateStatusAsync(false, cancellationToken).EnsureCompleted();
+
+public override async ValueTask<Response> UpdateStatusAsync(
+    CancellationToken cancellationToken = default) =>
+    await UpdateStatusAsync(true, cancellationToken).ConfigureAwait(false);
+
+private async Task<Response> UpdateStatusAsync(bool async, CancellationToken cancellationToken)
+{
+    // Short-circuit when already completed (which improves mocking scenarios that won't have a client).
+    if (HasCompleted)
+    {
+        return GetRawResponse();
+    }
+    ...
+```
+
+{% include requirement/MUST id="dotnet-lro-return" %} throw from methods on ```Operation<T>``` subclasses in the following scenarios.
+
+* If an underlying service operation call from ```UpdateStatus```, ```WaitForCompletion```, or ```WaitForCompletionAsync``` throws, re-throw ```RequestFailedException``` or its subtype.
+* If the operation completes with a non-success result, throw ```RequestFailedException``` or its subtype from ```UpdateStatus```, ```WaitForCompletion```, or ```WaitForCompletionAsync```.
+  * Include any relevant error state information in the exception details.
+
+```csharp
+private async ValueTask<Response> UpdateStatusAsync(bool async, CancellationToken cancellationToken)
+{
+    ...
+
+        try
+        {
+            Response<AnalyzeOperationResult> update = async
+                ? await _serviceClient.GetAnalyzeLayoutResultAsync(new Guid(Id), cancellationToken).ConfigureAwait(false)
+                : _serviceClient.GetAnalyzeLayoutResult(new Guid(Id), cancellationToken);
+
+            _response = update.GetRawResponse();
+
+            if (update.Value.Status == OperationStatus.Succeeded)
+            {
+                // we need to first assign a value and then mark the operation as completed to avoid race conditions
+                _value = ConvertValue(update.Value.AnalyzeResult.PageResults, update.Value.AnalyzeResult.ReadResults);
+                _hasCompleted = true;
+            }
+            else if (update.Value.Status == OperationStatus.Failed)
+            {
+                _requestFailedException = await ClientCommon
+                    .CreateExceptionForFailedOperationAsync(async, _diagnostics, _response, update.Value.AnalyzeResult.Errors)
+                    .ConfigureAwait(false);
+                _hasCompleted = true;
+
+                // the operation didn't throw, but it completed with a non-success result.
+                throw _requestFailedException;
+            }
+        }
+        catch (Exception e)
+        {
+            scope.Failed(e);
+            throw;
+        }
+    }
+
+    return GetRawResponse();
+}
+```
+
+* If the ```Value``` property is evaluated after the operation failed (```HasValue``` is false and ```HasCompleted``` is true) throw the same exception as the one thrown when the operation failed.
+
+```csharp
+public override FooResult Value
+{
+    get
+    {
+        if (HasCompleted && !HasValue)
+#pragma warning disable CA1065 // Do not raise exceptions in unexpected locations
+
+            // throw the exception captured when the operation failed.
+            throw _requestFailedException;
+
+#pragma warning restore CA1065 // Do not raise exceptions in unexpected locations
+        else
+            return OperationHelpers.GetValue(ref _value);
+    }
+}
+```
+
+* If the ```Value``` property is evaluated before the operation is complete (```HasCompleted``` is false) throw ```InvalidOperationException```.
+  * The exception message should be: "The operation has not yet completed."
+
+```csharp
+// start the operation.
+var operation = await client.StartExampleOperationAsync(someParameter);
+
+if (!operation.HasCompleted)
+{
+    // attempt to get the Value property before the operation has completed.
+    var myResult = operation.Value;  //throws InvalidOperationException.
+}
+else if (!operation.HasValue)
+{
+    // attempt to get the Value property after the operation has completed unsuccessfully.
+    var myResult = operation.Value;  //throws RequestFailedException.
+}
+```
 
 ### Primitive Types
 

--- a/docs/dotnet/introduction.md
+++ b/docs/dotnet/introduction.md
@@ -505,6 +505,10 @@ BlobBaseClient client = ...
 
 {% include requirement/MUST id="dotnet-lro-return" %} return a subclass of ```Operation<T>``` from LRO methods.
 
+{% include requirement/MUST id="dotnet-lro-return" %} throw ```InvalidOperationException``` when the ```Value``` property is evaluated before the operation is complete (```HasCompleted``` is false).
+
+{% include requirement/MUST id="dotnet-lro-return" %} throw ```RequestFailedException``` or its subtype when the ```Value``` property is evaluated and the operation has completed without a successful result.
+
 {% include requirement/MAY id="dotnet-lro-subclass" %} add additional APIs to subclasses of ```Operation<T>```.
 For example, some subclasses add a constructor allowing to create an operation instance from a previously saved operation ID. Also, some subclasses are more granular states besides the IsCompleted and HasValue states that are present on the base class.
 

--- a/docs/dotnet/introduction.md
+++ b/docs/dotnet/introduction.md
@@ -953,7 +953,7 @@ Optional JSON properties should be deserialized into nullable model properties.
 
 ### Implementing Subtypes of Operation<T> {#dotnet-implement-operation}
 
-{% include requirement/MUST id="dotnet-lro-return" %} check the value of ```HasCompleted``` in subclass implementations of ```UpdateStatus``` and ```UpdateStatusAsync``` and immediately return the result of ```GetRawResponse``` if it is true.
+{% include requirement/MUST id="dotnet-lro-return" %} check the value of `HasCompleted` in subclass implementations of `UpdateStatus` and `UpdateStatusAsync` and immediately return the result of `GetRawResponse` if it is true.
 
 ```csharp
 public override Response UpdateStatus(
@@ -971,13 +971,15 @@ private async Task<Response> UpdateStatusAsync(bool async, CancellationToken can
     {
         return GetRawResponse();
     }
+
+    // some service operation call here, which the above check avoids if the operation has already completed.
     ...
 ```
 
-{% include requirement/MUST id="dotnet-lro-return" %} throw from methods on ```Operation<T>``` subclasses in the following scenarios.
+{% include requirement/MUST id="dotnet-lro-return" %} throw from methods on `Operation<T>` subclasses in the following scenarios.
 
-* If an underlying service operation call from ```UpdateStatus```, ```WaitForCompletion```, or ```WaitForCompletionAsync``` throws, re-throw ```RequestFailedException``` or its subtype.
-* If the operation completes with a non-success result, throw ```RequestFailedException``` or its subtype from ```UpdateStatus```, ```WaitForCompletion```, or ```WaitForCompletionAsync```.
+* If an underlying service operation call from `UpdateStatus`, `WaitForCompletion`, or `WaitForCompletionAsync` throws, re-throw `RequestFailedException` or its subtype.
+* If the operation completes with a non-success result, throw `RequestFailedException` or its subtype from `UpdateStatus`, `WaitForCompletion`, or `WaitForCompletionAsync`.
   * Include any relevant error state information in the exception details.
 
 ```csharp
@@ -987,16 +989,16 @@ private async ValueTask<Response> UpdateStatusAsync(bool async, CancellationToke
 
         try
         {
-            Response<AnalyzeOperationResult> update = async
-                ? await _serviceClient.GetAnalyzeLayoutResultAsync(new Guid(Id), cancellationToken).ConfigureAwait(false)
-                : _serviceClient.GetAnalyzeLayoutResult(new Guid(Id), cancellationToken);
+            Response<ExampleOperationResult> update = async
+                ? await _serviceClient.GetExampleResultAsync(new Guid(Id), cancellationToken).ConfigureAwait(false)
+                : _serviceClient.GetExampleResult(new Guid(Id), cancellationToken);
 
             _response = update.GetRawResponse();
 
             if (update.Value.Status == OperationStatus.Succeeded)
             {
                 // we need to first assign a value and then mark the operation as completed to avoid race conditions
-                _value = ConvertValue(update.Value.AnalyzeResult.PageResults, update.Value.AnalyzeResult.ReadResults);
+                _value = ConvertValue(update.Value.ExampleResult.PageResults, update.Value.ExampleResult.ReadResults);
                 _hasCompleted = true;
             }
             else if (update.Value.Status == OperationStatus.Failed)
@@ -1046,17 +1048,17 @@ public override FooResult Value
 
 ```csharp
 // start the operation.
-var operation = await client.StartExampleOperationAsync(someParameter);
+ExampleOperation operation = await client.StartExampleOperationAsync(someParameter);
 
 if (!operation.HasCompleted)
 {
     // attempt to get the Value property before the operation has completed.
-    var myResult = operation.Value;  //throws InvalidOperationException.
+    ExampleOperationResult myResult = operation.Value;  //throws InvalidOperationException.
 }
 else if (!operation.HasValue)
 {
     // attempt to get the Value property after the operation has completed unsuccessfully.
-    var myResult = operation.Value;  //throws RequestFailedException.
+    ExampleOperationResult myResult = operation.Value;  //throws RequestFailedException.
 }
 ```
 

--- a/docs/dotnet/introduction.md
+++ b/docs/dotnet/introduction.md
@@ -512,14 +512,12 @@ For example, some subclasses add a constructor allowing to create an operation i
 
 {% include requirement/MUST id="dotnet-lro-return" %} throw from ```Operation<T>``` subclasses in the following scenarios.
 
-* ```RequestFailedException``` or its subtype should be thrown from ```UpdateStatus```, ```WaitForCompletion```, or ```WaitForCompletionAsync``` if the operation completes with an non-success result. Include any relevant error state information in the exception details.
-* Any ```RequestFailedException```or its subtype resulting from the underlying service operation calls in ```RequestFailedException``` from ```UpdateStatus```, ```WaitForCompletion```, or ```WaitForCompletionAsync```.
-* ```RequestFailedException``` should be thrown when the ```Value``` property is evaluated before the operation is complete (```HasCompleted``` is false).
-  * The exception should be the same as what was thrown from ```UpdateStatus```, ```WaitForCompletion```, or ```WaitForCompletionAsync```.
-* ```InvalidOperationException``` should be thrown when the ```Value``` property is evaluated if the operation failed (```HasValue``` is false).
+* If the operation completes with a non-success result, throw ```RequestFailedException``` or its subtype from ```UpdateStatus```, ```WaitForCompletion```, or ```WaitForCompletionAsync```.
+  * Include any relevant error state information in the exception details.
+* If an underlying service operation call from ```UpdateStatus```, ```WaitForCompletion```, or ```WaitForCompletionAsync``` throws, re-throw ```RequestFailedException``` or its subtype.
+* If the ```Value``` property is evaluated after the operation failed (```HasValue``` is false and ```HasCompleted``` is true) throw the same exception as the one thrown when the operation failed.
+* If the ```Value``` property is evaluated before the operation is complete (```HasCompleted``` is false) throw ```InvalidOperationException```.
   * The exception message should be: "The operation has not yet completed."
-
-{% include requirement/MUST id="dotnet-lro-return" %} throw ```RequestFailedException``` or its subtype when the ```Value``` property is evaluated and the operation has completed without a successful result.
 
 ### Supporting Mocking {#dotnet-mocking}
 

--- a/docs/dotnet/introduction.md
+++ b/docs/dotnet/introduction.md
@@ -505,14 +505,21 @@ BlobBaseClient client = ...
 
 {% include requirement/MUST id="dotnet-lro-return" %} return a subclass of ```Operation<T>``` from LRO methods.
 
-{% include requirement/MUST id="dotnet-lro-return" %} throw ```InvalidOperationException``` when the ```Value``` property is evaluated before the operation is complete (```HasCompleted``` is false).
-
-{% include requirement/MUSTNOT id="dotnet-namespaces-location" %} throw from ```UpdateStatus```, ```WaitForCompletion```, or ```WaitForCompletionAsync```.
-
-{% include requirement/MUST id="dotnet-lro-return" %} throw ```RequestFailedException``` or its subtype when the ```Value``` property is evaluated and the operation has completed without a successful result.
+{% include requirement/MUST id="dotnet-lro-return" %} check the value of ```HasCompleted``` in subclass implementations of ```UpdateStatus``` and ```UpdateStatusAsync``` and immediately return the result of ```GetRawResponse``` if it is true.
 
 {% include requirement/MAY id="dotnet-lro-subclass" %} add additional APIs to subclasses of ```Operation<T>```.
 For example, some subclasses add a constructor allowing to create an operation instance from a previously saved operation ID. Also, some subclasses are more granular states besides the IsCompleted and HasValue states that are present on the base class.
+
+{% include requirement/MUST id="dotnet-lro-return" %} throw from ```Operation<T>``` subclasses in the following scenarios.
+
+* ```RequestFailedException``` or its subtype should be thrown from ```UpdateStatus```, ```WaitForCompletion```, or ```WaitForCompletionAsync``` if the operation completes with an non-success result. Include any relevant error state information in the exception details.
+* Any ```RequestFailedException```or its subtype resulting from the underlying service operation calls in ```RequestFailedException``` from ```UpdateStatus```, ```WaitForCompletion```, or ```WaitForCompletionAsync```.
+* ```RequestFailedException``` should be thrown when the ```Value``` property is evaluated before the operation is complete (```HasCompleted``` is false).
+  * The exception should be the same as what was thrown from ```UpdateStatus```, ```WaitForCompletion```, or ```WaitForCompletionAsync```.
+* ```InvalidOperationException``` should be thrown when the ```Value``` property is evaluated if the operation failed (```HasValue``` is false).
+  * The exception message should be: "The operation has not yet completed."
+
+{% include requirement/MUST id="dotnet-lro-return" %} throw ```RequestFailedException``` or its subtype when the ```Value``` property is evaluated and the operation has completed without a successful result.
 
 ### Supporting Mocking {#dotnet-mocking}
 

--- a/docs/dotnet/introduction.md
+++ b/docs/dotnet/introduction.md
@@ -507,7 +507,7 @@ BlobBaseClient client = ...
 
 {% include requirement/MUST id="dotnet-lro-return" %} throw ```InvalidOperationException``` when the ```Value``` property is evaluated before the operation is complete (```HasCompleted``` is false).
 
-{% include requirement/MUSTNOT id="dotnet-namespaces-location" %} throw from an LRO except for when evaluating the ```Value``` property as described above.
+{% include requirement/MUSTNOT id="dotnet-namespaces-location" %} throw from ```UpdateStatus```, ```WaitForCompletion```, or ```WaitForCompletionAsync```.
 
 {% include requirement/MUST id="dotnet-lro-return" %} throw ```RequestFailedException``` or its subtype when the ```Value``` property is evaluated and the operation has completed without a successful result.
 

--- a/docs/dotnet/introduction.md
+++ b/docs/dotnet/introduction.md
@@ -507,6 +507,8 @@ BlobBaseClient client = ...
 
 {% include requirement/MUST id="dotnet-lro-return" %} throw ```InvalidOperationException``` when the ```Value``` property is evaluated before the operation is complete (```HasCompleted``` is false).
 
+{% include requirement/MUSTNOT id="dotnet-namespaces-location" %} throw from an LRO except for when evaluating the ```Value``` property as described above.
+
 {% include requirement/MUST id="dotnet-lro-return" %} throw ```RequestFailedException``` or its subtype when the ```Value``` property is evaluated and the operation has completed without a successful result.
 
 {% include requirement/MAY id="dotnet-lro-subclass" %} add additional APIs to subclasses of ```Operation<T>```.


### PR DESCRIPTION
# Summary
The focus of this proposed change is to provide more clarity to the behavior of the `Value` property of `Operation<T>`, specifically with regard to exceptions.

This guidance is currently implied only in the code LRO code example and the exception behavior comes up frequently in code reviews.