### PR TITLE
Remove special handling for .net Github IO path

### DIFF
--- a/_includes/releases/variables/dotnet.md
+++ b/_includes/releases/variables/dotnet.md
@@ -2,5 +2,5 @@
 {% assign package_trim = "Azure." %}
 {% assign package_url_template = "https://www.nuget.org/packages/item.Package/item.Version" %}
 {% assign msdocs_url_template = "https://docs.microsoft.com/dotnet/api/overview/azure/item.TrimmedPackage-readme" %}
-{% assign ghdocs_url_template = "https://azuresdkdocs.blob.core.windows.net/$web/dotnet/item.Package/item.Version/api/index.html" %}
+{% assign ghdocs_url_template = "https://azuresdkdocs.blob.core.windows.net/$web/dotnet/item.Package/item.Version/index.html" %}
 {% assign source_url_template = "https://github.com/Azure/azure-sdk-for-net/tree/item.Package_item.Version/sdk/item.RepoPath/item.Package/" %}

--- a/eng/scripts/Update-Release-Versions.ps1
+++ b/eng/scripts/Update-Release-Versions.ps1
@@ -62,7 +62,6 @@ function UpdateDocLinks($lang, $pkg, $skipIfNA = $false)
   }
   $ghformat = "{0}/{1}"
   if ($lang -eq "javascript") { $ghformat = "azure-${trimmedPackage}/{1}" }
-  elseif ($lang -eq "dotnet") { $ghformat = "{0}/{1}/api" }
 
   $ghLinkFormat = "$azuresdkdocs/${lang}/${ghformat}/index.html"
 


### PR DESCRIPTION
We have unified .NET blob storage index.html path to align with other lang repo. There is no need of special handling here. 