### PR TITLE
Remove TBD sections

### DIFF
--- a/docs/policies/releases.md
+++ b/docs/policies/releases.md
@@ -118,19 +118,7 @@ A manual migration test should be developed to ensure that payloads and data fed
 
 ### 5) Updating package manager references
 
-When releasing any new version of an SDKs follow best practices of the language specific package managers to ensure that this new version's visibility is elevated and recommended by default to the users. Here's the guidance per language.
-
-#### .NET
-TBD
-
-#### Java
-TBD
-
-#### TS/JS
-TBD
-
-#### Python
-TBD
+When releasing any new version of an SDK follow best practices of the language specific package managers to ensure that this new version's visibility is elevated and recommended by default to the users.
 
 ## Terms
 


### PR DESCRIPTION
@salameer you added these TBD sections with https://github.com/Azure/azure-sdk/pull/2093. I'm removing them because they ended up hijacking the anchor tags (https://azure.github.io/azure-sdk/policies_releases.html#net) from the package versioning section for each language. If we want to add instructions back here at some point I suggest we add them in the package versioning section for each language. 