### PR TITLE
Do not return Response<T> for service methods that may not call the service

### DIFF
--- a/docs/java/introduction.md
+++ b/docs/java/introduction.md
@@ -453,6 +453,10 @@ For methods that combine multiple requests into a single call:
 
 {% include requirement/MUST id="java-response-errors" %} provide enough information in failure cases for a developer to take appropriate corrective action, including a message describing what went wrong and details on the corrective actions to take.
 
+For methods that may not make a service call each time it is invoked either because the response is cached by the client or the response can be computed locally:
+
+{% include requirement/MUSTNO id="java-no-withresponse" %} offer `WithResponse` service method that returns `Response<T>`. All overloads should return `T` instead.
+
 #### Service Method Parameters
 
 ##### Option Parameters

--- a/docs/java/introduction.md
+++ b/docs/java/introduction.md
@@ -455,7 +455,7 @@ For methods that combine multiple requests into a single call:
 
 For methods that may not make a service call each time it is invoked either because the response is cached by the client or the response can be computed locally:
 
-{% include requirement/MUSTNOT id="java-no-withresponse" %} offer `WithResponse` service method that returns `Response<T>`. All overloads should return `T` instead.
+{% include requirement/MUSTNOT id="java-no-withresponse" %} offer `WithResponse` service method which return `Response<T>` when the response is not always returned from a web service (e.g. when it is cached or calculated locally).
 
 #### Service Method Parameters
 

--- a/docs/java/introduction.md
+++ b/docs/java/introduction.md
@@ -455,7 +455,7 @@ For methods that combine multiple requests into a single call:
 
 For methods that may not make a service call each time it is invoked either because the response is cached by the client or the response can be computed locally:
 
-{% include requirement/MUSTNO id="java-no-withresponse" %} offer `WithResponse` service method that returns `Response<T>`. All overloads should return `T` instead.
+{% include requirement/MUSTNOT id="java-no-withresponse" %} offer `WithResponse` service method that returns `Response<T>`. All overloads should return `T` instead.
 
 #### Service Method Parameters
 


### PR DESCRIPTION
This guideline is based on the existing patterns used in Key Vault and Identity:

- [CryptographyClient](https://apiview.dev/Assemblies/Review/3657b535be7a41d0952418b69d33f880#com.azure.security.keyvault.keys.cryptography.CryptographyAsyncClient) in KeyVault - here service methods compute the response locally if the key is locally available or calls the service if it's not. So, `WithResponse` methods are not offered for most methods. 
- All credential types in Azure Identity do not offer `WithResponse` methods.