### PR TITLE
Change Iot to IoT

### DIFF
--- a/_includes/tables/data_namespaces.md
+++ b/_includes/tables/data_namespaces.md
@@ -6,7 +6,7 @@
 | `diagnostics`    | Gathering data for diagnosing issues                                      |
 | `digitaltwins`   | Digital Twins, digital representations of physical spaces and IoT devices |
 | `identity`       | Authentication and authorization                                          |
-| `iot`            | Internet of things                                                        |
+| `iot`            | Internet of Things                                                        |
 | `management`     | Control Plane (Azure Resource Manager)                                    |
 | `media`          | Audio, video, or mixed reality                                            |
 | `messaging`      | Messaging services, like push notifications or pub-sub                    |

--- a/_includes/tables/data_namespaces_pascal_case.md
+++ b/_includes/tables/data_namespaces_pascal_case.md
@@ -6,7 +6,7 @@
 | `Diagnostics`    | Gathering data for diagnosing issues                                      |
 | `DigitalTwins`   | Digital Twins, digital representations of physical spaces and IoT devices |
 | `Identity`       | Authentication and authorization                                          |
-| `IoT`            | Internet of things                                                        |
+| `IoT`            | Internet of Things                                                        |
 | `Management`     | Control Plane (Azure Resource Manager)                                    |
 | `Media`          | Audio, video, or mixed reality                                            |
 | `Messaging`      | Messaging services, like push notifications or pub-sub                    |

--- a/_includes/tables/data_namespaces_pascal_case.md
+++ b/_includes/tables/data_namespaces_pascal_case.md
@@ -6,7 +6,7 @@
 | `Diagnostics`    | Gathering data for diagnosing issues                                      |
 | `DigitalTwins`   | Digital Twins, digital representations of physical spaces and IoT devices |
 | `Identity`       | Authentication and authorization                                          |
-| `Iot`            | Internet of things                                                        |
+| `IoT`            | Internet of things                                                        |
 | `Management`     | Control Plane (Azure Resource Manager)                                    |
 | `Media`          | Audio, video, or mixed reality                                            |
 | `Messaging`      | Messaging services, like push notifications or pub-sub                    |

--- a/docs/dotnet/introduction.md
+++ b/docs/dotnet/introduction.md
@@ -804,7 +804,7 @@ For example, `Azure.Storage.Blobs`.
 - `Azure.Data` for client libraries that handle databases or structured data stores
 - `Azure.DigitalTwins` for DigitalTwins related technologies
 - `Azure.Identity` for authentication and authorization client libraries
-- `Azure.Iot` for client libraries dealing with the Internet of Things
+- `Azure.IoT` for client libraries dealing with the Internet of Things
 - `Azure.Management` for client libraries accessing the control plane (Azure Resource Manager)
 - `Azure.Media` for client libraries that deal with audio, video, or mixed reality
 - `Azure.Messaging` for client libraries that provide messaging services, such as push notifications or pub-sub.


### PR DESCRIPTION
Closes #2550 

.NET guide says use Iot not IoT in namespace
 
IoT is industry standard and used in code in every other place than namespace.
 
AWS uses IoT in their SDK namespace and classes.
 
I think we should change it to IoT so it can be consistent everywhere in our codebase and align with industry standard.
