### PR TITLE
Hide Microsoft.Extensions.Azure until next GA

### DIFF
--- a/_data/releases/latest/dotnet-packages.csv
+++ b/_data/releases/latest/dotnet-packages.csv
@@ -427,7 +427,7 @@
 "Microsoft.Azure.EventHubs","4.3.1","","Event Hubs","Event Hubs","eventhub","","","client","false","","Replaced by: Azure.Messaging.EventHubs"
 "Microsoft.Azure.EventHubs.Processor","4.3.1","","Event Hubs - Processor","Event Hubs","eventhub","NA","","client","false","","Replaced by: Azure.Messaging.EventHubs.Processor"
 "Microsoft.Azure.EventHubs.ServiceFabricProcessor","0.5.4","","Event Hubs - Service Fabric Processor","Event Hubs","eventhub","NA","NA","client","false","",""
-"Microsoft.Extensions.Azure","1.0.0","1.1.0-beta.1","Extensions - Azure","Extensions","extensions","NA","","client","false","",""
+"Microsoft.Extensions.Azure","1.0.0","1.1.0-beta.1","Extensions - Azure","Extensions","extensions","NA","","client","false","true",""
 "Microsoft.Extensions.Caching.Cosmos","","1.0.0-preview5","Extensions - Caching Cosmos","Cosmos DB","https://github.com/Azure/Microsoft.Extensions.Caching.Cosmos/tree/v1.0.0-preview4","NA","NA","client","false","",""
 "Microsoft.Azure.CognitiveServices.FormRecognizer","","0.8.0-preview","Form Recognizer","Form Recognizer","https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/cognitiveservices/FormRecognizer","NA","NA","client","false","","Replaced by: Azure.AI.FormRecognizer"
 "Microsoft.Azure.Functions.Extensions","1.1.0","1.1.0-preview1","Functions - Extensions","Functions","https://github.com/Azure/azure-functions-dotnet-extensions","NA","NA","client","false","",""


### PR DESCRIPTION
Microsoft.Extensions.Azure moved from core to extensions directory
between 1.0.0 GA and 1.1.0-beta.1 and so those 2 versions have different 
source patterns and thus we cannot have valid links for both of them in 
the index system, so for now until 1.1.0 GA's we are hiding this package from the index. 

FYI @pakrym