### PR TITLE
Fix bug in Generate-ReleaseNotes.ps1

### DIFF
--- a/eng/scripts/Generate-ReleaseNotes.ps1
+++ b/eng/scripts/Generate-ReleaseNotes.ps1
@@ -26,7 +26,7 @@ LogDebug "Release File Path [ $releaseFilePath ]"
 
 if (!(Test-Path $releaseFilePath))
 {
-    $PSScriptRoot\Generate-Release-Structure.ps1 -releaseFileName "${releaseFileName}.md"
+    &(Join-Path $PSScriptRoot Generate-Release-Structure.ps1) -releaseFileName "${releaseFileName}.md"
 }
 
 $existingReleaseContent = Get-Content $releaseFilePath


### PR DESCRIPTION
Bug fix to get `Generate-Release-Structure.ps1` running as part of Generate-ReleaseNotes.ps1