### PR TITLE
Update generate release notes

### DIFF
--- a/docs/policies/releasenotes.md
+++ b/docs/policies/releasenotes.md
@@ -7,11 +7,18 @@ sidebar: general_sidebar
 
 # Producing Release Notes
 
-Each release cycle, we produce release notes for every language.  To do this:
+Each release cycle, we produce release notes for every language. This process is partly automated. The [azure-sdk - generate-release-notes](https://dev.azure.com/azure-sdk/internal/_build?definitionId=2359) runs at 12:30PM every weekday and produces pull requests with titles of the form **(Create or Update Release Notes for {Language} {YYYY-MM} release)** for dotnet, java, js, and python. Below are instructions for updating/reviewing the PRs before merging.
 
-* The release manager (within the PM organization) will create a new folder within the `/releases` directory of the `azure/azure-sdk` repository (named in `YYYY-MM` format) and create the necessary files.
-* The engineering leads for the packages being released are responsible for ensuring the details of the release notes are filled in via the normal PR process.
-* The release manager will review the release notes, merging PRs.  After code complete, the release manager will do a final editorial pass before linking the release notes into the table of contents.
+- The **engineering leads** for the released packages should make sure they have been picked up by the automation and that the entry is correct.
+  - To prevent the conflicts between the automation and manual edits, instead of pushing new commits you should make code suggestion on the PR, then allow the release manager to take care of merging everything in.
+  - Feel free to suggest edits to individual `Release Highlights` sections as you see fit.
+  - Suggest new release entries that should be added to the PR if it has not already been added by the automation (it most likely will be). 
+  - If there are packages that should be in the release that don't appear it is probably because this automation runs at 12:30PM every weekday. If you released you package after 12:30PM you should wait till 12:30PM the next day, by then the automation would have picked it up.
+
+- The **release manager** should remove all entries for packages that should not be in the release period, review and merge the pull request.
+  - Entries will have to be removed from the `Release Highlights`, `Installation Instructions` as well as the `Updates`, `Beta` or, `GA` sections as the case may be. 
+  -  **Do not** remove the entries inside the HTML comments `<!--  -->` as that will cause the automation to re-add the entry on the next run. 
+  - After code complete, the release manager will do a final editorial pass before linking the release notes into the table of contents.
 
 Release notes are part of the release and must be ready for final edit by the "Code Complete" date.
 

--- a/docs/policies/releasenotes.md
+++ b/docs/policies/releasenotes.md
@@ -7,13 +7,13 @@ sidebar: general_sidebar
 
 # Producing Release Notes
 
-Each release cycle, we produce release notes for every language. This process is partly automated. The [azure-sdk - generate-release-notes](https://dev.azure.com/azure-sdk/internal/_build?definitionId=2359) runs at 12:30PM every weekday and produces pull requests with titles of the form **(Create or Update Release Notes for {Language} {YYYY-MM} release)** for dotnet, java, js, and python. Below are instructions for updating/reviewing the PRs before merging.
+Each release cycle, we produce release notes for every language. This process is partly automated. The `azure-sdk - generate-release-notes` once every weekday and produces pull requests with titles of the form **(Create or Update Release Notes for {Language} {YYYY-MM} release)** for dotnet, java, js, and python. Below are instructions for updating/reviewing the PRs before merging.
 
 - The **engineering leads** for the released packages should make sure they have been picked up by the automation and that the entry is correct.
   - To prevent the conflicts between the automation and manual edits, instead of pushing new commits you should make code suggestion on the PR, then allow the release manager to take care of merging everything in.
   - Feel free to suggest edits to individual `Release Highlights` sections as you see fit.
   - Suggest new release entries that should be added to the PR if it has not already been added by the automation (it most likely will be). 
-  - If there are packages that should be in the release that don't appear it is probably because this automation runs at 12:30PM every weekday. If you released you package after 12:30PM you should wait till 12:30PM the next day, by then the automation would have picked it up.
+  - If there are packages that should be in the release that don't appear it is probably because this automation runs once every weekday. Your package should generally get picked up by the automation within 24 hours.
 
 - The **release manager** should remove all entries for packages that should not be in the release period, review and merge the pull request.
   - Entries will have to be removed from the `Release Highlights`, `Installation Instructions` as well as the `Updates`, `Beta` or, `GA` sections as the case may be. 

--- a/docs/policies/releasenotes.md
+++ b/docs/policies/releasenotes.md
@@ -11,7 +11,7 @@ Each release cycle, we produce release notes for every language. This process is
 
 - The **engineering leads** for the released packages should make sure they have been picked up by the automation and that the entry is correct.
   - To prevent the conflicts between the automation and manual edits, instead of pushing new commits you should make code suggestion on the PR, then allow the release manager to take care of merging everything in.
-  - Feel free to suggest edits to individual `Release Highlights` sections as you see fit.
+  - Feel free to suggest edits to individual `Release Highlights` sections as you see fit. Suggestions should use the github suggest feature instead of manually pushing new commits. 
   - Suggest new release entries that should be added to the PR if it has not already been added by the automation (it most likely will be). 
   - If there are packages that should be in the release that don't appear it is probably because this automation runs once every weekday. Your package should generally get picked up by the automation within 24 hours.
 
@@ -76,4 +76,3 @@ You may optionally provide social media outreach for out-of-band releases.  Cont
 ## Where do I go if I need help?
 
 The _Azure SDK release manager_ is best place to start when you need help with a release. They manage the Release channel in the Azure SDK Teams team.  If you need help you can post a message in that Teams channel here: <https://aka.ms/azsdk/teams/release>
-

--- a/eng/pipelines/generate-releasenotes.yml
+++ b/eng/pipelines/generate-releasenotes.yml
@@ -72,6 +72,7 @@ steps:
         PROwner: Azure
         PRBranchName: '${{ parameters.PrBranchName }}_${{ repo.value.Language }}_$(ReleasePeriod)'
         CommitMsg: "Create or Update Release Notes for ${{ repo.value.Language }} $(ReleasePeriod) release"
-        PRTitle: "Use this PR for $(ReleasePeriod) ${{ repo.value.Language }} release notes update. See [Producing Release Notes](https://github.com/Azure/azure-sdk/blob/master/docs/policies/releasenotes.md#producing-release-notes)"
+        PRTitle: "Create or Update Release Notes for ${{ repo.value.Language }} $(ReleasePeriod) release"
+        PRBody: "Use this PR for $(ReleasePeriod) ${{ repo.value.Language }} release notes update. See [Producing Release Notes](https://github.com/Azure/azure-sdk/blob/master/docs/policies/releasenotes.md#producing-release-notes)"
         WorkingDirectory: $(System.DefaultWorkingDirectory)/azure-sdk
         ScriptDirectory: $(System.DefaultWorkingDirectory)/azure-sdk-tools/eng/common/scripts

--- a/eng/pipelines/generate-releasenotes.yml
+++ b/eng/pipelines/generate-releasenotes.yml
@@ -72,6 +72,6 @@ steps:
         PROwner: Azure
         PRBranchName: '${{ parameters.PrBranchName }}_${{ repo.value.Language }}_$(ReleasePeriod)'
         CommitMsg: "Create or Update Release Notes for ${{ repo.value.Language }} $(ReleasePeriod) release"
-        PRTitle: "Create or Update Release Notes for ${{ repo.value.Language }} $(ReleasePeriod) release"
+        PRTitle: "Use this PR for $(ReleasePeriod) ${{ repo.value.Language }} release notes update. See [Producing Release Notes](https://github.com/Azure/azure-sdk/blob/master/docs/policies/releasenotes.md#producing-release-notes)"
         WorkingDirectory: $(System.DefaultWorkingDirectory)/azure-sdk
         ScriptDirectory: $(System.DefaultWorkingDirectory)/azure-sdk-tools/eng/common/scripts

--- a/eng/scripts/Generate-ReleaseNotes.ps1
+++ b/eng/scripts/Generate-ReleaseNotes.ps1
@@ -135,6 +135,7 @@ function Write-GeneralReleaseNote ($releaseHighlights, $releaseNotesContent, $re
                 }
 
                 $changelogUrl = $releaseHighlights[$key]["ChangelogUrl"]
+                $GroupId = $releaseHighlights[$key]["PackageProperties"].Group
                 $changelogUrl = "(${changelogUrl})"
                 $highlightsBody = ($releaseHighlights[$key]["Content"] | Out-String).Trim()
                 $packageSemVer = [AzureEngSemanticVersion]::ParseVersionString($PackageVersion)

--- a/eng/scripts/release-template/java.md
+++ b/eng/scripts/release-template/java.md
@@ -32,7 +32,7 @@ To use the GA and beta libraries, refer to the Maven dependency information belo
 
 ```
 
-[pattern]: # (<dependency>`n  <groupId>${GroupId}</groupId>`n  <artifactId>${PackageName}</artifactId>`n  <version>${PackageVersion}</version>`n</dependency>`n`n)
+[pattern]: # (<dependency>`n  <groupId>${GroupId}</groupId>`n  <artifactId>${PackageName}</artifactId>`n  <version>${PackageVersion}</version>`n</dependency>`n)
 
 ## Feedback
 


### PR DESCRIPTION
- Initialize GroupId property before expanding pattern string to allow groupId value to show up in Java.
- Update documentation for producing release notes and link to it in the Create/Update release notes oullrequest.