### PR TITLE
[Core - HTTP] Title fix for the JavaScript work item

### DIFF
--- a/_data/releases/latest/js-packages.csv
+++ b/_data/releases/latest/js-packages.csv
@@ -6,7 +6,7 @@
 "@azure/communication-chat","","1.0.0-beta.3","Communication Chat","Communication","communication","","","client","true","",""
 "@azure/communication-common","","1.0.0-beta.3","Communication Common","Communication","communication","","","client","true","",""
 "@azure/communication-sms","","1.0.0-beta.3","Communication Sms","Communication","communication","","","client","true","",""
-"@azure/core-http","1.2.0","","Core","Core","core","","","client","true","",""
+"@azure/core-http","1.2.0","","Core - HTTP","Core","core","","","client","true","",""
 "@azure/core-amqp","2.0.0","","Core - AMQP","Core","core","","","client","true","",""
 "@azure/cosmos","3.9.3","","Cosmos DB","Cosmos DB","cosmosdb","","","client","true","",""
 "@azure/digital-twins-core","1.0.0","","Digital Twins - Core","Digital Twins","digitaltwins","","","client","true","",""


### PR DESCRIPTION
Since JavaScript doesn't have just one core package, it makes sense to move core-http out of the "Core" folder/section.