### PR TITLE
Add deputy architects to CODEOWNERS file.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,19 +45,19 @@
 #####
 
 # Engineering systems documents
-docs/android/                @JonathanGiles @annelo-msft @salameer
-docs/clang/                  @JeffreyRichter @annelo-msft @salameer
-docs/cpp/                    @JeffreyRichter @annelo-msft @salameer
-docs/dotnet/                 @KrzysztofCwalina @annelo-msft @salameer
+docs/android/                @JonathanGiles @annelo-msft @salameer @bsiegel
+docs/clang/                  @JeffreyRichter @annelo-msft @salameer @ahsonkhan
+docs/cpp/                    @JeffreyRichter @annelo-msft @salameer @RickWinter
+docs/dotnet/                 @KrzysztofCwalina @annelo-msft @salameer @tg-msft
 docs/general/                @annelo-msft @salameer
-docs/golang/                 @JeffreyRichter @annelo-msft @salameer
-docs/ios/                    @annelo-msft @salameer
-docs/java/                   @JonathanGiles @annelo-msft @salameer
-docs/policies/               @Kurtzeborn @weshaggard  @annelo @salameer
-docs/python/                 @johanste @annelo-msft @salameer
+docs/golang/                 @JeffreyRichter @annelo-msft @salameer @jhendrixMSFT
+docs/ios/                    @annelo-msft @salameer @bsiegel
+docs/java/                   @JonathanGiles @annelo-msft @salameer @srnagar
+docs/policies/               @Kurtzeborn @weshaggard @annelo @salameer
+docs/python/                 @johanste @annelo-msft @salameer @annatisch
 docs/redirects/              @kyle-patterson
 docs/tables/                 @kyle-patterson
-docs/typescript/             @bterlson @annelo-msft @salameer
+docs/typescript/             @bterlson @annelo-msft @salameer @xirzec
 eng/                         @weshaggard
 releases/                    @kyle-patterson @loarabia @czubair @jeremymeng @alzimmermsft @ShivangiReja @xiangyan99 @kinelski
 _posts/                      @kyle-patterson @loarabia


### PR DESCRIPTION
For MQ Guidelines effort.