### PR TITLE
Refactor Go design guidelines

### DIFF
--- a/docs/golang/design.md
+++ b/docs/golang/design.md
@@ -178,8 +178,8 @@ TODO
 ```go
 // GetWidgetOptions contains the optional parameters for the Widget.Get method.
 type GetWidgetOptions struct {
-	OptionalTag *string
-	OptionalLength *int
+	Tag *string
+	Length *int
 }
 
 // SetWidgetOptions contains the optional parameters for the Widget.Set method.

--- a/docs/golang/design.md
+++ b/docs/golang/design.md
@@ -8,95 +8,11 @@ sidebar: general_sidebar
 
 {% include draft.html content="The Go Language guidelines are in DRAFT status" %}
 
-# Packages
+## Azure SDK API Design
 
-Go groups related types in a package.  In Go, the package should be named `<prefix><service>`, where `<prefix>` is either `arm` or `az`, and where `<service>` is the service name represented as a single word.
+Azure services will be exposed to Go developers as one or more _service client_ types and a set of _supporting types_.
 
-{% include requirement/MUST id="golang-package-prefix" %} start the package with `arm` or `az` to indicate an Azure client package.  Use `arm` for management-plane packages, and `az` for all other packages.
-
-{% include requirement/MUST id="golang-package-name" %} construct the package name with all lowercase letters (uppercase letters, hyphens and underscores are not allowed). For example, the Azure compute management package would be named `armcompute` and the Azure blob storage package would be named `azblob`.
-
-{% include requirement/MUST id="golang-package-registration" %} register the chosen package name with the [Architecture Board]. Open an issue to request the package name. See the [registered package list](registered_namespaces.html) for a list of the currently registered packages.
-
-## Directory Structure
-
-{% include requirement/MUST id="golang-pkgpath-construction" %} construct a package import path that allows the consumer to tie its packages to the service being used. The package path does **NOT** change when the branding of the product changes. Avoid the use of marketing names that may change.
-
-{% include requirement/MUST id="golang-pkgpath-leaf" %} ensure that the package leaf directory name matches the package name declared in the source code.
-
-{% include requirement/MUST id="golang-pkgpath-apiver" %} ensure that each service API version is in its own directory, IFF that service supports multiple API versions.
-
-{% include requirement/MUST id="golang-pkgpath-mgmt" %} place the management (Azure Resource Manager) API in the `arm` path. Use the grouping `./sdk/arm/<group>/<api-version>/arm<service>` for the package path. Since more services require management APIs than data plane APIs, other paths may be used explicitly for management only. Data plane usage is by exception only. Additional paths that can be used for control plane SDKs include:
-
-{% include tables/mgmt_namespaces.md %}
-
-Many management APIs do not have a data plane because they deal with management of the Azure account. Place the management package in the `arm` path. For example, use `sdk/arm/costanalysis/...` instead of `sdk/arm/management/costanalysis`.
-
-Here is a complete example.
-
-Data-plane packages:
-
-- github.com/Azure/azure-sdk-for-go/sdk/keyvault/7.0/azkeyvault
-- github.com/Azure/azure-sdk-for-go/sdk/storage/blob/2019-12-19/azblob
-- github.com/Azure/azure-sdk-for-go/sdk/storage/queue/2019-12-19/azqueue
-- github.com/Azure/azure-sdk-for-go/sdk/storage/table/2019-12-19/aztable
-
-Management-plane packages:
-
-- github.com/Azure/azure-sdk-for-go/sdk/arm/keyvault/2019-09-01/armkeyvault
-- github.com/Azure/azure-sdk-for-go/sdk/arm/storage/2019-01-01/armstorage
-- github.com/Azure/azure-sdk-for-go/sdk/arm/storage/2019-02-01/armstorage
-
-## Versioning
-
-{% include requirement/MUST id="golang-versioning-modules" %} release each package as a [Go module](https://blog.golang.org/using-go-modules).  Legacy dependency management tools such as `dep` and `glide` are not supported.
-
-{% include requirement/MUST id="golang-versioning-semver" %} release versions of modules in accordance with [semver 2.0](https://semver.org/spec/v2.0.0.html).
-
-{% include requirement/MUST id="golang-versioning-beta" %} clearly version prerelease modules.  For new modules, use a v0 major version with no suffix (v0.1.0).  For existing modules, use a `-beta` suffix (v1.1.0-beta, v2.0.0-beta).
-
-## Dependencies
-
-Packages should strive to avoid taking dependencies on packages outside of the standard library for the following reasons:
-
-- **Versioning** - Exposing types defined outside the standard library (i.e. `exchange types`) can indroduce versioning complexity.  If we have an client package that exposes types from a v3 of package Foo and the consumer wants to use v5 of package Foo, then the consumer cannot use the v5 types to satisfy the v3 requirement.
-- **Size** - Consumer applications must be able to deploy as fast as possible into the cloud and move in various ways across networks. Removing additional code (like dependencies) improves deployment performance.
-- **Licensing** - You must be conscious of the licensing restrictions of a dependency and often provide proper attribution and notices when using them.
-- **Compatibility** - Often times you do not control a dependency and it may choose to evolve in a direction that is incompatible with your original use.
-- **Security** - If a security vulnerability is discovered in a dependency, it may be difficult or time consuming to get the vulnerability corrected if Microsoft does not control the dependency's code base.
-
-{% include requirement/MUST id="golang-dependencies-exch-types" %} limit exchange types to those provided by the standard library (**NO EXCEPTIONS**).
-
-{% include requirement/MUST id="golang-dependencies-azure-core" %} depend on the `azcore` package for functionality that is common across all client packages.  This package includes APIs for HTTP connectivity, global configuration, logging, credential handling, and more.
-
-{% include requirement/MUST id="golang-dependencies-azure-core" %} depend on the `sdk/internal` package for functionality that is common across all client packages that should not be publicly exported.  This package includes helpers for creating errors with stack frame information, and more.
-
-{% include requirement/MUSTNOT id="golang-dependencies-approved-list" %} be dependent on any other packages within the client package distribution package, with the exception of the following:
-
-{% include_relative approved_dependencies.md %}
-
-## Service-Specific Common Packages
-
-There are occasions when common code needs to be shared between several client packages. For example, a set of cooperating client packages may wish to share a set of exceptions or models.
-
-{% include requirement/MUST id="golang-commonlib-approval" %} gain [Architecture Board] approval prior to implementing a common package.
-
-{% include requirement/MUST id="golang-commonlib-minimize-code" %} minimize the code within a common package. Code within the common package is treated the same as any other client package.
-
-{% include requirement/MUST id="golang-commonlib-namespace" %} store the common package in the same directory as the associated client packages.
-
-A common package will only be approved if:
-
-* The consumer of the non-shared package will consume the objects within the common package directly, AND
-* The information will be shared between multiple client package.
-
-Let's take two examples:
-
-1. Implementing two Cognitive Services client packages, we find a model is required that is produced by one Cognitive Services client package and consumed by another Coginitive Services client package, or the same model is produced by two client packages. The consumer is required to do the passing of the model in their code, or may need to compare the model produced by one client package vs. that produced by another client package. This is a good candidate for choosing a common package.
-
-2. Two Cognitive Services client packages return a `BoundingBox` model to indicate where an object was detected in an image. There is no linkage between the `BoundingBox` model in each client package, and it is not passed into another client package. This is not a good candidate for creation of a common package (although you may wish to place this model in a common package if one exists for the namespace already). Instead, produce two different models - one in each client package.
-
-# Service Clients
+### Service Clients
 
 Your API surface consists of one or more service clients that the consumer instantiates to connect to your service, plus a set of supporting types.
 
@@ -108,11 +24,7 @@ type WidgetClient struct {
 }
 ```
 
-{% include requirement/MUST id="golang-api-service-client-immutable" %} ensure that all service client types are safe for concurrent use by multiple goroutines.  Ideally, all client state is immutable which will satisfy this guideline.
-
-{% include requirement/MUSTNOT id="golang-api-service-client-fields" %} export any fields on client types.  This is to support mocking of clients via interface types.
-
-## Service Client Constructors
+#### Service Client Constructors
 
 {% include requirement/MUST id="golang-client-constructors" %} provide two constructors in the following format that return a new instance of a service client type.  Constructors MUST return the client instance by reference.
 
@@ -146,32 +58,29 @@ func NewDefaultClient(cred azcore.Credential, options *ClientOptions) (*WidgetCl
 
 {% include requirement/MUST id="golang-client-constructors-params" %} document all constructor parameters as part of the method block comment.
 
-## Authentication and Credentials
+##### Service Client Configuration
 
-Azure services use different kinds of authentication schemes to allow clients to access the service. Conceptually, there are two entities responsible in this process: a credential and an authentication policy. Credentials provide confidential authentication data. Authentication policies use the data provided by a credential to modify an HTTP request before it is sent to the service.
+TODO
 
-{% include requirement/MUST id="golang-auth-support" %} support all authentication techniques that the service supports.
+##### Setting the Service Version
 
-{% include requirement/MUST id="golang-auth-use-azidentity" %} use credential and authentication policy implementations from the `azcore` or `azidentity` package where available.
+TODO
 
-{% include requirement/MUST id="golang-auth-concurrency" %} provide credential types that can be used to fetch all data needed to authenticate a request to the service. If using a service-specific credential type, the implementation must be safe for concurrent use by multiple goroutines.
+##### Client Immutability
 
-{% include requirement/MUSTNOT id="golang-auth-connection-strings" %} support constructing a service client with a connection string unless such connection string is available within tooling (e.g. Azure portal, for copy/paste operations). A connection string is a combination of an endpoint, credential data, and other options used to simplify service client configuration. Connection strings are easily integrated into an application by copy/paste from the portal. However, credentials within a connection string can’t be rotated within a running process. Their use should be discouraged in production apps.  If the client library supports connection strings, the constructor should look like this:
+{% include requirement/MUST id="golang-api-service-client-immutable" %} ensure that all service client types are safe for concurrent use by multiple goroutines.  Ideally, all client state is immutable which will satisfy this guideline.
 
-```go
-// NewWidgetClientFromConnectionString creates a new instance of WidgetClient with the specified values.  It uses the default pipeline configuration.
-func NewWidgetClientFromConnectionString(con string, options *WidgetClientOptions) (*WidgetClient, error) {
-	// ...
-}
-```
+{% include requirement/MUSTNOT id="golang-api-service-client-fields" %} export any fields on client types.  This is to support mocking of clients via interface types.
 
-When implementing authentication, don't open up the consumer to security holes like PII (personally identifiable information) leakage or credential leakage. Credentials are generally issued with a time limit, and must be refreshed periodically to ensure that the service connection continues to function as expected. Ensure your client library follows all current security recommendations and consider an independent security review of the client library to ensure you're not introducing potential security problems for the consumer.
+#### Service Methods
 
-{% include requirement/MUSTNOT id="golang-auth-persistence" %} persist, cache, or reuse security credentials. Security credentials should be considered short lived to cover both security concerns and credential refresh situations.
+_Service methods_ are the methods on the client that invoke operations on the service.
 
-{% include requirement/MUST id="golang-auth-policy-impl" %} provide a suitable authentication policy if your service implements a non-standard authentication system (that is, an authentication system that is not supported by Azure Core).  You also need to produce an authentication policy for the HTTP pipeline that can add credentials to requests given the alternative authentication mechanism provided by the service.  Custom credentials will need to implement the `azcore.Credentials` interface.
+##### Sync and Async
 
-## Service Methods
+The Go idiom is to expose only synchronous methods.  This allows callers to implement asynchronous calls as appropriate for their use-case.
+
+##### Naming
 
 {% include requirement/MUST id="golang-client-crud-verbs" %} prefer the use of the following terms for CRUD operations:
 
@@ -188,54 +97,7 @@ When implementing authentication, don't open up the consumer to security holes l
 
 {% include requirement/MUSTNOT id="golang-api-multimethods" %} provide multiple methods for a single REST endpoint.
 
-## Service Method Parameters
-
-{% include requirement/MUST id="golang-api-service-client-byref" %} ensure that all methods on client types pass their receiver by reference.
-
-{% include requirement/MUST id="golang-api-context" %} accept a `context.Context` object as the first parameter to every method that performs any I/O operations.
-
-{% include requirement/MUST id="golang-api-mandatory-params" %} have every I/O method accept all required parameters after the mandatory `context.Context` object.
-
-{% include requirement/MUST id="golang-api-options-struct" %} define a `<MethodNameOptions>` structure for every method.  This structure includes fields for all non-mandatory parameters. The structure can have fields added to it over time to simplify versioning.  To disambiguate names, use the client type name for a prefix.  If the method contains no optional parameters, the `options` struct should have a comment indicating it's a placeholder for future optional parameters.
-
-```go
-// GetWidgetOptions contains the optional parameters for the Widget.Get method.
-type GetWidgetOptions struct {
-	OptionalTag *string
-	OptionalLength *int
-}
-
-// SetWidgetOptions contains the optional parameters for the Widget.Set method.
-type SetWidgetOptions struct {
-	// placeholder for future optional parameters
-}
-```
-
-{% include requirement/MUST id="golang-api-options-ptr" %} allow the user to pass a pointer to the structure as the last parameter. If the user passes `nil`, then the method should assume appropriate default values for all the structure’s fields.  Note that `nil` and a zero-initialized `<MethodNameOptions>` structure are **NOT** required to be semantically equivalent.
-
-{% include requirement/MUST id="golang-api-params" %} document all parameters as part of the method block comment.
-
-```go
-// GetWidget retrieves the specified Widget.
-// ctx - The context used to control the lifetime of the request.
-// name - The name of the Widget to retrieve.
-// options - Any optional parameters.
-func (c *WidgetClient) GetWidget(ctx context.Context, name string, options *GetWidgetOptions) (WidgetResponse, error) {
-	// ...
-}
-```
-
-### Parameter Validation
-
-The service client will have several methods that perform requests on the service. _Service parameters_ are directly passed across the wire to an Azure service. _Client parameters_ are not passed directly to the service, but used within the client library to fulfill the request.  Examples of client parameters include values that are used to construct a URI, or a file that needs to be uploaded to storage.
-
-{% include requirement/MUST id="golang-params-client-validation" %} validate client parameters.
-
-{% include requirement/MUSTNOT id="golang-params-service-validation" %} validate service parameters. This includes null checks, empty strings, and other common validating conditions. Let the service validate any request parameters.
-
-{% include requirement/MUST id="golang-params-devex" %} validate the developer experience when the service parameters are invalid to ensure appropriate error messages are generated by the service. If the developer experience is compromised due to service-side error messages, work with the service team to correct prior to release.
-
-## Service Method Return Types
+##### Return Types
 
 Requests to the service fall into two basic groups: methods that make a single logical request, and methods that make a deterministic sequence of requests. An example of a _single logical request_ is a request that may be retried inside the operation. An example of a _deterministic sequence of requests_ is a paged operation.
 
@@ -293,7 +155,64 @@ Model structures are types that consumers use to provide required information in
 
 {% include requirement/MUST id="golang-model-types-ro" %} document all read-only fields and exclude their values when marshalling the structure to be sent over the wire.
 
-## Pagination Methods
+##### Cancellation
+
+TODO
+
+##### Thread Safety
+
+{% include requirement/MUST id="golang-methods-thread-safety" %} be safe for concurrent use across multiple goroutines.
+
+#### Service Method Parameters
+
+{% include requirement/MUST id="golang-api-service-client-byref" %} ensure that all methods on client types pass their receiver by reference.
+
+{% include requirement/MUST id="golang-api-context" %} accept a `context.Context` object as the first parameter to every method that performs any I/O operations.
+
+{% include requirement/MUST id="golang-api-mandatory-params" %} have every I/O method accept all required parameters after the mandatory `context.Context` object.
+
+##### Optional Parameters
+
+{% include requirement/MUST id="golang-api-options-struct" %} define a `<MethodNameOptions>` structure for every method.  This structure includes fields for all non-mandatory parameters. The structure can have fields added to it over time to simplify versioning.  To disambiguate names, use the client type name for a prefix.  If the method contains no optional parameters, the `options` struct should have a comment indicating it's a placeholder for future optional parameters.
+
+```go
+// GetWidgetOptions contains the optional parameters for the Widget.Get method.
+type GetWidgetOptions struct {
+	OptionalTag *string
+	OptionalLength *int
+}
+
+// SetWidgetOptions contains the optional parameters for the Widget.Set method.
+type SetWidgetOptions struct {
+	// placeholder for future optional parameters
+}
+```
+
+{% include requirement/MUST id="golang-api-options-ptr" %} allow the user to pass a pointer to the structure as the last parameter. If the user passes `nil`, then the method should assume appropriate default values for all the structure’s fields.  Note that `nil` and a zero-initialized `<MethodNameOptions>` structure are **NOT** required to be semantically equivalent.
+
+{% include requirement/MUST id="golang-api-params" %} document all parameters as part of the method block comment.
+
+```go
+// GetWidget retrieves the specified Widget.
+// ctx - The context used to control the lifetime of the request.
+// name - The name of the Widget to retrieve.
+// options - Any optional parameters.
+func (c *WidgetClient) GetWidget(ctx context.Context, name string, options *GetWidgetOptions) (WidgetResponse, error) {
+	// ...
+}
+```
+
+##### Parameter Validation
+
+The service client will have several methods that perform requests on the service. _Service parameters_ are directly passed across the wire to an Azure service. _Client parameters_ are not passed directly to the service, but used within the client library to fulfill the request.  Examples of client parameters include values that are used to construct a URI, or a file that needs to be uploaded to storage.
+
+{% include requirement/MUST id="golang-params-client-validation" %} validate client parameters.
+
+{% include requirement/MUSTNOT id="golang-params-service-validation" %} validate service parameters. This includes null checks, empty strings, and other common validating conditions. Let the service validate any request parameters.
+
+{% include requirement/MUST id="golang-params-devex" %} validate the developer experience when the service parameters are invalid to ensure appropriate error messages are generated by the service. If the developer experience is compromised due to service-side error messages, work with the service team to correct prior to release.
+
+#### Methods Returning Collections (Paging)
 
 {% include requirement/MUST id="golang-pagination" %} return a value that implements the Pager interface for operations that return pages.  The Pager interface allows consumers to iterate over all pages as defined by the service.
 
@@ -341,7 +260,7 @@ if pager.Err() != nil {
 
 {% include requirement/MUST id="golang-pagination-serialization" %} provide means to serialize and deserialize a Pager so that paging can pause and continue, potentially on another machine.
 
-## Long Running Operations
+#### Methods Invoking Long Running Operations
 
 {% include requirement/MUST id="golang-lro-poller" %} return a value that implements the Poller interface for long-running operation methods.  The Poller interface encapsulates the polling and status of the long-running operation.
 
@@ -489,19 +408,31 @@ if err != nil {
 process(w)
 ```
 
-## Mocking
+##### Conditional Request Methods
 
-One of the key things we want to support is to allow consumers of the package to easily write repeatable unit-tests for their applications without activating a service. This allows them to reliably and quickly test their code without worrying about the vagaries of the underlying service implementation (including, for example, network conditions or service outages). Mocking is also helpful to simulate failures, edge cases, and hard to reproduce situations (for example: does code work on February 29th).
+TODO
 
-{% include requirement/MUST id="golang-mock-friendly" %} generate types and methods that can be mocked to simulate a response from an Azure endpoint.
+### Supporting Types
 
-{% include requirement/MUST id="golang-mock-procedure" %} document the tools and procedures recommended to generate client interfaces for mocking.
+In addition to service client types, Azure SDK APIs provide and use other supporting types as well.
 
-{% include requirement/MUST id="golang-mock-lro-pages" %} generate interface types for LRO and pageable response types that contain all of the methods for their respective types.  The interface type name will be the same as the LRO/pageable response type name.
+#### Model Types
 
-{% include requirement/MUST id="golang-test-recordings" %} support HTTP request and response recording/playback via the pipeline.
+TODO
 
-## Enumerated Types
+##### Model Type Naming
+
+TODO
+
+#### Azure Core Types
+
+TODO
+
+#### Primitive Types
+
+TODO
+
+#### Constants as Enumerations
 
 {% include requirement/MUST id="golang-enum-type" %} define the enumeration's type to match the type sent/received over-the-wire (string is the most common example).
 
@@ -534,22 +465,32 @@ func (c WidgetColor) ToPtr() *WidgetColor {
 
 ```
 
-## Service Client Configuration
+### Authentication
 
-{% include requirement/MUST id="golang-config-global" %} use relevant global configuration settings either by default or when explicitly requested to by the user, for example by passing in a configuration object to a client constructor.
+Azure services use different kinds of authentication schemes to allow clients to access the service. Conceptually, there are two entities responsible in this process: a credential and an authentication policy. Credentials provide confidential authentication data. Authentication policies use the data provided by a credential to modify an HTTP request before it is sent to the service.
 
-{% include requirement/MUST id="golang-config-client" %} allow different clients of the same type to use different configurations.
+{% include requirement/MUST id="golang-auth-support" %} support all authentication techniques that the service supports.
 
-{% include requirement/MUST id="golang-config-optout" %} allow consumers of your service clients to opt out of all global configuration settings at once.
+{% include requirement/MUST id="golang-auth-use-azidentity" %} use credential and authentication policy implementations from the `azcore` or `azidentity` package where available.
 
-{% include requirement/MUST id="golang-config-global-override" %} allow all global configuration settings to be overridden by client-provided options. The names of these options should align with any user-facing global configuration keys.
+{% include requirement/MUST id="golang-auth-concurrency" %} provide credential types that can be used to fetch all data needed to authenticate a request to the service. If using a service-specific credential type, the implementation must be safe for concurrent use by multiple goroutines.
 
-{% include requirement/MUSTNOT id="golang-config-behavior-changes" %} change behavior based on configuration changes that occur after the client is constructed. Hierarchies of clients inherit parent client configuration unless explicitly changed or overridden. Exceptions to this requirement are as follows:
+{% include requirement/MUSTNOT id="golang-auth-connection-strings" %} support constructing a service client with a connection string unless such connection string is available within tooling (e.g. Azure portal, for copy/paste operations). A connection string is a combination of an endpoint, credential data, and other options used to simplify service client configuration. Connection strings are easily integrated into an application by copy/paste from the portal. However, credentials within a connection string can’t be rotated within a running process. Their use should be discouraged in production apps.  If the client library supports connection strings, the constructor should look like this:
 
-1. Log level, which must take effect immediately across the Azure SDK.
-2. Tracing on/off, which must take effect immediately across the Azure SDK.
+```go
+// NewWidgetClientFromConnectionString creates a new instance of WidgetClient with the specified values.  It uses the default pipeline configuration.
+func NewWidgetClientFromConnectionString(con string, options *WidgetClientOptions) (*WidgetClient, error) {
+	// ...
+}
+```
 
-# Error Handling and Diagnostics
+When implementing authentication, don't open up the consumer to security holes like PII (personally identifiable information) leakage or credential leakage. Credentials are generally issued with a time limit, and must be refreshed periodically to ensure that the service connection continues to function as expected. Ensure your client library follows all current security recommendations and consider an independent security review of the client library to ensure you're not introducing potential security problems for the consumer.
+
+{% include requirement/MUSTNOT id="golang-auth-persistence" %} persist, cache, or reuse security credentials. Security credentials should be considered short lived to cover both security concerns and credential refresh situations.
+
+{% include requirement/MUST id="golang-auth-policy-impl" %} provide a suitable authentication policy if your service implements a non-standard authentication system (that is, an authentication system that is not supported by Azure Core).  You also need to produce an authentication policy for the HTTP pipeline that can add credentials to requests given the alternative authentication mechanism provided by the service.  Custom credentials will need to implement the `azcore.Credentials` interface.
+
+### Error Handling
 
 {% include requirement/MUST id="golang-errors" %} return an error if a method fails to perform its intended functionality.  For methods that return multiple items, the error object is always the last item in the return signature.
 
@@ -574,75 +515,25 @@ In the case of a method that makes multiple HTTP requests, the first error encou
 
 {% include requirement/MUSTNOT id="golang-errors-other-types" %} create arbitrary error types.  Use error types provided by the service, standard library, or `azcore`.
 
-## Logging
+### Package Naming
 
-Client libraries must support robust logging mechanisms so that the consumer can adequately diagnose issues with the method calls and quickly determine whether the issue is in the consumer code, client library code, or service.
+TODO (namespaces in other languages)
 
-{% include requirement/MUST id="golang-log-api" %} use the Logger API provided within `azcore` as the sole logging API throughout all client libraries.
+### Support for Mocking
 
-{% include requirement/MUST id="golang-log-classification" %} define constant classification strings using the `azcore.LogClassification` type, then log using these values.
+One of the key things we want to support is to allow consumers of the package to easily write repeatable unit-tests for their applications without activating a service. This allows them to reliably and quickly test their code without worrying about the vagaries of the underlying service implementation (including, for example, network conditions or service outages). Mocking is also helpful to simulate failures, edge cases, and hard to reproduce situations (for example: does code work on February 29th).
 
-{% include requirement/MUST id="golang-log-inclue" %} log HTTP request line, response line, and all header/query parameter names.
+{% include requirement/MUST id="golang-mock-friendly" %} generate types and methods that can be mocked to simulate a response from an Azure endpoint.
 
-{% include requirement/MUSTNOT id="golang-log-exclude" %} log payloads or HTTP header/query parameter values that aren't on the allow list.  For header/query parameters not on the allow list use the value `<REDACTED>` in place of the real value.
+{% include requirement/MUST id="golang-mock-procedure" %} document the tools and procedures recommended to generate client interfaces for mocking.
 
-## Distributed Tracing
+{% include requirement/MUST id="golang-mock-lro-pages" %} generate interface types for LRO and pageable response types that contain all of the methods for their respective types.  The interface type name will be the same as the LRO/pageable response type name.
 
-{% include requirement/MUST id="golang-tracing-abstraction" %} abstract the underlying tracing facility, allowing consumers to use the tracing implementation of their choice.
+{% include requirement/MUST id="golang-test-recordings" %} support HTTP request and response recording/playback via the pipeline.
 
-{% include requirement/MUST id="golang-tracing-span-per-call" %} create a new trace span for each API call.  New spans must be children of the context that was passed in.
+### Hierarchical Clients
 
-{% include requirement/MUST id="golang-tracing-span-name" %} use `<package name>.<type name>.<method name>` as the name of the span.
-
-{% include requirement/MUST id="golang-tracing-propagate" %} propagate tracing context on each outgoing service request through the appropriate headers to support a tracing service like [Azure Monitor](https://azure.microsoft.com/services/monitor/) or [ZipKin](https://zipkin.io/).  This is generally done with the HTTP pipeline.
-
-# HTTP Pipeline and Policies
-
-Each supported language has an Azure Core library that contains common mechanisms for cross cutting concerns such as configuration and doing HTTP requests.
-
-{% include requirement/MUST id="golang-network-use-http-pipeline" %} use the HTTP pipeline component within `azcore` library for communicating to service REST endpoints.
-
-The HTTP pipeline consists of a HTTP transport that is wrapped by multiple policies. Each policy is a control point during which the pipeline can modify either the request and/or response. We prescribe a default set of policies to standardize how client libraries interact with Azure services. The order in the list is the most sensible order for implementation.
-
-{% include requirement/MUST id="golang-network-policies" %} implement the following policies in the HTTP pipeline:
-
-- Telemetry
-- Retry
-- Authentication
-- Response downloader
-- Distributed tracing
-- Logging
-- The HTTP transport itself
-
-{% include requirement/SHOULD id="golang-network-azure-core-policies" %} use the policy implementations in Azure Core whenever possible. Do not try to "write your own" policy unless it is doing something unique to your service. If you need another option to an existing policy, engage with the [Architecture Board] to add the option.
-
-# Configuration via Environment Variables
-
-{% include requirement/MUST id="golang-envvars-prefix" %} prefix Azure-specific environment variables with `AZURE_`.
-
-{% include requirement/MAY id="golang-envvars-client-prefix" %} use client library-specific environment variables for portal-configured settings which are provided as parameters to your client library. This generally includes credentials and connection details. For example, Service Bus could support the following environment variables:
-
-* `AZURE_SERVICEBUS_CONNECTION_STRING`
-* `AZURE_SERVICEBUS_NAMESPACE`
-* `AZURE_SERVICEBUS_ISSUER`
-* `AZURE_SERVICEBUS_ACCESS_KEY`
-
-Storage could support:
-
-* `AZURE_STORAGE_ACCOUNT`
-* `AZURE_STORAGE_ACCESS_KEY`
-* `AZURE_STORAGE_DNS_SUFFIX`
-* `AZURE_STORAGE_CONNECTION_STRING`
-
-{% include requirement/MUST id="golang-envvars-approval" %} get approval from the [Architecture Board] for every new environment variable.
-
-{% include requirement/MUST id="golang-envvars-syntax" %} use this syntax for environment variables specific to a particular Azure service:
-
-* `AZURE_<ServiceName>_<ConfigurationKey>`
-
-where _ServiceName_ is the canonical shortname without spaces, and _ConfigurationKey_ refers to an unnested configuration key for that client library.
-
-{% include requirement/MUSTNOT id="golang-envvars-posix-compliance" %} use non-alpha-numeric characters in your environment variable names with the exception of underscore. This ensures broad interoperability.
+TODO
 
 {% include refs.md %}
 {% include_relative refs.md %}

--- a/docs/golang/implementation.md
+++ b/docs/golang/implementation.md
@@ -1,0 +1,144 @@
+---
+title: "Go Guidelines: API Implementation"
+keywords: guidelines golang
+permalink: golang_design.html
+folder: golang
+sidebar: general_sidebar
+---
+
+## API Implementation
+
+TODO
+
+### The Service Client
+
+TODO
+
+#### Service Methods
+
+TODO
+
+##### Using azcore.Pipeline
+
+Each supported language has an Azure Core library that contains common mechanisms for cross cutting concerns such as configuration and doing HTTP requests.
+
+{% include requirement/MUST id="golang-network-use-http-pipeline" %} use the HTTP pipeline component within `azcore` library for communicating to service REST endpoints.
+
+The HTTP pipeline consists of a HTTP transport that is wrapped by multiple policies. Each policy is a control point during which the pipeline can modify either the request and/or response. We prescribe a default set of policies to standardize how client libraries interact with Azure services. The order in the list is the most sensible order for implementation.
+
+{% include requirement/MUST id="golang-network-policies" %} implement the following policies in the HTTP pipeline:
+
+- Telemetry
+- Retry
+- Authentication
+- Response downloader
+- Distributed tracing
+- Logging
+- The HTTP transport itself
+
+{% include requirement/SHOULD id="golang-network-azure-core-policies" %} use the policy implementations in Azure Core whenever possible. Do not try to "write your own" policy unless it is doing something unique to your service. If you need another option to an existing policy, engage with the [Architecture Board] to add the option.
+
+##### Using azcore.Policy
+
+TODO
+
+#### Service Method Parameters
+
+TODO
+
+##### Parameter validation
+
+TODO
+
+### Supporting Types
+
+TODO
+
+#### Model Types
+
+TODO
+
+##### Serialization
+
+TODO
+
+#### Enumeration-like constants
+
+TODO
+
+### SDK Feature Implementation
+
+TODO
+
+#### Configuration
+
+{% include requirement/MUST id="golang-config-global" %} use relevant global configuration settings either by default or when explicitly requested to by the user, for example by passing in a configuration object to a client constructor.
+
+{% include requirement/MUST id="golang-config-client" %} allow different clients of the same type to use different configurations.
+
+{% include requirement/MUST id="golang-config-optout" %} allow consumers of your service clients to opt out of all global configuration settings at once.
+
+{% include requirement/MUST id="golang-config-global-override" %} allow all global configuration settings to be overridden by client-provided options. The names of these options should align with any user-facing global configuration keys.
+
+{% include requirement/MUSTNOT id="golang-config-behavior-changes" %} change behavior based on configuration changes that occur after the client is constructed. Hierarchies of clients inherit parent client configuration unless explicitly changed or overridden. Exceptions to this requirement are as follows:
+
+1. Log level, which must take effect immediately across the Azure SDK.
+2. Tracing on/off, which must take effect immediately across the Azure SDK.
+
+##### Configuration via Environment Variables
+
+{% include requirement/MUST id="golang-envvars-prefix" %} prefix Azure-specific environment variables with `AZURE_`.
+
+{% include requirement/MAY id="golang-envvars-client-prefix" %} use client library-specific environment variables for portal-configured settings which are provided as parameters to your client library. This generally includes credentials and connection details. For example, Service Bus could support the following environment variables:
+
+* `AZURE_SERVICEBUS_CONNECTION_STRING`
+* `AZURE_SERVICEBUS_NAMESPACE`
+* `AZURE_SERVICEBUS_ISSUER`
+* `AZURE_SERVICEBUS_ACCESS_KEY`
+
+Storage could support:
+
+* `AZURE_STORAGE_ACCOUNT`
+* `AZURE_STORAGE_ACCESS_KEY`
+* `AZURE_STORAGE_DNS_SUFFIX`
+* `AZURE_STORAGE_CONNECTION_STRING`
+
+{% include requirement/MUST id="golang-envvars-approval" %} get approval from the [Architecture Board] for every new environment variable.
+
+{% include requirement/MUST id="golang-envvars-syntax" %} use this syntax for environment variables specific to a particular Azure service:
+
+* `AZURE_<ServiceName>_<ConfigurationKey>`
+
+where _ServiceName_ is the canonical shortname without spaces, and _ConfigurationKey_ refers to an unnested configuration key for that client library.
+
+{% include requirement/MUSTNOT id="golang-envvars-posix-compliance" %} use non-alpha-numeric characters in your environment variable names with the exception of underscore. This ensures broad interoperability.
+
+#### Logging
+
+Client libraries must support robust logging mechanisms so that the consumer can adequately diagnose issues with the method calls and quickly determine whether the issue is in the consumer code, client library code, or service.
+
+{% include requirement/MUST id="golang-log-api" %} use the Logger API provided within `azcore` as the sole logging API throughout all client libraries.
+
+{% include requirement/MUST id="golang-log-classification" %} define constant classification strings using the `azcore.LogClassification` type, then log using these values.
+
+{% include requirement/MUST id="golang-log-inclue" %} log HTTP request line, response line, and all header/query parameter names.
+
+{% include requirement/MUSTNOT id="golang-log-exclude" %} log payloads or HTTP header/query parameter values that aren't on the allow list.  For header/query parameters not on the allow list use the value `<REDACTED>` in place of the real value.
+
+#### Distributed Tracing
+
+{% include requirement/MUST id="golang-tracing-abstraction" %} abstract the underlying tracing facility, allowing consumers to use the tracing implementation of their choice.
+
+{% include requirement/MUST id="golang-tracing-span-per-call" %} create a new trace span for each API call.  New spans must be children of the context that was passed in.
+
+{% include requirement/MUST id="golang-tracing-span-name" %} use `<package name>.<type name>.<method name>` as the name of the span.
+
+{% include requirement/MUST id="golang-tracing-propagate" %} propagate tracing context on each outgoing service request through the appropriate headers to support a tracing service like [Azure Monitor](https://azure.microsoft.com/services/monitor/) or [ZipKin](https://zipkin.io/).  This is generally done with the HTTP pipeline.
+
+#### Telemetry
+
+TODO
+
+### Testing
+
+TODO

--- a/docs/golang/introduction.md
+++ b/docs/golang/introduction.md
@@ -60,5 +60,9 @@ The Azure SDK should be designed to enhance the productivity of developers conne
 
 {% include requirement/MUST id="golang-general-engsys" %} follow Azure SDK engineering systems guidelines for working in the [azure/azure-sdk-for-go] GitHub repository.
 
+## Support for non-HTTP Protocols
+
+This document contains guidelines developed primarily for typical Azure REST services, i.e. stateless services with request-response based interaction model. Many of the guidelines in this document are more broadly applicable, but some might be specific to such REST services.
+
 {% include refs.md %}
 {% include_relative refs.md %}

--- a/docs/golang/packages.md
+++ b/docs/golang/packages.md
@@ -1,0 +1,123 @@
+---
+title: "Go Guidelines: Package Implementation"
+keywords: guidelines golang
+permalink: golang_design.html
+folder: golang
+sidebar: general_sidebar
+---
+
+## Packages
+
+Go groups related types in a package.  In Go, the package should be named `<prefix><service>`, where `<prefix>` is either `arm` or `az`, and where `<service>` is the service name represented as a single word.
+
+{% include requirement/MUST id="golang-package-prefix" %} start the package with `arm` or `az` to indicate an Azure client package.  Use `arm` for management-plane packages, and `az` for all other packages.
+
+{% include requirement/MUST id="golang-package-name" %} construct the package name with all lowercase letters (uppercase letters, hyphens and underscores are not allowed). For example, the Azure compute management package would be named `armcompute` and the Azure blob storage package would be named `azblob`.
+
+{% include requirement/MUST id="golang-package-registration" %} register the chosen package name with the [Architecture Board]. Open an issue to request the package name. See the [registered package list](registered_namespaces.html) for a list of the currently registered packages.
+
+### Directory Structure
+
+{% include requirement/MUST id="golang-pkgpath-construction" %} construct a package import path that allows the consumer to tie its packages to the service being used. The package path does **NOT** change when the branding of the product changes. Avoid the use of marketing names that may change.
+
+{% include requirement/MUST id="golang-pkgpath-leaf" %} ensure that the package leaf directory name matches the package name declared in the source code.
+
+{% include requirement/MUST id="golang-pkgpath-apiver" %} ensure that each service API version is in its own directory, IFF that service supports multiple API versions.
+
+{% include requirement/MUST id="golang-pkgpath-mgmt" %} place the management (Azure Resource Manager) API in the `arm` path. Use the grouping `./sdk/arm/<group>/<api-version>/arm<service>` for the package path. Since more services require management APIs than data plane APIs, other paths may be used explicitly for management only. Data plane usage is by exception only. Additional paths that can be used for control plane SDKs include:
+
+{% include tables/mgmt_namespaces.md %}
+
+Many management APIs do not have a data plane because they deal with management of the Azure account. Place the management package in the `arm` path. For example, use `sdk/arm/costanalysis/...` instead of `sdk/arm/management/costanalysis`.
+
+Here is a complete example.
+
+Data-plane packages:
+
+- github.com/Azure/azure-sdk-for-go/sdk/keyvault/7.0/azkeyvault
+- github.com/Azure/azure-sdk-for-go/sdk/storage/blob/2019-12-19/azblob
+- github.com/Azure/azure-sdk-for-go/sdk/storage/queue/2019-12-19/azqueue
+- github.com/Azure/azure-sdk-for-go/sdk/storage/table/2019-12-19/aztable
+
+Management-plane packages:
+
+- github.com/Azure/azure-sdk-for-go/sdk/arm/keyvault/2019-09-01/armkeyvault
+- github.com/Azure/azure-sdk-for-go/sdk/arm/storage/2019-01-01/armstorage
+- github.com/Azure/azure-sdk-for-go/sdk/arm/storage/2019-02-01/armstorage
+
+### Common Packages
+
+There are occasions when common code needs to be shared between several client packages. For example, a set of cooperating client packages may wish to share a set of errors or models.
+
+{% include requirement/MUST id="golang-commonlib-approval" %} gain [Architecture Board] approval prior to implementing a common package.
+
+{% include requirement/MUST id="golang-commonlib-minimize-code" %} minimize the code within a common package. Code within the common package is treated the same as any other client package.
+
+{% include requirement/MUST id="golang-commonlib-namespace" %} store the common package in the same directory as the associated client packages.
+
+A common package will only be approved if:
+
+* The consumer of the non-shared package will consume the objects within the common package directly, AND
+* The information will be shared between multiple client package.
+
+Let's take two examples:
+
+1. Implementing two Cognitive Services client packages, we find a model is required that is produced by one Cognitive Services client package and consumed by another Coginitive Services client package, or the same model is produced by two client packages. The consumer is required to do the passing of the model in their code, or may need to compare the model produced by one client package vs. that produced by another client package. This is a good candidate for choosing a common package.
+
+2. Two Cognitive Services client packages return a `BoundingBox` model to indicate where an object was detected in an image. There is no linkage between the `BoundingBox` model in each client package, and it is not passed into another client package. This is not a good candidate for creation of a common package (although you may wish to place this model in a common package if one exists for the namespace already). Instead, produce two different models - one in each client package.
+
+### Package Versioning
+
+{% include requirement/MUST id="golang-versioning-modules" %} release each package as a [Go module](https://blog.golang.org/using-go-modules).  Legacy dependency management tools such as `dep` and `glide` are not supported.
+
+{% include requirement/MUST id="golang-versioning-semver" %} release versions of modules in accordance with [semver 2.0](https://semver.org/spec/v2.0.0.html).
+
+{% include requirement/MUST id="golang-versioning-beta" %} clearly version prerelease modules.  For new modules, use a v0 major version with no suffix (v0.1.0).  For existing modules, use a `-beta` suffix (v1.1.0-beta, v2.0.0-beta).
+
+### Dependencies
+
+Packages should strive to avoid taking dependencies on packages outside of the standard library for the following reasons:
+
+- **Versioning** - Exposing types defined outside the standard library (i.e. `exchange types`) can indroduce versioning complexity.  If we have an client package that exposes types from a v3 of package Foo and the consumer wants to use v5 of package Foo, then the consumer cannot use the v5 types to satisfy the v3 requirement.
+- **Size** - Consumer applications must be able to deploy as fast as possible into the cloud and move in various ways across networks. Removing additional code (like dependencies) improves deployment performance.
+- **Licensing** - You must be conscious of the licensing restrictions of a dependency and often provide proper attribution and notices when using them.
+- **Compatibility** - Often times you do not control a dependency and it may choose to evolve in a direction that is incompatible with your original use.
+- **Security** - If a security vulnerability is discovered in a dependency, it may be difficult or time consuming to get the vulnerability corrected if Microsoft does not control the dependency's code base.
+
+{% include requirement/MUST id="golang-dependencies-exch-types" %} limit exchange types to those provided by the standard library (**NO EXCEPTIONS**).
+
+{% include requirement/MUST id="golang-dependencies-azure-core" %} depend on the `azcore` package for functionality that is common across all client packages.  This package includes APIs for HTTP connectivity, global configuration, logging, credential handling, and more.
+
+{% include requirement/MUST id="golang-dependencies-azure-core" %} depend on the `sdk/internal` package for functionality that is common across all client packages that should not be publicly exported.  This package includes helpers for creating errors with stack frame information, and more.
+
+{% include requirement/MUSTNOT id="golang-dependencies-approved-list" %} be dependent on any other packages within the client package distribution package, with the exception of the following:
+
+{% include_relative approved_dependencies.md %}
+
+### Native Code
+
+TODO
+
+### Doc Comments
+
+TODO
+
+### Repository Guidelines
+
+TODO
+
+#### OSS Repos
+
+TODO
+
+#### Documentation Type
+
+TODO
+
+#### README
+
+TODO
+
+#### Samples
+
+TODO


### PR DESCRIPTION
This moves the content to follow the template used across all languages.
Topics that have not yet been covered by the guidelines were left with a
TODO comment with rare exception.
No existing content was changed in any way.