### PR TITLE
Update guidelines for logger and fluent setter method for subclasses

### DIFF
--- a/docs/android/implementation.md
+++ b/docs/android/implementation.md
@@ -255,7 +255,7 @@ This happens within azure-core by default, but users can configure this through 
 
 {% include requirement/MUST id="android-logging-exceptions" %} log thrown exceptions at the `Logger.warning` level. If the log level is set to `debug`, append stack trace information to the message.
 
-{% include requirement/MUST id="android-logging-log-and-throw" %} throw all exceptions created within the client library code through one of the logger APIs - `ClientLogger.logThrowableAsError()`, `ClientLogger.logExceptionAsError()` or `ClientLogger.logExceptionAsWarning()`.
+{% include requirement/MUST id="android-logging-log-and-throw" %} throw all exceptions created within the client library code through one of the logger APIs - `ClientLogger.logThrowableAsError()`, `ClientLogger.logThrowableAsWarning()`, `ClientLogger.logExceptionAsError()` or `ClientLogger.logExceptionAsWarning()`.
 
 For example:
 

--- a/docs/android/implementation.md
+++ b/docs/android/implementation.md
@@ -255,7 +255,7 @@ This happens within azure-core by default, but users can configure this through 
 
 {% include requirement/MUST id="android-logging-exceptions" %} log thrown exceptions at the `Logger.warning` level. If the log level is set to `debug`, append stack trace information to the message.
 
-{% include requirement/MUST id="android-logging-log-and-throw" %} throw all exceptions created within the client library code through the `ClientLogger.logAndThrow()` API.
+{% include requirement/MUST id="android-logging-log-and-throw" %} throw all exceptions created within the client library code through one of the logger APIs - `ClientLogger.logThrowableAsError()`, `ClientLogger.logExceptionAsError()` or `ClientLogger.logExceptionAsWarning()`.
 
 For example:
 
@@ -266,8 +266,20 @@ if (priority != null && priority < 0) {
 }
 
 // Good
+
+// Log any Throwable as error and throw the exception
+if (!file.exists()) {
+    throw logger.logThrowableAsError(new IOException("File does not exist " + file.getName()));
+}
+
+// Log a RuntimeException as error and throw the exception
 if (priority != null && priority < 0) {
-    logger.logAndThrow(new IllegalArgumentException("'priority' cannot be a negative value. Please specify a zero or positive long value."));
+    throw logger.logExceptionAsError(new IllegalArgumentException("'priority' cannot be a negative value. Please specify a zero or positive long value."));
+}
+
+// Log a RuntimeException as warning and throw the exception
+if (numberOfAttempts < retryPolicy.getMaxRetryCount()) {
+    throw logger.logExceptionAsWarning(new RetryableException("A transient error occurred. Another attempt will be made after " + retryPolicy.getDelay()));
 }
 ```
 

--- a/docs/android/implementation.md
+++ b/docs/android/implementation.md
@@ -272,6 +272,11 @@ if (!file.exists()) {
     throw logger.logThrowableAsError(new IOException("File does not exist " + file.getName()));
 }
 
+// Log any Throwable as warning and throw the exception
+if (!file.exists()) {
+    throw logger.logThrowableAsWarning(new IOException("File does not exist " + file.getName()));
+}
+
 // Log a RuntimeException as error and throw the exception
 if (priority != null && priority < 0) {
     throw logger.logExceptionAsError(new IllegalArgumentException("'priority' cannot be a negative value. Please specify a zero or positive long value."));

--- a/docs/java/implementation.md
+++ b/docs/java/implementation.md
@@ -151,6 +151,11 @@ if (!file.exists()) {
     throw logger.logThrowableAsError(new IOException("File does not exist " + file.getName()));
 }
 
+// Log any Throwable as warning and throw the exception
+if (!file.exists()) {
+    throw logger.logThrowableAsWarning(new IOException("File does not exist " + file.getName()));
+}
+
 // Log a RuntimeException as error and throw the exception
 if (priority != null && priority < 0) {
     throw logger.logExceptionAsError(new IllegalArgumentException("'priority' cannot be a negative value. Please specify a zero or positive long value."));

--- a/docs/java/implementation.md
+++ b/docs/java/implementation.md
@@ -134,7 +134,7 @@ This happens within azure-core by default, but users can configure this through 
 
 {% include requirement/MUST id="java-logging-exceptions" %} log exceptions thrown as a `Warning` level message. If the log level set to `Verbose`, append stack trace information to the message.
 
-{% include requirement/MUST id="java-logging-log-and-throw" %} throw all exceptions created within the client library code through one of the logger APIs - `ClientLogger.logThrowableAsError()`, `ClientLogger.logExceptionAsError()` or `ClientLogger.logExceptionAsWarning()`.
+{% include requirement/MUST id="java-logging-log-and-throw" %} throw all exceptions created within the client library code through one of the logger APIs - `ClientLogger.logThrowableAsError()`, `ClientLogger.logThrowableAsWarning()`, `ClientLogger.logExceptionAsError()` or `ClientLogger.logExceptionAsWarning()`.
 
 For example:
 

--- a/docs/java/implementation.md
+++ b/docs/java/implementation.md
@@ -134,7 +134,7 @@ This happens within azure-core by default, but users can configure this through 
 
 {% include requirement/MUST id="java-logging-exceptions" %} log exceptions thrown as a `Warning` level message. If the log level set to `Verbose`, append stack trace information to the message.
 
-{% include requirement/MUST id="java-logging-log-and-throw" %} throw all exceptions created within the client library code through the `ClientLogger.logAndThrow()` API.
+{% include requirement/MUST id="java-logging-log-and-throw" %} throw all exceptions created within the client library code through one of the logger APIs - `ClientLogger.logThrowableAsError()`, `ClientLogger.logExceptionAsError()` or `ClientLogger.logExceptionAsWarning()`.
 
 For example:
 
@@ -145,8 +145,20 @@ if (priority != null && priority < 0) {
 }
 
 // Good
+
+// Log any Throwable as error and throw the exception
+if (!file.exists()) {
+    throw logger.logThrowableAsError(new IOException("File does not exist " + file.getName()));
+}
+
+// Log a RuntimeException as error and throw the exception
 if (priority != null && priority < 0) {
-    logger.logAndThrow(new IllegalArgumentException("'priority' cannot be a negative value. Please specify a zero or positive long value."));
+    throw logger.logExceptionAsError(new IllegalArgumentException("'priority' cannot be a negative value. Please specify a zero or positive long value."));
+}
+
+// Log a RuntimeException as warning and throw the exception
+if (numberOfAttempts < retryPolicy.getMaxRetryCount()) {
+    throw logger.logExceptionAsWarning(new RetryableException("A transient error occurred. Another attempt will be made after " + retryPolicy.getDelay()));
 }
 ```
 

--- a/docs/java/introduction.md
+++ b/docs/java/introduction.md
@@ -799,6 +799,45 @@ public final class TextDocumentInput {
 
 {% include requirement/MUST id="java-models-fluent" %} provide a fluent setter API to configure the model class, where each `set` method should `return this`. This allows chaining of set operations.
 
+{% include requirement/MUST id="java-models-fluent" %} override the `set` methods when extending a fluent type to return the extended type to allow chaining of `set` operations on the sub-class.
+
+```java
+@Fluent
+public class SettlementOptions {
+    private ServiceBusTransactionContext transactionContext;
+
+    public ServiceBusTransactionContext getTransactionContext() {
+        return transactionContext;
+    }
+
+    public SettlementOptions setTransactionContext(ServiceBusTransactionContext transactionContext) {
+        this.transactionContext = transactionContext;
+        return this;
+    }
+}
+
+@Fluent
+public final AbandonOptions extends SettlementOptions {
+    private Map<String, Object> propertiesToModify;
+
+    public Map<String, Object> getPropertiesToModify() {
+        return propertiesToModify;
+    }
+
+    public AbandonOptions setPropertiesToModify(Map<String, Object> propertiesToModify) {
+        this.propertiesToModify = propertiesToModify;
+        return this;
+    }
+
+    // Override setter method of the parent class
+    @Override
+    public AbandonOptions setTransactionContext(ServiceBusTransactionContext transactionContext) {
+        super.setTransactionContext(transactionContext);
+        return this;
+    }
+}
+```
+
 {% include requirement/MUST id="java-models-fluent-annotation" %} apply the `@Fluent` annotation to the class.
 
 Fluent types must not be immutable.  Don't return a new instance on each setter call.

--- a/docs/java/introduction.md
+++ b/docs/java/introduction.md
@@ -799,7 +799,7 @@ public final class TextDocumentInput {
 
 {% include requirement/MUST id="java-models-fluent" %} provide a fluent setter API to configure the model class, where each `set` method should `return this`. This allows chaining of set operations.
 
-{% include requirement/MUST id="java-models-fluent" %} override ALL `set` methods when extending a fluent type to return the extended type. This allows chaining of `set` operations on the sub-class.
+{% include requirement/MUST id="java-models-fluent" %} override all `set` methods when extending a fluent type to return the extended type. This allows chaining of `set` operations on the sub-class.
 
 ```java
 @Fluent

--- a/docs/java/introduction.md
+++ b/docs/java/introduction.md
@@ -799,7 +799,7 @@ public final class TextDocumentInput {
 
 {% include requirement/MUST id="java-models-fluent" %} provide a fluent setter API to configure the model class, where each `set` method should `return this`. This allows chaining of set operations.
 
-{% include requirement/MUST id="java-models-fluent" %} override the `set` methods when extending a fluent type to return the extended type to allow chaining of `set` operations on the sub-class.
+{% include requirement/MUST id="java-models-fluent" %} override ALL `set` methods when extending a fluent type to return the extended type. This allows chaining of `set` operations on the sub-class.
 
 ```java
 @Fluent


### PR DESCRIPTION
This PR updates:
- logging guidelines to use the correct APIs. The current guideline refers to `ClientLogger.logAndThrow()` API which does not exist in `ClientLogger`. This PR changes the codesnippet in the guideline to use APIs that exist in `ClientLogger` like `logExceptionAs*` and `logThrowableAs*`.

- fluent setter method guidelins for subclasses
