### PR TITLE
Update support policy with details for JS runtimes

### DIFF
--- a/docs/policies/support.md
+++ b/docs/policies/support.md
@@ -48,13 +48,7 @@ For Mobile development, please check the [IOS supported platforms](https://azure
 
 - Any platforms supporting .NET Standard 2.0. Tested on .NET Framework 4.6.1 and .NET Core 2.1, .NET 5.0
 - Java: Java 8 , Java 11
-- JS/TS:
-  - Node.js: [LTS versions of Node.js](https://nodejs.org/about/releases/) including not just the ones in Active status, but also the ones in Maintainence status.
-  - Browsers:
-    - Apple Safari: latest two versions
-    - Google Chrome: latest two versions
-    - Microsoft Edge: all supported versions
-    - Mozilla FireFox: latest two versions
+- Node.js: [LTS versions of Node.js](https://nodejs.org/about/releases/) including not just the ones in Active status, but also the ones in Maintainence status.
 - Python 3.5+, 2.7
 - Go runtime– we support 2 latest major Go releases, refer to https://golang.org/doc/devel/release.html for more details.”
 - For C, refer to the list of supported platforms and compilers [here](https://azure.github.io/azure-sdk/clang_design.html)

--- a/docs/policies/support.md
+++ b/docs/policies/support.md
@@ -46,8 +46,8 @@ For Mobile development, please check the [IOS supported platforms](https://azure
 
 **Runtime:**
 
-- Any platforms supporting .NET Standard 2.0. Tested on .NET Framework 4.6.1 and .NET Core 2.1, .NET 5.0, see test configuration [here](https://github.com/Azure/azure-sdk-for-net/blob/master/eng/pipelines/templates/stages/platform-matrix.json)
-- Java: Java 8 , Java 11, see test configuration [here](https://github.com/Azure/azure-sdk-for-java/blob/master/eng/pipelines/templates/stages/platform-matrix.json)
+- Any platforms supporting .NET Standard 2.0. Tested on .NET Framework 4.6.1 and .NET Core 2.1, .NET 5.0
+- Java: Java 8 , Java 11
 - JS/TS:
   - Node.js: [LTS versions of Node.js](https://nodejs.org/about/releases/) including not just the ones in Active status, but also the ones in Maintainence status.
   - Browsers:
@@ -55,9 +55,16 @@ For Mobile development, please check the [IOS supported platforms](https://azure
     - Google Chrome: latest two versions
     - Microsoft Edge: all supported versions
     - Mozilla FireFox: latest two versions
-- Python 3.5+, 2.7 , see test configuration [here](https://github.com/Azure/azure-sdk-for-python/blob/master/eng/pipelines/templates/stages/platform-matrix.json)
+- Python 3.5+, 2.7
 - Go runtime– we support 2 latest major Go releases, refer to https://golang.org/doc/devel/release.html for more details.”
 - For C, refer to the list of supported platforms and compilers [here](https://azure.github.io/azure-sdk/clang_design.html)
+
+**Test configurations:**
+
+- [.NET test configuration](https://github.com/Azure/azure-sdk-for-java/blob/master/eng/pipelines/templates/stages/platform-matrix.json)
+- [Java test configuration](https://github.com/Azure/azure-sdk-for-java/blob/master/eng/pipelines/templates/stages/platform-matrix.json)
+- [JavaScript test configuration](https://github.com/Azure/azure-sdk-for-js/blob/master/eng/pipelines/templates/stages/platform-matrix.json)
+- [Python test configuration](https://github.com/Azure/azure-sdk-for-python/blob/master/eng/pipelines/templates/stages/platform-matrix.json)
 
 ### **Support**:
 

--- a/docs/policies/support.md
+++ b/docs/policies/support.md
@@ -55,7 +55,7 @@ For Mobile development, please check the [IOS supported platforms](https://azure
 
 **Test configurations:**
 
-Below are the test configurations covering different operating systems and runtimes. You may see some outgoing versions for which we drop support or incoming versions that we don't officially support yet. Please see the details in the previous section for the officially supported set.
+Below are the test configurations covering different operating systems and runtimes. You may see some outgoing versions for which we are dropping support or incoming versions that we don't officially support yet. Please see the details in the previous section for the officially supported set.
 
 - [.NET test configuration](https://github.com/Azure/azure-sdk-for-java/blob/master/eng/pipelines/templates/stages/platform-matrix.json)
 - [Java test configuration](https://github.com/Azure/azure-sdk-for-java/blob/master/eng/pipelines/templates/stages/platform-matrix.json)

--- a/docs/policies/support.md
+++ b/docs/policies/support.md
@@ -7,47 +7,59 @@ sidebar: general_sidebar
 
 ## **Azure SDK lifecycle and support policy**
 
-Azure SDK Lifecycle and support are governed by the latest [Microsoft Modern Lifecycle Policy](https://docs.microsoft.com/en-US/lifecycle/policies/modern),  which will prevail in case of any conflicts with the information below. 
+Azure SDK Lifecycle and support are governed by the latest [Microsoft Modern Lifecycle Policy](https://docs.microsoft.com/en-US/lifecycle/policies/modern), which will prevail in case of any conflicts with the information below.
 
-### **Package lifecycle** 
+### **Package lifecycle**
+
 Here are the stages of a typical package lifecycle (for major versions)
-1.	**Beta** – A new SDK that is available for early access and feedback purposes and is not recommended for use in production. 
-The beta version support is limited to GitHub issues and response time is not guaranteed. Beta releases live typically for less than 1 year, after which they are either retired or released to GA.
 
-2.	**Active** - The SDKs are generally available and fully supported, will receive new feature updates, as well as bug and security fixes.  
-The major version will remain active for at least 12 months from the release date. Compatible updates for the major release are provided through minor versions, or patch versions.  
-Customers are encouraged to use the latest version as that is the version that will get fixes and updates.  
+1. **Beta** – A new SDK that is available for early access and feedback purposes and is not recommended for use in production.
+   The beta version support is limited to GitHub issues and response time is not guaranteed. Beta releases live typically for less than 1 year, after which they are either retired or released to GA.
 
-3.	**Maintenance** - Typically, maintenance mode is announced at the same time as the next major version is transitioned to Active,  
-after which the releases will only address the most critical bug fixes and security fixes for at least another 12 months.  
+2. **Active** - The SDKs are generally available and fully supported, will receive new feature updates, as well as bug and security fixes.  
+   The major version will remain active for at least 12 months from the release date. Compatible updates for the major release are provided through minor versions, or patch versions.  
+   Customers are encouraged to use the latest version as that is the version that will get fixes and updates.
 
-4.	**Community** - SDK will no longer receive updates from Microsoft unless otherwise specified in the separate customer agreement.  
-The package will remain available via public package managers and the GitHub repo, which can be maintained by the community.  
+3. **Maintenance** - Typically, maintenance mode is announced at the same time as the next major version is transitioned to Active,  
+   after which the releases will only address the most critical bug fixes and security fixes for at least another 12 months.
 
-You can check the lifecycle stage for your package at [this page](https://azure.github.io/azure-sdk/releases/latest/index.html)  
+4. **Community** - SDK will no longer receive updates from Microsoft unless otherwise specified in the separate customer agreement.  
+   The package will remain available via public package managers and the GitHub repo, which can be maintained by the community.
 
-### **Azure Clouds** 
+You can check the lifecycle stage for your package at [this page](https://azure.github.io/azure-sdk/releases/latest/index.html)
+
+### **Azure Clouds**
+
 By default, the Azure libraries are configured to connect to the Global Azure Cloud.  
 Additional cloud target platforms are available, such as Azure Stack, Azure China and Government Cloud.  
-Package lifecycle may vary across different target platforms. Refer to the target platform documentation for more information.   
+Package lifecycle may vary across different target platforms. Refer to the target platform documentation for more information.
 
 ### **Azure SDK dependencies**
+
 The Azure SDK libraries depend on Azure Service REST API, programming language runtime, OS, and third-party libraries.  
-The Azure SDK will not guarantee support of dependencies that reached their end of life.  
+The Azure SDK will not guarantee support of dependencies that reached their end of life.
 
-Below is a list of common Azure SDK dependencies for your reference: 
+Below is a list of common Azure SDK dependencies for your reference:
 
-**Operating Systems:** Windows 10, macOS-10.15 , Linux (tested on Ubuntu 18.04) 
-For Mobile development, please find IOS supported platforms [here](https://azure.github.io/azure-sdk/ios_design.html#ios-library-support), and Android supported platforms [here](https://azure.github.io/azure-sdk/android_design.html)
+**Operating Systems:** Windows 10, macOS-10.15 , Linux (tested on Ubuntu 18.04)
+For Mobile development, please check the [IOS supported platforms](https://azure.github.io/azure-sdk/ios_design.html#ios-library-support), and the [Android supported platforms](https://azure.github.io/azure-sdk/android_design.html)
 
-**Runtime:** 
-* Any platforms supporting .NET Standard 2.0. Tested on .NET Framework 4.6.1 and .NET Core 2.1, .NET 5.0, see test configuration [here](https://github.com/Azure/azure-sdk-for-net/blob/master/eng/pipelines/templates/stages/platform-matrix.json)  
-* Java: Java 8 , Java 11, see test configuration [here](https://github.com/Azure/azure-sdk-for-java/blob/master/eng/pipelines/templates/stages/platform-matrix.json)  
-* JS/TS: Node 8.x,10.x,12.x,14.x , see test configuration [here](https://github.com/Azure/azure-sdk-for-js/blob/master/eng/pipelines/templates/stages/platform-matrix.json)  
-* Python 3.5+, 2.7 , see test configuration [here](https://github.com/Azure/azure-sdk-for-python/blob/master/eng/pipelines/templates/stages/platform-matrix.json)  
-* Go runtime– we support 2 latest major Go releases, refer to  https://golang.org/doc/devel/release.html for more details.”
-* For C, refer to the list of supported platforms and compilers [here](https://azure.github.io/azure-sdk/clang_design.html)
+**Runtime:**
+
+- Any platforms supporting .NET Standard 2.0. Tested on .NET Framework 4.6.1 and .NET Core 2.1, .NET 5.0, see test configuration [here](https://github.com/Azure/azure-sdk-for-net/blob/master/eng/pipelines/templates/stages/platform-matrix.json)
+- Java: Java 8 , Java 11, see test configuration [here](https://github.com/Azure/azure-sdk-for-java/blob/master/eng/pipelines/templates/stages/platform-matrix.json)
+- JS/TS:
+  - Node.js: [LTS versions of Node.js](https://nodejs.org/about/releases/)(both Active and Maintainence status)
+  - Browsers:
+    - Apple Safari: latest two versions
+    - Google Chrome: latest two versions
+    - Microsoft Edge: all supported versions
+    - Mozilla FireFox: latest two versions
+- Python 3.5+, 2.7 , see test configuration [here](https://github.com/Azure/azure-sdk-for-python/blob/master/eng/pipelines/templates/stages/platform-matrix.json)
+- Go runtime– we support 2 latest major Go releases, refer to https://golang.org/doc/devel/release.html for more details.”
+- For C, refer to the list of supported platforms and compilers [here](https://azure.github.io/azure-sdk/clang_design.html)
 
 ### **Support**:
+
 Customers with a support plan can open an Azure Support ticket [here](https://azure.microsoft.com/en-us/support/create-ticket/)  
-You can open GitHub issues [in the Azure SDK GitHub repositories](https://github.com/Azure/azure-sdk/blob/master/README.md) to track bugs and feature requests. GitHub issues are free, but may take a longer time to process.   
+You can open GitHub issues [in the Azure SDK GitHub repositories](https://github.com/Azure/azure-sdk/blob/master/README.md) to track bugs and feature requests. GitHub issues are free, but may take a longer time to process.

--- a/docs/policies/support.md
+++ b/docs/policies/support.md
@@ -49,7 +49,7 @@ For Mobile development, please check the [IOS supported platforms](https://azure
 - Any platforms supporting .NET Standard 2.0. Tested on .NET Framework 4.6.1 and .NET Core 2.1, .NET 5.0, see test configuration [here](https://github.com/Azure/azure-sdk-for-net/blob/master/eng/pipelines/templates/stages/platform-matrix.json)
 - Java: Java 8 , Java 11, see test configuration [here](https://github.com/Azure/azure-sdk-for-java/blob/master/eng/pipelines/templates/stages/platform-matrix.json)
 - JS/TS:
-  - Node.js: [LTS versions of Node.js](https://nodejs.org/about/releases/)(both Active and Maintainence status)
+  - Node.js: [LTS versions of Node.js](https://nodejs.org/about/releases/) including not just the ones in Active status, but also the ones in Maintainence status.
   - Browsers:
     - Apple Safari: latest two versions
     - Google Chrome: latest two versions

--- a/docs/policies/support.md
+++ b/docs/policies/support.md
@@ -55,6 +55,8 @@ For Mobile development, please check the [IOS supported platforms](https://azure
 
 **Test configurations:**
 
+Below are the test configurations covering different operating systems and runtimes. You may see some outgoing versions for which we drop support or incoming versions that we don't officially support yet. Please see the details in the previous section for the officially supported set.
+
 - [.NET test configuration](https://github.com/Azure/azure-sdk-for-java/blob/master/eng/pipelines/templates/stages/platform-matrix.json)
 - [Java test configuration](https://github.com/Azure/azure-sdk-for-java/blob/master/eng/pipelines/templates/stages/platform-matrix.json)
 - [JavaScript test configuration](https://github.com/Azure/azure-sdk-for-js/blob/master/eng/pipelines/templates/stages/platform-matrix.json)


### PR DESCRIPTION
This PR updates the support policy for JS around runtimes.
- Link to official docs on LTS versions of Node.js rather than the test matrix we maintain
~~- Include note on browsers with text copied from https://azure.github.io/azure-sdk/typescript_design.html#ts-platform-support~~

Other changes:
- My formatter formatted the file, so a whole bunch of whitespace only changes
- Fix the link texts to not be just the word "here" which is bad for accessibility

@xirzec I wanted to instead just add link to https://azure.github.io/azure-sdk/typescript_design.html#ts-platform-support, but would hold that off until other languages have a similar section.

_Tip to reviewers: Use the "Hide whitespace changes" option to reduce the noise in the PR diff_
