### PR TITLE
Fix opentelemetry link

### DIFF
--- a/releases/2020-11/dotnet.md
+++ b/releases/2020-11/dotnet.md
@@ -108,7 +108,7 @@ If you have a bug or feature request for one of the libraries, please [file an i
 
 ## Release highlights
 
-### Azure Monitor [Changelog](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/CHANGELOG.md#100-beta1-2020-11-06)
+### Azure Monitor [Changelog](https://github.com/Azure/azure-sdk-for-net/blob/Microsoft.OpenTelemetry.Exporter.AzureMonitor_1.0.0-beta.1/sdk/monitor/Microsoft.OpenTelemetry.Exporter.AzureMonitor/CHANGELOG.md#100-beta1-2020-11-06)
 
 - Initial release of Azure Monitor Exporter for [OpenTelemetry .NET](https://github.com/open-telemetry/opentelemetry-dotnet).
 


### PR DESCRIPTION
FYI @TimothyMothra I've updated this link that was broken by your PR https://github.com/Azure/azure-sdk-for-net/pull/18494 to use a release tag instead of master. 