### PR TITLE
Establish standard structure for release-templates

### DIFF
--- a/eng/scripts/release-template/dotnet.md
+++ b/eng/scripts/release-template/dotnet.md
@@ -6,27 +6,33 @@ sidebar: releases_sidebar
 repository: azure/azure-sdk-for-net
 ---
 
+<!--
+[pattern]: # (${PackageName}:${PackageVersion})
+-->
+
 The Azure SDK team is pleased to announce our %%MMMM yyyy%% client library releases.
 
 #### GA
 
-- _Add packages_
+[pattern.ga]: # (- ${PackageFriendlyName})
 
 #### Updates
 
-- _Add packages_
+[pattern.patch]: # (- ${PackageFriendlyName})
 
 #### Beta
 
-- _Add packages_
+[pattern.beta]: # (- ${PackageFriendlyName})
 
 ## Installation Instructions
 
 To install any of our packages, please search for them via `Manage NuGet Packages...` in Visual Studio (with `Include prerelease` checked) or copy these commands into your terminal:
 
 ```bash
-$> dotnet install PACKAGE --version whatever
+
 ```
+
+[pattern]: # ($> dotnet install ${PackageName} --version ${PackageVersion})
 
 ## Feedback
 
@@ -34,9 +40,7 @@ If you have a bug or feature request for one of the libraries, please [file an i
 
 ## Release highlights
 
-### _Package name_ 
-
-- Major changes only!!!
+[pattern]: # (### ${PackageFriendlyName} ${PackageVersion} [Changelog]${ChangelogUrl}`n${HighlightsBody}`n)
 
 ## Latest Releases
 

--- a/eng/scripts/release-template/java.md
+++ b/eng/scripts/release-template/java.md
@@ -6,27 +6,33 @@ sidebar: releases_sidebar
 repository: azure/azure-sdk-for-java
 ---
 
+<!--
+[pattern]: # (${PackageName}:${PackageVersion})
+-->
+
 The Azure SDK team is pleased to announce our %%MMMM yyyy%% client library releases.
 
 #### GA
 
-- _Add packages_
+[pattern.ga]: # (- ${PackageFriendlyName})
 
 #### Updates
 
-- _Add packages_
+[pattern.patch]: # (- ${PackageFriendlyName})
 
 #### Beta
 
-- _Add packages_
+[pattern.beta]: # (- ${PackageFriendlyName})
 
 ## Installation Instructions
 
 To use the GA and beta libraries, refer to the Maven dependency information below, which may be copied into your projects Maven `pom.xml` file as appropriate. If you are using a different build tool, refer to its documentation on how to specify dependencies.
 
 ```xml
-<!-- Insert dependencies -->
+
 ```
+
+[pattern]: # (<dependency>`n  <groupId>${GroupId}</groupId>`n  <artifactId>${PackageName}</artifactId>`n  <version>${PackageVersion}</version>`n</dependency>`n`n)
 
 ## Feedback
 
@@ -34,10 +40,8 @@ If you have a bug or feature request for one of the libraries, please post an is
 
 ## Release highlights
 
-### _Package name_
+[pattern]: # (### ${PackageFriendlyName} ${PackageVersion} [Changelog]${ChangelogUrl}`n${HighlightsBody}`n)
 
-- Major changes only!
-  
 ## Need help
 
 - For reference documentation visit the [Azure SDK for Java documentation](https://azure.github.io/azure-sdk-for-java/).

--- a/eng/scripts/release-template/js.md
+++ b/eng/scripts/release-template/js.md
@@ -6,27 +6,33 @@ sidebar: releases_sidebar
 repository: azure/azure-sdk-for-js
 ---
 
+<!--
+[pattern]: # (${PackageName}:${PackageVersion})
+-->
+
 The Azure SDK team is pleased to make available the %%MMMM yyyy%% client library release.
 
 #### GA
 
-- _Add packages_
+[pattern.ga]: # (- ${PackageFriendlyName})
 
 #### Updates
 
-- _Add packages_
+[pattern.patch]: # (- ${PackageFriendlyName})
 
 #### Beta
 
-- _Add packages_
+[pattern.beta]: # (- ${PackageFriendlyName})
 
 ## Installation Instructions
 
 To install the packages, copy and paste the below into a terminal.
 
 ```bash
-$> npm install @azure/package-name
+
 ```
+
+[pattern]: # ($> npm install ${PackageName}@${PackageVersion})
 
 ## Feedback
 
@@ -34,9 +40,7 @@ If you have a bug or feature request for one of the libraries, please post an is
 
 ## Release highlights
 
-### _Package name_
-
-- Major changes only!
+[pattern]: # (### ${PackageFriendlyName} ${PackageVersion} [Changelog]${ChangelogUrl}`n${HighlightsBody}`n)
 
 ## Latest Releases
 

--- a/eng/scripts/release-template/python.md
+++ b/eng/scripts/release-template/python.md
@@ -6,27 +6,33 @@ sidebar: releases_sidebar
 repository: azure/azure-sdk-for-python
 ---
 
+<!--
+[pattern]: # (${PackageName}:${PackageVersion})
+-->
+
 The Azure SDK team is pleased to make available the %%MMMM yyyy%% client library release.
 
 #### GA
 
-- _Add packages_
+[pattern.ga]: # (- ${PackageFriendlyName})
 
 #### Updates
 
-- _Add packages_
+[pattern.patch]: # (- ${PackageFriendlyName})
 
 #### Beta
 
-- _Add packages_
+[pattern.beta]: # (- ${PackageFriendlyName})
 
 ## Installation Instructions
 
 To install the latest beta version of the packages, copy and paste the following commands into a terminal:
 
 ```bash
-$> pip install azure-packagename
+
 ```
+
+[pattern]: # ($> pip install ${PackageName}==${PackageVersion})
 
 ## Feedback
 
@@ -34,9 +40,7 @@ If you have a bug or feature request for one of the libraries, please post an is
 
 ## Release highlights
 
-### _Package name_
-
-- Major changes only!
+[pattern]: # (### ${PackageFriendlyName} ${PackageVersion} [Changelog]${ChangelogUrl}`n${HighlightsBody}`n)
 
 ## Latest Releases
 


### PR DESCRIPTION
- Rename `eng/scripts/release-template/js.md` to `eng/scripts/release-template/javascript.md`
- Fill in each `eng/scripts/release-template/language.md` using the the template package for that language.

- We might consider using friendly names for the packages in some places, but we might need a standard mapping for automating conversion from the standard package name to a friendly name.