### PR TITLE
Java guidelines updates for May

### DIFF
--- a/docs/java/implementation.md
+++ b/docs/java/implementation.md
@@ -41,7 +41,7 @@ public final class ConfigurationAsyncClient {
 | Annotation | Location | Description |
 |:-----------|:---------|:------------|
 | `@ServiceClient` | Service Client | Specifies the builder responsible for instantiating the service client, whether the API is asynchronous, and a reference back to the service interface (the interface annotated with `@ServiceInterface`). |
-| `@ServiceMethod` | Service Method | Placed on all service client methods that do network operations. |
+| `@ServiceMethod` | Service Method | Placed on all methods that do network operations, regardless of whether it is a client class or not. |
 
 #### Service Client Builder
 

--- a/docs/java/introduction.md
+++ b/docs/java/introduction.md
@@ -536,7 +536,7 @@ If in common scenarios, users are likely to pass just a small subset of what the
 
 {% include requirement/MUST id="java-params-complex-withResponse" %} use the _options_ parameter type, if it exists, for all `*WithResponse` methods. If no _options_ parameter type exists, do not create one solely for the `*WithResponse` method.
 
-{% include requirement/MUST id="java-params-options-package" %} place all options types in a root-level `options` package, to make options types distinct from service clients and model types.
+{% include requirement/MUST id="java-params-options-package" %} place all options types in a root-level `models` package, to prevent too many root-level packages and to make use of the existing `models` package used by other model types.
 
 {% include requirement/MUST id="java-params-options-design" %} design options types with the same design guidance as given below for model class types, namely fluent setters for optional arguments, using the standard JavaBean naming convention of `get*`, `set*`, and `is*`. Additionally, there may be constructor overloads for each combination of required arguments.
 
@@ -865,7 +865,7 @@ Examples of situations where this is applicable include when there are construct
 
 Enumerations in Java are extremely convenient, but used improperly can lead to breaking changes to the API. This is because often the Java compiler is configured to fail if not all enum values are listed in a switch statement, so with the addition of a new enum value, users will encounter breaking builds when updating their dependency to a newer version. Because of this, the Java azure-core ships with the `ExpandableStringEnum` that is the suggested means through which enumerations are exposed. Whilst not technically a Java enumeration, it can be treated as such in much the same way, without concerns about breaking changes from adding new values. It is also more user-friendly when new values are introduced on the service side before a library update has been shipped, as users can manually create their own values within the context of a single `ExpandableStringEnum`.
 
-{% include requirement/MUSTNOT id="java-enums" %} define Java enum types for parameters, properties, and return types, except when values are fixed and will never change over time.
+{% include requirement/MUSTNOT id="java-enums" %} define Java enum types for parameters, properties, and return types, except in two scenarios: 1) when values are fixed and will never change over time, or 2) when the enum is used as an input-only enum and therefore the likelihood of users running into breaking changes (i.e. when they must `switch` over all values) is low.
 
 {% include requirement/MUST id="java-naming-enum-uppercase" %} use all upper-case names for enum (and `ExpandableStringEnum`) values. `EnumType.FOO` and `EnumType.TWO_WORDS` are valid, whereas `EnumType.Foo` and `EnumType.twoWords` are not.
 

--- a/docs/java/introduction.md
+++ b/docs/java/introduction.md
@@ -73,8 +73,6 @@ There exists a distinction that must be made clear with service clients: not all
 
 {% include requirement/MUST id="java-service-client-immutable" %} ensure that all service client classes are immutable and stateless upon instantiation.
 
-{% include requirement/MUSTNOT id="java-service-client-overuse" %} overuse the _Client_ suffix for classes that do not meet the expectations for a service client.
-
 {% include requirement/MUST id="java-network-separate-packages" %} have separate service clients for sync and async APIs.
 
 #### Sync Service Clients
@@ -378,7 +376,7 @@ public class UserApplication {
 
 #### Service Methods
 
-Service methods are the methods on the client that invoke operations on the service.
+Service methods are methods that invoke operations on a service. They are commonly found on classes suffixed with `Client`, but can also be found on other resource classes that are vended by a client.
 
 {% include requirement/MUSTNOT id="java-async-suffix" %} use the suffix `Async` in methods that do operations asynchronously. Let the fact the user has an instance of an 'async client' provide this context.
 
@@ -424,9 +422,7 @@ Clients often have non-service methods, for accessing details such as the servic
 
 {% include requirement/MUST id="java-service-client-method-naming" %} use standard JavaBean naming prefixes for all methods that are not service methods.
 
-{% include requirement/MUST id="java-service-client-vend-prefix" %} prefix methods in sync clients that create or vend sub-clients with `get` and suffix with `Client`. For example, `container.getBlobClient()`.
-
-{% include requirement/MUST id="java-service-async-client-vend-prefix" %} prefix methods in async clients that create or vend sub-clients with `get` and suffix with `AsyncClient`. For example, `container.getBlobAsyncClient()`.
+{% include requirement/MUST id="java-service-client-vend-prefix" %} prefix methods in sync clients that create or vend sub-clients with `get` and suffix with `Client`. For example, `container.getBlobClient()`. Similarly, prefix methods in async clients that create or vend sub-clients with `get` and suffix with `AsyncClient`. For example, `container.getBlobAsyncClient()`. Keep in mind the guidance in the [service client](#service-client) section, as it cannot be assumed that the `Client` suffix applies to another client-like class vended by a client. The `Client` suffix is only applicable in certain situations, and therefore, methods should not be named `get*Client` if the type is not a client.
 
 ##### Cancellation
 
@@ -556,7 +552,7 @@ Common parameter validations include null checks, empty string checks, and range
 
 #### Methods Returning Collections (Paging)
 
-Many Azure REST APIs return collections of data in batches or pages. A client library will expose such APIs as special enumerable types `PagedIterable<T>` or `PagedFlux<T>`, for synchronous and asynchronous APIs, respectively. These types are located in the [azure-core library](#using-azure-core-types).
+Many Azure REST APIs return collections of data in batches or pages. A client library will expose such APIs as special enumerable types `PagedIterable<T>` or `PagedFlux<T>` (or one of their parent types), for synchronous and asynchronous APIs, respectively. These types are located in the [azure-core library](#using-azure-core-types).
 
 {% include requirement/MUST id="java-pagination-pagediterable" %} return `PagedIterable<T>` from service methods in synchronous that return a collection of items. For example, the configuration service **sync** client should offer the following API:
 
@@ -653,7 +649,7 @@ public final class <service_name>AsyncClient {
 
 {% include requirement/MUST id="java-lro-prefix" %} prefix method names which return a poller with the `begin` prefix.
 
-{% include requirement/MUST id="java-lro-continuation" %} provide a way to instantiate a poller with the serialized state of another poller to begin where it left off, for example by passing the state as a parameter to the same method which started the operation (or an overload).
+{% include requirement/MUST id="java-lro-continuation" %} provide a way to instantiate a poller with the serialized state of another poller to begin where it left off, for example by passing the state as a parameter to the same method which started the operation, or by directly instantiating a poller with that state.
 
 {% include requirement/MUSTNOT id="java-lro-no-void-terminal-state" %} specify any poller (`SyncPoller` or `PollerFlux`) with a terminal state (i.e. the `U` in `SyncPoller<T, U>` or `PollerFlux<T, U>`) as being `void`. This does not benefit users, as it is typically their desire to inspect the terminal state for some quality, and by being void we are making this inspection more difficult than necessary.
 

--- a/docs/java/introduction.md
+++ b/docs/java/introduction.md
@@ -861,7 +861,10 @@ Examples of situations where this is applicable include when there are construct
 
 Enumerations in Java are extremely convenient, but used improperly can lead to breaking changes to the API. This is because often the Java compiler is configured to fail if not all enum values are listed in a switch statement, so with the addition of a new enum value, users will encounter breaking builds when updating their dependency to a newer version. Because of this, the Java azure-core ships with the `ExpandableStringEnum` that is the suggested means through which enumerations are exposed. Whilst not technically a Java enumeration, it can be treated as such in much the same way, without concerns about breaking changes from adding new values. It is also more user-friendly when new values are introduced on the service side before a library update has been shipped, as users can manually create their own values within the context of a single `ExpandableStringEnum`.
 
-{% include requirement/MUSTNOT id="java-enums" %} define Java enum types for parameters, properties, and return types, except in two scenarios: 1) when values are fixed and will never change over time, or 2) when the enum is used as an input-only enum and therefore the likelihood of users running into breaking changes (i.e. when they must `switch` over all values) is low.
+{% include requirement/MUSTNOT id="java-enums" %} define Java enum types for parameters, properties, and return types, except in two scenarios: 
+
+1) When values are fixed and will never change over time, or,
+2) When the enum is used as an input-only enum and therefore the likelihood of users running into breaking changes (i.e. when they must `switch` over all values) is low.
 
 {% include requirement/MUST id="java-naming-enum-uppercase" %} use all upper-case names for enum (and `ExpandableStringEnum`) values. `EnumType.FOO` and `EnumType.TWO_WORDS` are valid, whereas `EnumType.Foo` and `EnumType.twoWords` are not.
 
@@ -1028,7 +1031,7 @@ In Java, the namespace should be named `com.azure.<group>.<service>[.<feature>]`
 
 If the client library does not seem to fit into the group list, contact the [Architecture Board] to discuss the namespace requirements.
 
-{% include requirement/MUST id="java-namespaces-management" %} place the management (Azure Resource Manager) API in the `resourcemanager` group.  Use the grouping `<AZURE>.resourcemanager.<service>` for the namespace. Management plane libraries do not have a `<group>`.
+{% include requirement/MUST id="java-namespaces-management" %} place the management (Azure Resource Manager) API in the `resourcemanager` group.  Use the grouping `com.azure.resourcemanager.<service>` for the namespace. Management plane libraries do not have a `<group>`.
 
 {% include requirement/MUST id="java-namespaces-registration" %} register the chosen namespace with the [Architecture Board].  Open an issue to request the namespace.  See [the registered namespace list](registered_namespaces.html) for a list of the currently registered namespaces.
 

--- a/docs/java/spring.md
+++ b/docs/java/spring.md
@@ -18,7 +18,7 @@ Providing the Spring ecosystem with a first-class experience is of the utmost im
 
 ### Maven
 
-{% include requirement/MUST id="java-spring-maven-groupid" %} use the group ID of `com.azure`.
+{% include requirement/MUST id="java-spring-maven-groupid" %} use the group ID of `com.azure.spring`.
 
 {% include requirement/MUST id="java-spring-maven-artifactid" %} specify the `artifactId` to be of the form `azure-spring-boot-starter-<group>-<service>[-<feature>]`, for example, `azure-spring-boot-starter-storage-blob` or `azure-spring-boot-starter-security-keyvault-secrets`.
 


### PR DESCRIPTION
A small batch of guidelines updates:

* When to use Client suffix for sub-clients
* Immutability expectations around model collection types
* PollerFlux / SyncPoller terminal state expectations (no voids)
* Stronger guidance around enums
* Fix guideline around management plane group expectations
* Remove todo around LRO rehydration