### PR TITLE
Use tags for ios changelog links

### DIFF
--- a/releases/2020-10/ios.md
+++ b/releases/2020-10/ios.md
@@ -64,19 +64,19 @@ Detailed changelogs are linked from the [Quick Links](#quick-links) below. Here 
 
 ### Azure Communication Services Chat
 
-#### 1.0.0-beta.2 ([Changelog](https://github.com/Azure/azure-sdk-for-ios/blob/master/CHANGELOG.md#100-beta2-2020-10-05))
+#### 1.0.0-beta.2 ([Changelog](https://github.com/Azure/azure-sdk-for-ios/blob/1.0.0-beta.2/CHANGELOG.md#100-beta2-2020-10-05))
 
 - Initial Preview release for Azure Communication Services Chat
 
 ### Azure Communication Services Common
 
-#### 1.0.0-beta.1 ([Changelog](https://github.com/Azure/azure-sdk-for-ios/blob/master/CHANGELOG.md#100-beta1-2020-09-21))
+#### 1.0.0-beta.1 ([Changelog](https://github.com/Azure/azure-sdk-for-ios/blob/1.0.0-beta.2/CHANGELOG.md#100-beta1-2020-09-21))
 
 - Initial Preview release for Azure Communication Services Common
 
 ### Azure Core
 
-#### 1.0.0-beta.1 ([Changelog](https://github.com/Azure/azure-sdk-for-ios/blob/master/CHANGELOG.md#100-beta1-2020-09-21))
+#### 1.0.0-beta.1 ([Changelog](https://github.com/Azure/azure-sdk-for-ios/blob/1.0.0-beta.2/CHANGELOG.md#100-beta1-2020-09-21))
 
 - Initial Preview release for Azure Core
 

--- a/releases/2020-11/ios.md
+++ b/releases/2020-11/ios.md
@@ -93,7 +93,7 @@ If you have a bug or feature request for one of the libraries, please post an is
 
 ## Release highlights
 
-### 1.0.0-beta.6 ([Changelog](https://github.com/Azure/azure-sdk-for-ios/blob/master/CHANGELOG.md#100-beta6-2020-11-23))
+### 1.0.0-beta.6 ([Changelog](https://github.com/Azure/azure-sdk-for-ios/blob/1.0.0-beta.6/CHANGELOG.md#100-beta6-2020-11-23))
 
 #### Azure Communication Services Calling
 
@@ -102,7 +102,7 @@ If you have a bug or feature request for one of the libraries, please post an is
 - Fixed crash on calling `Call.hangup()`.
 - Fixed invalid values for `CFBundleVersion` and `CFBundleShortVersionString` in `Info.plist`.
 
-### 1.0.0-beta.5 ([Changelog](https://github.com/Azure/azure-sdk-for-ios/blob/master/CHANGELOG.md#100-beta5-2020-11-18))
+### 1.0.0-beta.5 ([Changelog](https://github.com/Azure/azure-sdk-for-ios/blob/1.0.0-beta.5/CHANGELOG.md#100-beta5-2020-11-18))
 
 #### Azure Communication Services Calling
 

--- a/releases/2021-01/ios.md
+++ b/releases/2021-01/ios.md
@@ -89,7 +89,7 @@ If you have a bug or feature request for one of the libraries, please post an is
 
 ## Release highlights
 
-### 1.0.0-beta.7 ([Changelog](https://github.com/Azure/azure-sdk-for-ios/blob/master/CHANGELOG.md#100-beta7-2021-01-12))
+### 1.0.0-beta.7 ([Changelog](https://github.com/Azure/azure-sdk-for-ios/blob/1.0.0-beta.7/CHANGELOG.md#100-beta7-2021-01-12))
 
 #### Azure Communication Services Calling
 

--- a/releases/2021-02/ios.md
+++ b/releases/2021-02/ios.md
@@ -92,7 +92,7 @@ If you have a bug or feature request for one of the libraries, please post an is
 
 ## Release highlights
 
-### 1.0.0-beta.8 ([Changelog](https://github.com/Azure/azure-sdk-for-ios/blob/master/CHANGELOG.md#100-beta8-2021-02-09))
+### 1.0.0-beta.8 ([Changelog](https://github.com/Azure/azure-sdk-for-ios/blob/1.0.0-beta.8/CHANGELOG.md#100-beta8-2021-02-09))
 #### Azure Communication Services Common
 
 ##### Breaking Changes

--- a/releases/2021-03/ios.md
+++ b/releases/2021-03/ios.md
@@ -101,7 +101,7 @@ If you have a bug or feature request for one of the libraries, please post an is
 
 ## Release highlights
 
-### 1.0.0-beta.9 ([Changelog](https://github.com/Azure/azure-sdk-for-ios/blob/master/CHANGELOG.md#100-beta9-2021-03-10))
+### 1.0.0-beta.9 ([Changelog](https://github.com/Azure/azure-sdk-for-ios/blob/1.0.0-beta.9/CHANGELOG.md#100-beta9-2021-03-10))
 #### Azure Communication
 ##### Breaking Changes
 - **Remove `CommunicationCloudEnvironment.fromModel()` method from Azure Communication package**.


### PR DESCRIPTION
FYI @tjprescott your recent changes broke these links so I changed them to use the release tags. 