### PR TITLE
Manually update the opentelemetry-exporter docs link as placeholder

### DIFF
--- a/_data/releases/latest/python-packages.csv
+++ b/_data/releases/latest/python-packages.csv
@@ -23,7 +23,7 @@
 "azure-keyvault-secrets","4.2.0","","Key Vault - Secrets","Key Vault","keyvault","","","client","true","","",""
 "azure-media-analytics-edge","","1.0.0b1","Media Analytics Edge","Media","media","","","client","True","","",""
 "azure-ai-metricsadvisor","","1.0.0b3","Metrics Advisor","Metrics Advisor","metricsadvisor","","","client","true","","",""
-"azure-monitor-opentelemetry-exporter","","1.0.0b3","Monitor Exporter for OpenTelemetry","Monitor","monitor","","","client","true","1.0.0,04/13/2021","",""
+"azure-monitor-opentelemetry-exporter","","1.0.0b3","Monitor Exporter for OpenTelemetry","Monitor","monitor","https://docs.microsoft.com/en-us/python/api/overview/azure/opentelemetry-exporter-azuremonitor-readme","","client","true","1.0.0,04/13/2021","",""
 "microsoft-opentelemetry-exporter-azuremonitor","","1.0.0b1","Monitor Exporter for OpenTelemetry","Monitor","monitor","NA","","client","true","1.0.0,04/13/2021","",""
 "azure-servicebus","7.1.0","","Service Bus","Service Bus","servicebus","","","client","true","","",""
 "azure-storage-blob","12.8.0","","Storage - Blobs","Storage","storage","","","client","true","","",""


### PR DESCRIPTION
This is resolves the failing link from [this PR](https://dev.azure.com/azure-sdk/public/_build/results?buildId=774108&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=036ed663-514a-59f3-0c88-23d2cf182147&l=13)

The reason is that we don't want `microsoft-` in the leading. This is a good workaround until I extend the liquid template appropriately.
