### PR TITLE
No wrap on preview code

### DIFF
--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -1379,3 +1379,7 @@ h4.panel-title {
     flex-direction: column;
   }
 }
+
+pre code {
+  white-space: pre;
+}


### PR DESCRIPTION
Code Preview with no wrap

Half part of https://github.com/Azure/azure-sdk/issues/2157

Makes code preview to use scroll horizontal instead of wrapping down the code