### PR TITLE
avoid expanding the preview buttons and wrap them

### DIFF
--- a/_includes/releases/pkgbadge.md
+++ b/_includes/releases/pkgbadge.md
@@ -1,3 +1,3 @@
 {% if include.url != "NA" %}
-<a href="{{ include.url }}"><button type="button" class="btn btn-primary {% if include.preview == 'true' %}btn-preview{% endif %}">{{ include.label }} <span class="badge">{{ include.version }}</span></button></a>
+<a href="{{ include.url }}"><button type="button" class="btn btn-primary {% if include.preview == 'true' %}btn-preview{% endif %}">{{ include.label }} <span class="badge {% if include.preview == 'true' %}badge-preview{% endif %}">{{ include.version }}</span></button></a>
 {% endif %}

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -1320,8 +1320,13 @@ h4.panel-title {
 }
 
 .btn-preview {
+  align-items: center;
   background-color: #a9a9a9;
   border-color: #a9a9a9;
+  display: flex;
+  flex-wrap: wrap;
+  flex-flow: column;
+  margin-top: 4px;
 }
 
 .btn-preview:hover {
@@ -1333,4 +1338,8 @@ h4.panel-title {
   border-radius: 4px;
   margin-left: 3px;
   font-size: 10px;
+}
+
+.badge-preview {
+  margin-left: 0px;
 }


### PR DESCRIPTION
Suggested change for the team to consider and maybe vote.

Motivation: Trying to make the table smaller for mobile view and small screens.

fixes: https://github.com/Azure/azure-sdk/issues/2022

After the fix, the table looks like:
![image](https://user-images.githubusercontent.com/24213737/99010985-e7412a00-24ff-11eb-8fed-48cdf7fac1ae.png)


Instead of looking like:
![image](https://user-images.githubusercontent.com/24213737/99011038-0344cb80-2500-11eb-933d-35fdcae88c55.png)
