### PR TITLE
Java: Guidelines for azure-identity dependency, quantum group

### DIFF
--- a/_includes/tables/data_namespaces.md
+++ b/_includes/tables/data_namespaces.md
@@ -10,6 +10,7 @@
 | `management`     | Control Plane (Azure Resource Manager)                                    |
 | `media`          | Audio, video, or mixed reality                                            |
 | `messaging`      | Messaging services, like push notifications or pub-sub                    |
+| `quantum`        | Quantum computing technologies                                            |
 | `search`         | Search technologies                                                       |
 | `security`       | Security and cryptography                                                 |
 | `storage`        | Storage of unstructured data                                              |

--- a/docs/java/introduction.md
+++ b/docs/java/introduction.md
@@ -844,6 +844,8 @@ Fluent types must not be immutable.  Don't return a new instance on each setter 
 
 {% include requirement/MUST id="java-models-javabeans" %} use the JavaBean naming convention of `get*`, `set*`, and `is*`.
 
+{% include requirement/MUST id="java-models-deserialize" %} include static methods if new model instances are required to be created from raw data. The static method names should be `from<dataformat>`. For example, to create an instance of `BinaryData` from a string, include a static method called `fromString` in `BinaryData` class.
+
 Model types sometimes exist only as an Azure service return type, and developers would never instantiate these. Often, these model types have API that is not user-friendly (in particular, overly complex constructors). It would be best for developers if they were never presented with this API in the first place, and we refer to these as 'undesirable public API'.
 
 {% include requirement/MUST id="java-models-interface" %} put model classes that are intended as service return types only, and which have undesirable public API into the `.implementation.models` package. In its place, an interface should be put into the public-facing `.models` package, and it should be this type that is returned through the public API to end users. 
@@ -976,6 +978,8 @@ In addition to Azure Active Directory OAuth, services may provide custom authent
 {% include requirement/SHOULDNOT id="java-auth-credential-type-base" %} define custom credential types extending or implementing the TokenCredential abstraction from Azure Core. This is especially true in type safe languages where extending or implementing this abstraction would break the type safety of other service clients, allowing users to instantiate them with the custom credential of the wrong service.
 
 {% include requirement/MUST id="java-auth-credential-type-placement" %} define custom credential types in the same namespace and package as the client, or in a service group namespace and shared package, not in Azure Core or Azure Identity.
+
+{% include requirement/MUSTNOT id="java-auth-azure-identity-dependency" %} take compile-scope dependency on `azure-identity` library.
 
 {% include requirement/MUST id="java-auth-credential-type-prefix" %} prepend custom credential type names with the service name or service group name to provide clear context to its intended scope and usage.
 


### PR DESCRIPTION
This PR updates Java guidelines:
- To explicitly state not to include `azure-identity` as a dependency
- Add `quantum` as an approved namespace
- Static method naming guidelines for creating model instances from raw data