### PR TITLE
Fix script sorting

### DIFF
--- a/_data/releases/latest/java-packages.csv
+++ b/_data/releases/latest/java-packages.csv
@@ -11,7 +11,7 @@
 "azure-core-http-netty","com.azure","1.7.0","","Core - HTTP Netty","Core","core","","","client","true","",""
 "azure-core-http-okhttp","com.azure","1.4.0","","Core - HTTP OkHttp","Core","core","","","client","true","",""
 "azure-core-test","com.azure","1.5.1","","Core - Test","Core","core","","","client","true","",""
-"azure-core-tracing-opencensus","com.azure","","1.0.0-preview.4","Core - Tracing OpenCensus","Core","core","NA","","client","true","",""
+"azure-core-tracing-opencensus","com.azure","","1.0.0-preview.4","Core - Tracing OpenCensus","Core","core","NA","","client","false","false","Renamed to azure-core-tracing-opentelemetry before GA"
 "azure-core-experimental","com.azure","","1.0.0-beta.8","Core Experimental","Core","core","","","client","true","",""
 "azure-core-serializer-avro-apache","com.azure","","1.0.0-beta.5","Core Serializer Apache Avro","Core","core","","","client","true","",""
 "azure-core-serializer-avro-jackson","com.azure","","1.0.0-beta.1","Core Serializer Apache Jackson","Core","core","","","client","true","",""

--- a/eng/scripts/Update-DevOps-WorkItems.ps1
+++ b/eng/scripts/Update-DevOps-WorkItems.ps1
@@ -947,7 +947,7 @@ function UpdateShippedPackageVersion($pkgWorkItem, $versionsFromTags)
   }
 
   # Full merged version set
-  $versionList = $versionSet.Values | Sort-Object Date -Descending
+  $versionList = $versionSet.Values | Sort-Object Date, Version -Descending
 
   $versionFieldUpdates = GetTextVersionFields $versionList $pkgWorkItem
 


### PR DESCRIPTION
If we release more then one version in a day the script can sometimes
cause the order to be alternating so sort by version as well.

Mark one more java package as replaced to remove it from the list
we process.