### PR TITLE
Split codeowners up by language

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,6 +59,11 @@ docs/redirects/              @kyle-patterson
 docs/tables/                 @kyle-patterson
 docs/typescript/             @bterlson @annelo-msft @salameer @xirzec
 eng/                         @weshaggard
-releases/                    @kyle-patterson @czubair @jeremymeng @alzimmermsft @ShivangiReja @xiangyan99 @kinelski @Mohit-Chakraborty
 _posts/                      @kyle-patterson
 _data/                       @czubair @weshaggard
+c.md                         @czubair @rickwinter
+cpp.md                       @czubair @rickwinter
+dotnet.md                    @czubair @Mohit-Chakraborty
+java.md                      @czubair @g2vinay
+js.md                        @czubair @KarishmaGhiya
+python.md                    @czubair @xiangyan99


### PR DESCRIPTION
This will split up the code owners/reviewers up by language and avoid adding everyone to all release notes for different languages.