### PR TITLE
Condition the creation of the release markdown files

### DIFF
--- a/eng/scripts/Generate-Release-Structure.ps1
+++ b/eng/scripts/Generate-Release-Structure.ps1
@@ -3,7 +3,8 @@ param (
   [string]$releaseTemplate = "$PSScriptRoot\release-template",
   [string]$releaseRootFolder = "$PSScriptRoot\..\..\releases",
   [bool]$publishRelease = $false,
-  [string]$releaseFileName = "*"
+  [string]$releaseFileName = "*",
+  [string[]]$ExcludeFileNames = @("dotnet.md", "java.md", "js.md", "python.md")
 )
 
 if ($releaseDateString -eq "") {
@@ -49,7 +50,7 @@ else {
   }
 
   ### Copy template files for ones that don't exist
-  foreach ($file in (Get-ChildItem $releaseTemplate/$releaseFileName)) {
+  foreach ($file in (Get-ChildItem $releaseTemplate/$releaseFileName -Exclude $ExcludeFileNames)) {
     $newFile = Join-Path $releasefolder $file.Name
     if (Test-Path $newFile) {
       Write-Host "Skipping $newFile because it already exists"

--- a/eng/scripts/Generate-ReleaseNotes.ps1
+++ b/eng/scripts/Generate-ReleaseNotes.ps1
@@ -82,11 +82,6 @@ $pathToRelatedYaml = (Join-Path $ReleaseDirectory ".." _data releases $releasePe
 LogDebug "Release File Path [ $releaseFilePath ]"
 LogDebug "Related Yaml File Path [ $pathToRelatedYaml ]"
 
-if (!(Test-Path $releaseFilePath))
-{
-    &(Join-Path $PSScriptRoot Generate-Release-Structure.ps1) -releaseFileName "${releaseFileName}.md"
-}
-
 if (!(Test-Path $pathToRelatedYaml))
 {
     New-Item -Path $pathToRelatedYaml -Force
@@ -129,3 +124,8 @@ foreach ($entry in $filteredReleaseHighlights)
 }
 
 Set-Content -Path $pathToRelatedYaml -Value (ConvertTo-Yaml $existingYamlContent)
+
+if (!(Test-Path $releaseFilePath) -and $existingYamlContent.entries.Count -gt 0)
+{
+    &(Join-Path $PSScriptRoot Generate-Release-Structure.ps1) -releaseFileName "${releaseFileName}.md" -ExcludeFileNames @()
+}


### PR DESCRIPTION
- Exclude "dotnet.md", "java.md", "js.md", "python.md" when copying over release template for other languages.
- Only copy over the template when there is generated yml data.