### PR TITLE
Note that dropping support for EOL dependencies will be done without increasing major version

### DIFF
--- a/docs/policies/support.md
+++ b/docs/policies/support.md
@@ -37,7 +37,8 @@ Package lifecycle may vary across different target platforms. Refer to the targe
 ### **Azure SDK dependencies**
 
 The Azure SDK libraries depend on Azure Service REST API, programming language runtime, OS, and third-party libraries.  
-The Azure SDK will not guarantee support of dependencies that reached their end of life.
+
+> The Azure SDK libraries will not guarantee support of dependencies that reached their end of life. Dropping support for such dependencies will be done without increasing the major version of the libraries.
 
 Below is a list of common Azure SDK dependencies for your reference:
 


### PR DESCRIPTION


- Bring more attention to the fact that we do not support dependencies that reach EOL
- Add note that dropping support for EOL dependencies will be done without increasing major version