### PR TITLE
Update release notes of spring boot

### DIFF
--- a/releases/2020-11/java.md
+++ b/releases/2020-11/java.md
@@ -624,20 +624,6 @@ and key phrases extraction) simultaneously in a list of document.
 
 #### Breaking Changes
 
-*   Conditional access policy is not supported temporary, we may recover it in the future.
-*   Configuration items like `spring.security.oauth2.client.xxx` is not supported anymore. Please use the following configuration items instead:
-    
-    ```
-    azure.activedirectory.tenant-id=xxxxxx-your-tenant-id-xxxxxx
-    azure.activedirectory.client-id=xxxxxx-your-client-id-xxxxxx
-    azure.activedirectory.client-secret=xxxxxx-your-client-secret-xxxxxx
-    azure.activedirectory.user-group.allowed-groups=group1, group2
-    azure.activedirectory.scope = your-customized-scope1, your-customized-scope2
-    azure.activedirectory.redirect-uri-template=xxxxxx-your-redirect-uri-xxxxxx
-    
-    ```
-    
-*   Check scope parameter for AAD authorization requests before configuration. Necessary permissions would be automatically added if needed.
 *   Update `com.azure` group id to `com.azure.spring`.
 *   Deprecated azure-spring-boot-metrics-starter.
 *   Change group id from `com.microsoft.azure` to `com.azure.spring`.


### PR DESCRIPTION
Remove aad related release notes because the release of AAD starter was cancelled, refering to https://github.com/Azure/azure-sdk-for-java/pull/17820