### PR TITLE
Remove 'will replace' notes for SB 

### DIFF
--- a/_data/releases/latest/js-packages.csv
+++ b/_data/releases/latest/js-packages.csv
@@ -22,7 +22,7 @@
 "@azure/keyvault-keys","4.1.0","4.2.0-beta.2","Key Vault - Keys","Key Vault","keyvault","","","client","true","",""
 "@azure/keyvault-secrets","4.1.0","4.2.0-beta.1","Key Vault - Secrets","Key Vault","keyvault","","","client","true","",""
 "@azure/ai-metrics-advisor","","1.0.0-beta.2","Metrics Advisor","Metrics Advisor","metricsadvisor","","","client","true","",""
-"@azure/service-bus","7.0.0","","Service Bus","Service Bus","servicebus","","","client","true","","Will be replaced by: @azure/service-bus 7.x"
+"@azure/service-bus","7.0.0","","Service Bus","Service Bus","servicebus","","","client","true","",""
 "@azure/storage-blob","12.3.0","12.4.0-beta.1","Storage - Blobs","Storage","storage","","","client","true","",""
 "@azure/storage-blob-changefeed","","12.0.0-preview.2","Storage - Blobs ChangeFeed","Storage","storage","","","client","true","",""
 "@azure/storage-file-datalake","12.2.0","12.3.0-beta.1","Storage - Files Data Lake","Storage","storage","","","client","true","",""

--- a/_data/releases/latest/python-packages.csv
+++ b/_data/releases/latest/python-packages.csv
@@ -22,7 +22,7 @@
 "azure-keyvault-secrets","4.2.0","","Key Vault - Secrets","Key Vault","keyvault","","","client","true","",""
 "azure-ai-metricsadvisor","","1.0.0b2","Metrics Advisor","Metrics Advisor","metricsadvisor","","","client","true","",""
 "microsoft-opentelemetry-exporter-azuremonitor","","1.0.0b1","Microsoft Azure Monitor Opentelemetry Exporter","Monitor","monitor","","","client","true","",""
-"azure-servicebus","7.0.0","","Service Bus","Service Bus","servicebus","","","client","true","","Will be replaced by: azure-servicebus 7.x"
+"azure-servicebus","7.0.0","","Service Bus","Service Bus","servicebus","","","client","true","",""
 "azure-storage-blob","12.6.0","12.7.0b1","Storage - Blobs","Storage","storage","","","client","true","",""
 "azure-storage-blob-changefeed","","12.0.0b2","Storage - Blobs Changefeed","Storage","storage","","","client","true","",""
 "azure-storage-file-datalake","12.2.0","","Storage - Files Data Lake","Storage","storage","","","client","true","",""


### PR DESCRIPTION
For Python and JS, the track 2 packages that just went GA are the same package as track 1 with just the major version update. So, the note on "replacing" is not needed.

Found during https://github.com/azure/azure-sdk-for-js/issues/12376 by @richardpark-msft 