### PR TITLE
Azure core types for JS/TS

### DIFF
--- a/docs/typescript/design.md
+++ b/docs/typescript/design.md
@@ -614,7 +614,7 @@ TODO: Please add discussion similar to the [Model Type discussion from the Gener
 
 ## Using Azure Core {#ts-core-types}
 
-{% include requirement/MUST id="ts-core-types-must %} make use of packages in Azure Core to provide behavior consistent across all Azure SDK libraries. This includes, but is not limited to:
+{% include requirement/MUST id="ts-core-types-must" %} make use of packages in Azure Core to provide behavior consistent across all Azure SDK libraries. This includes, but is not limited to:
 
 * `core-http` for http client, pipeline and related functionality
 * `logger` for logging

--- a/docs/typescript/design.md
+++ b/docs/typescript/design.md
@@ -612,7 +612,17 @@ TODO: Please add a section providing guidance on model types.
 
 TODO: Please add discussion similar to the [Model Type discussion from the General Guidelines](https://azure.github.io/azure-sdk/general_design.html#model-types), including the naming table if relevant to JS/TS, or an alternate one specific to JS/TS.  
 
-TODO: Please add a section on Azure Core type usage, which may simply link out to Azure Core documentation in the azure-sdk-for-js repo, if this is self-explanatory.
+## Using Azure Core {#ts-core-types}
+
+{% include requirement/MUST id="ts-core-types-must %} make use of packages in Azure Core to provide behavior consistent across all Azure SDK libraries. This includes, but is not limited to:
+
+* `core-http` for http client, pipeline and related functionality
+* `logger` for logging
+* `core-tracing` for distributed tracing
+* `core-auth` for common auth interfaces
+* `core-lro` for long running operations
+
+See the [Azure Core readme](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/core) for more details.
 
 TODO: Please add a section on extensible enums, if this is relevant to JS/TS.
 


### PR DESCRIPTION
At some point we will have Azure Core documentation. It is sorely needed. This work is tracked here: https://github.com/Azure/azure-sdk-for-js/issues/10239.