### PR TITLE
Extend automation to include all java track 2 packages

### DIFF
--- a/eng/scripts/Generate-ReleaseNotes.ps1
+++ b/eng/scripts/Generate-ReleaseNotes.ps1
@@ -133,8 +133,6 @@ foreach ($packageName in $updatedPackageSet.Keys)
 {
   Write-Verbose "Checking release notes for $packageName"
   $pkgKey = $packageName
-  if ($repoLanguage -eq "java") { $pkgKey = "com.azure:${pkgKey}" }
-  if ($repoLanguage -eq "android") { $pkgKey = "com.azure.android:${pkgKey}" }
   $pkgMetadata = $languageMetadata[$pkgKey]
 
   if (!$pkgMetadata) {

--- a/eng/scripts/PackageList-Helpers.ps1
+++ b/eng/scripts/PackageList-Helpers.ps1
@@ -196,6 +196,19 @@ function GetPackageLookup($packageList)
         Write-Host "Found more than one package entry for $($pkg.Package) selecting the first non-hidden one."
       }
     }
+
+    if ($pkg.PSObject.Members.Name -contains "GroupId" -and ($pkg.New -eq "true") -and $pkg.Package) {
+      $pkgKey = $pkg.Package
+      if (!$packageLookup.ContainsKey($pkgKey))
+      {
+        $packageLookup[$pkgKey] = $pkg
+      }
+      else
+      {
+        $packageValue = $packageLookup[$pkgKey]
+        Write-Host "Found more than one package entry for $($packageValue.Package) selecting the first one with groupId $($packageValue.GroupId), skipping $($pkg.GroupId)"
+      }
+    }
   }
 
   return $packageLookup


### PR DESCRIPTION
Extend tha generate release notes automation to accomodate all track 2 packages regardless of the groupId.