### PR TITLE
"lro" to "LRO" on js-packages.csv

### DIFF
--- a/_data/releases/latest/js-packages.csv
+++ b/_data/releases/latest/js-packages.csv
@@ -441,7 +441,7 @@
 "@azure/core-auth","1.1.3","","Core - Auth","Core","core","","","client","false","",""
 "@azure/core-client","","1.0.0-alpha.20200925.1","Core - Client","Core","NA","NA","NA","client","false","",""
 "@azure/core-https","","1.0.0-alpha.20200925.1","Core - Https","Core","NA","NA","NA","client","false","",""
-"@azure/core-lro","1.0.2","","Core - lro","Core","core","NA","","client","false","",""
+"@azure/core-lro","1.0.2","","Core - LRO","Core","core","NA","","client","false","",""
 "@azure/core-paging","1.1.3","","Core - Paging","Core","core","","","client","false","",""
 "@azure/core-tracing","","1.0.0-preview.9","Core - Tracing","Core","core","NA","","client","false","",""
 "@azure/core-xml","","1.0.0-alpha.20200925.1","Core - XML","Core","NA","NA","NA","client","false","",""


### PR DESCRIPTION
"LRO" makes more sense to me than "lro".

In case anybody reads this and is unaware of the context, LRO means Long Running Operations.