### PR TITLE
docs/redirects/python-introduction.md

### DIFF
--- a/docs/redirects/python-introduction.md
+++ b/docs/redirects/python-introduction.md
@@ -1,0 +1,5 @@
+---
+permalink: /python/guidelines/python_introduction.html
+layout: redirect
+redirect_uri: /python/guidelines/index.html
+---


### PR DESCRIPTION
Fix redirect from deep link/python intro docs introduced in the restructuring of the guidelines. 