### PR TITLE
Update release note generation

### DIFF
--- a/_data/releases/latest/ios-packages.csv
+++ b/_data/releases/latest/ios-packages.csv
@@ -1,4 +1,5 @@
 "Package","VersionGA","VersionPreview","DisplayName","ServiceName","RepoPath","MSDocs","GHDocs","Type","New","PlannedVersions","FirstGADate","Support","Hide","Replace","Notes"
-"AzureCommunicationChat","","1.0.0-beta.11","Communication Chat","Communication","communication","NA","NA","client","true","","","","","",""
-"AzureCommunication","","1.0.0-beta.11","Communication Common","Communication","communication","NA","NA","client","true","","","","","",""
-"AzureCore","","1.0.0-beta.11","Core","Core","core","NA","NA","client","true","","","","","",""
+"AzureCommunicationCalling","1.0.1","1.1.0-beta.1","Communication Calling","Communication","communication","NA","NA","client","true","","","","","",""
+"AzureCommunicationChat","","1.0.0-beta.12","Communication Chat","Communication","communication","NA","NA","client","true","","","","","",""
+"AzureCommunicationCommon","1.0.0","","Communication Common","Communication","communication","NA","NA","client","true","","","","","",""
+"AzureCore","","1.0.0-beta.12","Core","Core","core","NA","NA","client","true","","","","","",""

--- a/_includes/releases/variables/ios.md
+++ b/_includes/releases/variables/ios.md
@@ -1,7 +1,7 @@
 {% assign package_label = "spm" %}
 {% assign package_trim = "Azure" %}
 {% assign pre_suffix = "" %}
-{% assign package_url_template = "https://github.com/Azure/azure-sdk-for-ios/tree/item.Version/sdk/item.RepoPath/item.Package" %}
+{% assign package_url_template = "https://github.com/Azure/azure-sdk-for-ios/tree/item.Package_item.Version/sdk/item.RepoPath/item.Package" %}
 <!--{% assign msdocs_url_template = "https://docs.microsoft.com/ios/api/overview/azure/item.TrimmedPackage-readme" %}-->
 <!--{% assign ghdocs_url_template = "https://azuresdkdocs.blob.core.windows.net/$web/ios/item.Package/item.Version/index.html" %}-->
-{% assign source_url_template = "https://github.com/Azure/azure-sdk-for-ios/tree/item.Version/sdk/item.RepoPath/item.Package" %}
+{% assign source_url_template = "https://github.com/Azure/azure-sdk-for-ios/tree/item.Package_item.Version/sdk/item.RepoPath/item.Package" %}

--- a/eng/pipelines/template/steps/generate-releasenotes.yml
+++ b/eng/pipelines/template/steps/generate-releasenotes.yml
@@ -1,13 +1,4 @@
 parameters:
-- name: CommonScriptPath
-  type: string
-  default: ""
-- name: ChangedPackagesPath
-  type: string
-  default: ""
-- name: DefaultBranch
-  type: string
-  default: ""
 - name: PrBranchName
   type: string
   default: "CreateOrUpdateReleaseDataFor"
@@ -30,9 +21,16 @@ steps:
     displayName: Set Release Period Value
 
   - pwsh: |
-      $(System.DefaultWorkingDirectory)/azure-sdk-tools/eng/common/scripts/Delete-RemoteBranches.ps1 -RepoOwner "azure-sdk" `
+      $(AzureSDKToolsScriptsPath)/Delete-RemoteBranches.ps1 -RepoOwner "azure-sdk" `
       -ForkRepoOwner "Azure" -RepoName "azure-sdk" -BranchPrefix '${{ parameters.PrBranchName }}' -AuthToken $(azuresdk-github-pat)
     displayName: Clean Up Stale Branches
+
+  - pwsh: |
+      git clone https://github.com/Azure/azure-sdk.git $(AzureSDKReleaseNotesClonePath)
+      cd $(AzureSDKReleaseNotesClonePath)
+      git remote add azure-sdk-fork "https://$(azuresdk-github-pat)@github.com/azure-sdk/azure-sdk.git"
+    displayName: Clone azure-sdk for release notes
+    condition: and(succeeded(), ne(variables['AzureSDKReleaseNotesClonePath'], variables['AzureSDKClonePath']))
 
   - ${{ each repo in parameters.Repos }}:
     - pwsh: |
@@ -53,34 +51,34 @@ steps:
         }
         else {
           # Reset back to the head of default so we can build on top of that if the branch doesn't already exist.
-          git reset --hard origin/${{ parameters.DefaultBranch }}
+          git reset --hard origin/$(DefaultBranch)
 
           Write-Host "git checkout -b $PRBranchName."
           git checkout -b $PRBranchName
         }
       displayName: Checkout Previous PRBranch if it exist.
-      workingDirectory: $(System.DefaultWorkingDirectory)/azure-sdk
+      workingDirectory: $(AzureSDKReleaseNotesClonePath)
 
     - task: PowerShell@2
       displayName: 'Generate ReleaseNotes for the Release Period'
       inputs:
         pwsh: true
         workingDirectory: $(System.DefaultWorkingDirectory)
-        filePath: $(System.DefaultWorkingDirectory)/azure-sdk/eng/scripts/Generate-ReleaseNotes.ps1
+        filePath: $(AzureSDKClonePath)/eng/scripts/Generate-ReleaseNotes.ps1
         arguments: >
           -releasePeriod $(ReleasePeriod)
-          -commonScriptPath ${{ parameters.CommonScriptPath }}
-          -releaseDirectory $(System.DefaultWorkingDirectory)/azure-sdk/releases
+          -commonScriptPath $(AzureSDKToolsScriptsPath)
+          -releaseDirectory $(AzureSDKClonePath)/releases
           -repoLanguage ${{ repo.value.Language }}
-          -changedPackagesPath ${{ parameters.ChangedPackagesPath }}
+          -github_pat '$(azuresdk-github-pat)'
 
     - template: eng/common/pipelines/templates/steps/create-pull-request.yml@azure-sdk-tools
       parameters:
         RepoName: azure-sdk
-        BaseBranchName: ${{ parameters.DefaultBranch }}
+        BaseBranchName: $(DefaultBranch)
         PRBranchName: $(PRBranchName)
         CommitMsg: "${{ repo.value.Language }} release notes for the $(ReleasePeriod) release"
         PRTitle: "${{ repo.value.Language }} release notes for the $(ReleasePeriod) release"
         PRBody: "This is an automated pull request to gather the ${{ repo.value.Language }} release notes for the $(ReleasePeriod) release. See [Producing Release Notes](https://github.com/Azure/azure-sdk/blob/master/docs/policies/releasenotes.md#producing-release-notes) for details of the processing."
-        WorkingDirectory: $(System.DefaultWorkingDirectory)/azure-sdk
-        ScriptDirectory: $(System.DefaultWorkingDirectory)/azure-sdk-tools/eng/common/scripts
+        WorkingDirectory: $(AzureSDKReleaseNotesClonePath)
+        ScriptDirectory: $(AzureSDKToolsScriptsPath)

--- a/eng/pipelines/template/steps/generate-releasenotes.yml
+++ b/eng/pipelines/template/steps/generate-releasenotes.yml
@@ -68,7 +68,7 @@ steps:
         arguments: >
           -releasePeriod $(ReleasePeriod)
           -commonScriptPath $(AzureSDKToolsScriptsPath)
-          -releaseDirectory $(AzureSDKReleaseNotesClonePath)/releases
+          -releaseDirectory $(AzureSDKReleaseNotesClonePath)/_data/releases
           -repoLanguage ${{ repo.value.Language }}
           -github_pat '$(azuresdk-github-pat)'
 

--- a/eng/pipelines/template/steps/generate-releasenotes.yml
+++ b/eng/pipelines/template/steps/generate-releasenotes.yml
@@ -68,7 +68,7 @@ steps:
         arguments: >
           -releasePeriod $(ReleasePeriod)
           -commonScriptPath $(AzureSDKToolsScriptsPath)
-          -releaseDirectory $(AzureSDKClonePath)/releases
+          -releaseDirectory $(AzureSDKReleaseNotesClonePath)/releases
           -repoLanguage ${{ repo.value.Language }}
           -github_pat '$(azuresdk-github-pat)'
 

--- a/eng/pipelines/version-updater.yml
+++ b/eng/pipelines/version-updater.yml
@@ -10,7 +10,9 @@ resources:
       ref: refs/tags/azure-sdk-tools_20210604.1
 
 variables:
-  ChangedPackagesFilePath: $(Build.StagingDirectory)/ChangedPackages.json
+  AzureSDKClonePath: $(System.DefaultWorkingDirectory)/azure-sdk
+  AzureSDKReleaseNotesClonePath: $(System.DefaultWorkingDirectory)/azure-sdk-notes
+  AzureSDKToolsScriptsPath: $(System.DefaultWorkingDirectory)/azure-sdk-tools/eng/common/scripts
 
 steps:
 - checkout: self
@@ -20,22 +22,21 @@ steps:
   displayName: Update packages from package manager
   inputs:
     pwsh: true
-    filePath: ./azure-sdk/eng/scripts/Query-Azure-Packages.ps1
+    filePath: $(AzureSDKClonePath)/eng/scripts/Query-Azure-Packages.ps1
 
 - task: PowerShell@2
   displayName: Update packages from sdk release data
   inputs:
     pwsh: true
-    filePath: ./azure-sdk/eng/scripts/Update-Release-Versions.ps1
+    filePath: $(AzureSDKClonePath)/eng/scripts/Update-Release-Versions.ps1
     arguments: >
       -github_pat '$(azuresdk-github-pat)'
-      -changedPackagesPath $(ChangedPackagesFilePath)
 
 - task: PowerShell@2
   displayName: Update release DevOps work-items
   inputs:
     pwsh: true
-    filePath: ./azure-sdk/eng/scripts/Update-DevOps-WorkItems.ps1
+    filePath: $(AzureSDKClonePath)/eng/scripts/Update-DevOps-WorkItems.ps1
     arguments: >
       -github_pat '$(azuresdk-github-pat)'
       -devops_pat '$(azuresdk-azure-sdk-devops-release-work-item-pat)'
@@ -44,13 +45,13 @@ steps:
     # Some steps, like release notes, require this remote all the time so lets always setup even if there are no changes
     git remote add azure-sdk-fork "https://$(azuresdk-github-pat)@github.com/azure-sdk/azure-sdk.git"
   displayName: Setup azure-sdk-fork remote
-  workingDirectory: $(System.DefaultWorkingDirectory)/azure-sdk
+  workingDirectory: $(AzureSDKClonePath)
 
 - pwsh: |
     $defaultBranch = (git remote show origin | Out-String) -replace "(?ms).*HEAD branch: (\w+).*", '$1'
     echo "##vso[task.setvariable variable=DefaultBranch]$defaultBranch"
   displayName: Setup default branch
-  workingDirectory: $(System.DefaultWorkingDirectory)/azure-sdk
+  workingDirectory: $(AzureSDKClonePath)
 
 - template: eng/common/pipelines/templates/steps/create-pull-request.yml@azure-sdk-tools
   parameters:
@@ -60,15 +61,11 @@ steps:
     CommitMsg: "Update package index with latest published versions"
     PRTitle: "Update package index with latest published versions"
     PushArgs: -f
-    WorkingDirectory: $(System.DefaultWorkingDirectory)/azure-sdk
-    ScriptDirectory: $(System.DefaultWorkingDirectory)/azure-sdk-tools/eng/common/scripts
+    WorkingDirectory: $(AzureSDKClonePath)
+    ScriptDirectory: $(AzureSDKToolsScriptsPath)
     PRLabels: 'auto-merge'
 
 - template: template/steps/generate-releasenotes.yml
-  parameters:
-    ChangedPackagesPath: $(ChangedPackagesFilePath)
-    DefaultBranch: $(DefaultBranch)
-    CommonScriptPath: $(System.DefaultWorkingDirectory)/azure-sdk-tools/eng/common/scripts
 
 - pwsh: |
     git clone https://$(azuresdk-github-pat)@github.com/MicrosoftDocs/azure-dev-docs-pr $(System.DefaultWorkingDirectory)/azure-dev-docs-pr
@@ -78,7 +75,7 @@ steps:
   displayName: Generate all package index markdown files
   inputs:
     pwsh: true
-    filePath: ./azure-sdk/eng/scripts/Generate-Package-Index.ps1
+    filePath: $(AzureSDKClonePath)/eng/scripts/Generate-Package-Index.ps1
     arguments: >
       -outputFolder $(System.DefaultWorkingDirectory)/azure-dev-docs-pr/articles/includes/
 
@@ -98,7 +95,7 @@ steps:
     PRTitle: "Update package index with latest published versions"
     PushArgs: -f
     WorkingDirectory: $(System.DefaultWorkingDirectory)/azure-dev-docs-pr
-    ScriptDirectory: $(System.DefaultWorkingDirectory)/azure-sdk-tools/eng/common/scripts
+    ScriptDirectory: $(AzureSDKToolsScriptsPath)
 
 - pwsh: |
     git clone https://github.com/dotnet/docs $(System.DefaultWorkingDirectory)/dotnet-docs
@@ -108,7 +105,7 @@ steps:
   displayName: Generate dotnet package index markdown files
   inputs:
     pwsh: true
-    filePath: ./azure-sdk/eng/scripts/Generate-Package-Index.ps1
+    filePath: $(AzureSDKClonePath)/eng/scripts/Generate-Package-Index.ps1
     arguments: >
       -language dotnet
       -outputFolder $(System.DefaultWorkingDirectory)/dotnet-docs/docs/azure/includes/
@@ -129,4 +126,4 @@ steps:
     PRTitle: "Update package index with latest published versions"
     PushArgs: -f
     WorkingDirectory: $(System.DefaultWorkingDirectory)/dotnet-docs
-    ScriptDirectory: $(System.DefaultWorkingDirectory)/azure-sdk-tools/eng/common/scripts
+    ScriptDirectory: $(AzureSDKToolsScriptsPath)

--- a/eng/scripts/Generate-ReleaseNotes.ps1
+++ b/eng/scripts/Generate-ReleaseNotes.ps1
@@ -131,7 +131,7 @@ foreach ($packageName in $updatedPackageSet.Keys)
     {
       $entry = GetReleaseNotesData $packageName $packageVersion.RawVersion $pkgMetadata
       if ($entry) {
-        Write-Host "Added `$pkgKey` to the release note entries"
+        Write-Host "Added '$pkgKey' to the release note entries"
         $existingYamlContent.entries += $entry
       }
     }

--- a/eng/scripts/Generate-ReleaseNotes.ps1
+++ b/eng/scripts/Generate-ReleaseNotes.ps1
@@ -1,92 +1,92 @@
+[CmdletBinding()]
 param (
   [string]$releasePeriod,
-  [string]$commonScriptPath,
-  [string]$releaseDirectory,
   [string]$repoLanguage,
-  [string]$changedPackagesPath
+  [string]$commonScriptPath,
+  [string]$releaseDirectory = "$PSScriptRoot\..\..\_data\releases",
+  [string]$github_pat = $env:GITHUB_PAT
 )
-
-function GetReleaseNotesData ($changedPackages)
-{
-    $entries = New-Object "System.Collections.Generic.List[System.Collections.Specialized.OrderedDictionary]"
-    foreach ($package in $changedPackages)
-    {
-        if ($package.Language -ne $repoLanguage)
-        {
-            continue
-        }
-
-        $changelogBlobLink = "$($package.SourceUrl)/CHANGELOG.md"
-        $changelogRawLink = $changelogBlobLink -replace "https://github.com/(.*)/(tree|blob)", "https://raw.githubusercontent.com/`$1"
-        try
-        { 
-            $changelogContent = Invoke-RestMethod -Method GET -Uri $changelogRawLink -MaximumRetryCount 2
-        }
-        catch
-        {
-            # Skip if the changelog Url is invalid
-            LogWarning "Failed to get content from ${changelogRawLink}"
-            LogWarning "ReleaseNotes will not be collected for $($package.Package) : $($package.UpdatedVersion). Please add entry manually."
-            continue
-        }
-
-        $changeLogEntries = Get-ChangeLogEntriesFromContent -changeLogContent $changelogContent
-        $updatedVersionEntry = $changeLogEntries[$package.UpdatedVersion]
-
-        if ($updatedVersionEntry)
-        {
-            $packageSemVer = [AzureEngSemanticVersion]::ParseVersionString($package.UpdatedVersion)
-            $releaseEntryContent = @()
-
-            if ($updatedVersionEntry.ReleaseContent)
-            {
-                # Bumping all MD headers by one level to fit in with the release template structure.
-                $updatedVersionEntry.ReleaseContent | %{
-                    $line = $_
-                    if ($line.StartsWith("#"))
-                    {
-                        $line = "#${line}"
-                    }
-                    $releaseEntryContent += $line
-                }
-            }
-
-            $entry = [ordered]@{
-                Name = $package.Package
-                Version = $package.UpdatedVersion
-                DisplayName = $package.DisplayName
-                ServiceName = $package.ServiceName
-                VersionType = $packageSemVer.VersionType
-                Hidden = $false
-                ChangelogUrl = $changelogBlobLink
-                ChangelogContent = ($releaseEntryContent | Out-String).Trim()
-            }
-
-            if (!$entry.DisplayName)
-            {
-                $entry.DisplayName = $entry.Name
-            }
-
-            if ($package.PSObject.Members.Name -contains "GroupId")
-            {
-                $entry.Add("GroupId", $package.GroupId)
-            }
-            $entries.Add($entry)
-        }
-    }
-    return $entries
-}
 
 . (Join-Path $commonScriptPath ChangeLog-Operations.ps1)
 . (Join-Path $commonScriptPath SemVer.ps1)
+. (Join-Path $PSScriptRoot PackageList-Helpers.ps1)
+. (Join-Path $PSScriptRoot PackageVersion-Helpers.ps1)
 
-$pathToRelatedYaml = (Join-Path $ReleaseDirectory ".." _data releases $releasePeriod "${repoLanguage}.yml")
+function GetReleaseNotesData ($packageName, $packageVersion, $packageMetadata)
+{
+  $sourceUrl = GetLinkTemplateValue $langLinkTemplates "source_url_template" $packageName $packageVersion $packageMetadata.RepoPath
+  if (!$sourceUrl.EndsWith("/")) { $sourceUrl += "/" }
+  $changelogBlobLink = "${sourceUrl}CHANGELOG.md"
+  $changelogRawLink = $changelogBlobLink -replace "https://github.com/(.*)/(tree|blob)", "https://raw.githubusercontent.com/`$1"
+  try
+  {
+    $changelogContent = Invoke-RestMethod -Method GET -Uri $changelogRawLink -MaximumRetryCount 2
+  }
+  catch
+  {
+    # Skip if the changelog Url is invalid
+    LogWarning "Failed to get content from ${changelogRawLink}"
+    LogWarning "ReleaseNotes will not be collected for $packageName : $packageVersion. Please add entry manually."
+    return $null
+  }
+
+  $changeLogEntries = Get-ChangeLogEntriesFromContent -changeLogContent $changelogContent
+  $updatedVersionEntry = $changeLogEntries[$packageVersion]
+
+  if (!$updatedVersionEntry)
+  {
+    # Skip if the changelog Url is invalid
+    LogWarning "Failed to get find matching change log entry from from ${changelogRawLink}"
+    LogWarning "ReleaseNotes will not be collected for $packageName : $packageVersion. Please add entry manually."
+    return $null
+  }
+
+  $packageSemVer = [AzureEngSemanticVersion]::ParseVersionString($packageVersion)
+  $releaseEntryContent = @()
+
+  if ($updatedVersionEntry.ReleaseContent)
+  {
+    # Bumping all MD headers by one level to fit in with the release template structure.
+    $updatedVersionEntry.ReleaseContent | ForEach-Object {
+      $line = $_
+      if ($line.StartsWith("#"))
+      {
+        $line = "#${line}"
+      }
+      $releaseEntryContent += $line
+    }
+  }
+
+  $entry = [ordered]@{
+    Name = $packageName
+    Version = $packageVersion
+    DisplayName = $packageMetadata.DisplayName
+    ServiceName = $packageMetadata.ServiceName
+    VersionType = $packageSemVer.VersionType
+    Hidden = $false
+    ChangelogUrl = $changelogBlobLink
+    ChangelogContent = ($releaseEntryContent | % { $_.Trim() } | Out-String).Trim()
+  }
+
+  if (!$entry.DisplayName)
+  {
+    $entry.DisplayName = $entry.Name
+  }
+
+  if ($packageMetadata.PSObject.Members.Name -contains "GroupId")
+  {
+    $entry.Add("GroupId", $packageMetadata.GroupId)
+  }
+  return $entry
+}
+
+$pathToRelatedYaml = (Join-Path $ReleaseDirectory $releasePeriod "${repoLanguage}.yml")
 LogDebug "Related Yaml File Path [ $pathToRelatedYaml ]"
 
 if (!(Test-Path $pathToRelatedYaml))
 {
-    New-Item -Path $pathToRelatedYaml -Force
-    Set-Content -Path $pathToRelatedYaml -Value @("entries:")
+  New-Item -Path $pathToRelatedYaml -Force
+  Set-Content -Path $pathToRelatedYaml -Value @("entries:")
 }
 
 # Install Powershell Yaml
@@ -96,28 +96,46 @@ Register-PSRepository -Name azure-sdk-tools-feed -SourceLocation $ToolsFeed -Pub
 Install-Module -Repository azure-sdk-tools-feed powershell-yaml
 
 $existingYamlContent = ConvertFrom-Yaml (Get-Content $pathToRelatedYaml -Raw) -Ordered
-
-$changedPackages = Get-Content -Path $changedPackagesPath | ConvertFrom-Json
-$incomingReleaseEntries = GetReleaseNotesData -changedPackages $changedPackages
-$filteredEntries = New-Object "System.Collections.Generic.List[System.Collections.Specialized.OrderedDictionary]"
-
-if($existingYamlContent.entries)
+if (!$existingYamlContent.entries)
 {
-    foreach ($entry in $incomingReleaseEntries)
+  $existingYamlContent.entries = New-Object "System.Collections.Generic.List[System.Collections.Specialized.OrderedDictionary]"
+}
+
+$langLinkTemplates = GetLinkTemplates $repoLanguage
+$updatedPackageSet = GetPackageVersions $repoLanguage $releasePeriod
+$languageMetadata = Get-PackageLookupForLanguage $repoLanguage
+
+foreach ($packageName in $updatedPackageSet.Keys)
+{
+  Write-Verbose "Checking release notes for $packageName"
+  $pkgKey = $packageName
+  if ($repoLanguage -eq "java") {
+    $pkgKey = "com.azure:${pkgKey}"
+  }
+  $pkgMetadata = $languageMetadata[$pkgKey]
+
+  if (!$pkgMetadata) {
+    Write-Host "Skipped package '$pkgKey' because it doesn't contain metadata in the csv file."
+    continue
+  }
+
+  if ($pkgMetadata.New -ne "true" -or $pkgMetadata.Hide -eq "true") {
+    Write-Host "Skipped package '$pkgKey' because it is not new ($($pkgMetadata.Hide)) or it is marked as hidden ($($pkgMetadata.Hide))"
+    continue
+  }
+
+  foreach ($packageVersion in $updatedPackageSet[$packageName].Versions)
+  {
+    $presentKey = $existingYamlContent.entries.Where({ ($_.name -eq $packageName) -and ($_.version -eq $packageVersion.RawVersion) })
+    if ($presentKey.Count -eq 0)
     {
-        $presentKey = $existingYamlContent.entries.Where( { ($_.name -eq $entry.name) -and ($_.version -eq $entry.version) } )
-        if ($presentKey.Count -gt 0)
-        {
-            continue
-        }
-        $filteredEntries.Add($entry)
+      $entry = GetReleaseNotesData $packageName $packageVersion.RawVersion $pkgMetadata
+      if ($entry) {
+        Write-Host "Added `$pkgKey` to the release note entries"
+        $existingYamlContent.entries += $entry
+      }
     }
+  }
 }
-else 
-{
-    $filteredEntries = $incomingReleaseEntries
-}
-
-$existingYamlContent.entries = $filteredEntries
 
 Set-Content -Path $pathToRelatedYaml -Value (ConvertTo-Yaml $existingYamlContent)

--- a/eng/scripts/PackageList-Helpers.ps1
+++ b/eng/scripts/PackageList-Helpers.ps1
@@ -43,6 +43,11 @@ function Get-PackageListForLanguage([string]$lang)
   return $packageList
 }
 
+function Get-PackageLookupForLanguage([string]$lang)
+{
+  return GetPackageLookup (Get-PackageListForLanguage $lang)
+}
+
 function Get-PackageListSplit([Array]$packageList)
 {
   $newPackages = $packageList.Where({ $_.Hide -ne "true" -and $_.New -eq "true" })
@@ -157,9 +162,16 @@ function PackageEqual($pkg1, $pkg2)
 function GetPackageKey($pkg)
 {
   $pkgKey = $pkg.Package
-  if ($pkg.PSObject.Members.Name -contains "GroupId" -and $pkg.GroupId) {
-    $pkgKey = $pkg.GroupId + ":" + $pkgKey
+  $groupId = $null
+
+  if ($pkg.PSObject.Members.Name -contains "GroupId") {
+    $groupId = $pkg.GroupId
   }
+
+  if ($groupId) {
+    $pkgKey = "${groupId}:${pkgKey}"
+  }
+
   return $pkgKey
 }
 
@@ -278,7 +290,7 @@ function GetLinkTemplateValue($linkTemplates, $templateName, $packageName = $nul
 
   if ($packageName) {
     $packageTrim = $linkTemplates["package_trim"]
-    $trimmedPackageName = $pkg.Package -replace "^$packageTrim", ""
+    $trimmedPackageName = $packageName -replace "^$packageTrim", ""
 
     $replacedString = $replacedString -replace "item.Package", $packageName
     $replacedString = $replacedString -replace "item.TrimmedPackage", $trimmedPackageName

--- a/eng/scripts/PackageVersion-Helpers.ps1
+++ b/eng/scripts/PackageVersion-Helpers.ps1
@@ -117,7 +117,6 @@ function GetPackageVersions($lang, [DateTime]$afterDate = [DateTime]::Now.AddMon
   if ($lang -eq "dotnet") { $repoName = "azure-sdk-for-net" }
   if ($lang -eq "go") { $tagSplit = "/v" }
   if ($lang -eq "c") { $tagSplit = $null }
-  if ($lang -eq "ios") { $tagSplit = $null }
 
   $tags = GetLatestTags $repoName $afterDate
   $packageVersions = @{}

--- a/eng/scripts/Update-DevOps-WorkItems.ps1
+++ b/eng/scripts/Update-DevOps-WorkItems.ps1
@@ -159,10 +159,7 @@ function ParseVersionsFromTags($versionsFromTags, $existingShippedVersionSet)
     # if we don't have a cached value or the cached value is Unknown look at the
     # release tag to try and get a date
     if ($d -eq "Unknown") {
-      $shaDate = GetCommitterDate $v.TagShaUrl
-      if ($shaDate) {
-        $d = $shaDate.ToString("MM/dd/yyyy")
-      }
+      $d = $v.Date.ToString("MM/dd/yyyy")
     }
     $versionList += New-Object PSObject -Property @{
       Type = $v.VersionType

--- a/eng/scripts/Update-Release-Versions.ps1
+++ b/eng/scripts/Update-Release-Versions.ps1
@@ -170,7 +170,7 @@ function GetFirstGADate($pkgVersion, $pkg)
     if ($gaIndex -lt 0) { return "" }
     $gaVersion = $gaVersions[$gaIndex]
 
-    $committeDate = GetCommitterDate $gaVersion.TagShaUrl;
+    $committeDate = $gaVersion.Date
 
     if ($committeDate) {
       $committeDate = $committeDate.ToString("MM/dd/yyyy")

--- a/eng/scripts/Update-Release-Versions.ps1
+++ b/eng/scripts/Update-Release-Versions.ps1
@@ -186,6 +186,7 @@ function Update-Packages($lang, $packageList, $langVersions, $langLinkTemplates)
   $updatedPackages = @()
   foreach ($pkg in $packageList)
   {
+    $pkgVersion = $null
     if ($langVersions.ContainsKey($pkg.Package)) {
       $pkgVersion = $langVersions[$pkg.Package]
     }
@@ -193,13 +194,9 @@ function Update-Packages($lang, $packageList, $langVersions, $langLinkTemplates)
       # Some repos use the same version for all packages so fall back to that case
       $pkgVersion = $langVersions[""]
     }
-    else {
-      Write-Host "Skipping update for $($pkg.Package) as we don't have version info for it. "
-      continue
-    }
 
     if ($null -eq $pkgVersion) {
-      Write-Host "Skipping update for $($pkg.Package) as we don't have version info for it. "
+      Write-Verbose "Skipping update for $($pkg.Package) as we don't have version info for it. "
       continue;
     }
 
@@ -274,7 +271,7 @@ function OutputVersions($lang)
   Write-Host "Checking $lang for updates..."
   $clientPackages, $global:otherPackages = Get-PackageListForLanguageSplit $lang
 
-  $langVersions = GetPackageVersions $lang
+  $langVersions = GetPackageVersions $lang -afterDate ([DateTime]::Now.AddMonths(-3))
   $langLinkTemplates = GetLinkTemplates $lang
 
   $updatedPackages = Update-Packages $lang $clientPackages $langVersions $langLinkTemplates


### PR DESCRIPTION
- Update release tag retrieve to be based on graphql instead of rest
  that allows us to retrieve just specific tags by date and also
  retreive the dates of tags in the same query
- Use release tags for determining what released for a given release period
- Use an isolated clone for upating the notes from the scripts we run
  so that the updated scripts can be used while maintaining the yml data seperate
- Clean-up the pipelines to share common variables