### PR TITLE
Update NET verbs table to be like all other langs and intro

### DIFF
--- a/_data/tables/net_standard_verbs.yaml
+++ b/_data/tables/net_standard_verbs.yaml
@@ -1,0 +1,34 @@
+# <noun> needs to be scaped with \ because it's a html tag.
+entries:
+  - Verb: Create
+    Parameters: key, item
+    Returns: Created item
+    Comments: Creates a resource. Throws if the resource exists.
+  - Verb: Set
+    Parameters: key, item
+    Returns:
+    Comments: Creates or replaces a resource.
+  - Verb: Update
+    Parameters: key, item
+    Returns: item
+    Comments: Updates a resource. Throws if the resource does not exist. Update methods might take a parameter controlling whether the update is a replace, merge, or other specific semantics.
+  - Verb: Get\<resource_name>
+    Parameters: key
+    Returns: item
+    Comments: Retrieves a resource. Throws if the resource does not exist.
+  - Verb: Get\<resource_name_plural>
+    Parameters: key, item
+    Returns: item
+    Comments: Retrieves one or more resources. Returns empty set if no resources found.
+  - Verb: Delete
+    Parameters: item
+    Returns: item
+    Comments: Deletes one or more resources, or no-op if the resources do not exist.
+  - Verb: Remove
+    Parameters: index, item
+    Returns: item
+    Comments: Remove a reference to a resource from a collection. This method doesn’t delete the actual resource, only the reference.
+  - Verb: \<resource_name>Exists
+    Parameters: key
+    Returns: item
+    Comments: Returns true if the resource exists, otherwise returns false.

--- a/_includes/tables/standard_verbs_row.html
+++ b/_includes/tables/standard_verbs_row.html
@@ -1,5 +1,5 @@
 <div class="standard-verbs-table-row">
-    <div class="standard-verbs-table-cell-container">
+    <div class="standard-verbs-table-cell-container standard-verbs-table-cell-verb">
         <div class="standard-verbs-table-cell standard-verbs-table-cell-mobile-header {{ include.perRowCellStyle }}">
             Verb</div>
         <div class="standard-verbs-table-cell {{ include.perRowCellStyle }} standard-verbs-table-cell-verb">

--- a/_includes/tables/standard_verbs_template.html
+++ b/_includes/tables/standard_verbs_template.html
@@ -1,7 +1,7 @@
 <div class="standard-verbs-table-container">
     <!-- Table Header -->
     <div class="standard-verbs-table-row">
-        <div class="standard-verbs-table-cell standard-verbs-table-cell-header">Verb</div>
+        <div class="standard-verbs-table-cell standard-verbs-table-cell-header standard-verbs-table-cell-verb">Verb</div>
         <div class="standard-verbs-table-cell standard-verbs-table-cell-header">Parameters</div>
         <div class="standard-verbs-table-cell standard-verbs-table-cell-header">Returns</div>
         <div class="standard-verbs-table-cell standard-verbs-table-cell-header standard-verbs-table-cell-comments">

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -1427,8 +1427,12 @@ pre code {
   font-weight: bold;
 }
 
-.standard-verbs-table-cell-comments {
+.standard-verbs-table-cell-verb {
   flex: 2;
+}
+
+.standard-verbs-table-cell-comments {
+  flex: 3;
 }
 
 .standard-verbs-table-cell-mobile-header {

--- a/docs/dotnet/introduction.md
+++ b/docs/dotnet/introduction.md
@@ -327,16 +327,9 @@ Most methods in Azure SDK libraries should be named following the typical .NET m
 
 {% include requirement/SHOULD id="general-client-standardize-verbs" %} use standard verbs for methods that access or manipulate server resources. 
 
-| Verb | Example | Usage |
-| `Create` | `BlobContainerClient.Create` | Creates a resource. Throws if the resource exists. |
-| `Set` | `BlobContainerClient.SetMetadata` | Creates or replaces a resource. |
-| `Update` | TBD | Updates a resource. Throws if the resource does not exist. Update methods might take a parameter controlling whether the update is a replace, merge, or other specific semantics. |
-| `Add` | `ConfigurationClient.AddConfigurationSetting` | Adds a resource to a resource collection or container. |
-| `Get<resource_name>` | `BlobContainerClient.GetAccessPolicy` | Retrieves a resource. Throws if the resource does not exist. |
-| `Get<resource_name_plural>` | `ConfigurationClient.GetConfigurationSettings` | Retrieves one or more resources. Returns empty set if no resources found. |
-| `Delete` | `BlobContainerClient.DeleteBlob` | Deletes one or more resources, or no-op if the resources do not exist. |
-| `Remove` | TBD | Remove a reference to a resource from a collection. This method doesn’t delete the actual resource, only the reference. |
-| `<resource_name>Exists` | TBD | Returns true if the resource exists, otherwise returns false. |
+<!-- The table data is in yaml format on _data/tables/net_standard_verbs -->
+{% assign data = site.data.tables.net_standard_verbs.entries %}
+{% include tables/standard_verbs_template.html %}
 
 ##### Cancellation
 


### PR DESCRIPTION
fixes: #2435
Current table:
https://azure.github.io/azure-sdk/dotnet_introduction.html#general-client-standardize-verbs

Updated table: (Demo for how it would look)
https://vhvb1989.github.io/azure-sdk/dotnet_introduction.html#general-client-standardize-verbs

Main table:
https://azure.github.io/azure-sdk/general_design.html#general-client-standardize-verbs

.NET is currently using a different table format and info than any other language.
This PR updates the table design to follow the genal design and all other langs tables.  @annelo-msft @KrzysztofCwalina  please let me know if .NET needs to have a different layout for this table (as the current layout is) and I can update the style only without changing the layout:

.NET layout:
![image](https://user-images.githubusercontent.com/24213737/110545979-bc986400-80e2-11eb-9d9d-b158b5931914.png)


General layout (general and non NET langs)
![image](https://user-images.githubusercontent.com/24213737/110545942-af7b7500-80e2-11eb-98c4-8f68802032f1.png)


