### PR TITLE
Add public constructor guideline for LRO

### DIFF
--- a/docs/dotnet/introduction.md
+++ b/docs/dotnet/introduction.md
@@ -635,6 +635,8 @@ BlobBaseClient client = ...
 {% include requirement/MAY id="dotnet-lro-subclass" %} add additional APIs to subclasses of ```Operation<T>```.
 For example, some subclasses add a constructor allowing to create an operation instance from a previously saved operation ID. Also, some subclasses are more granular states besides the IsCompleted and HasValue states that are present on the base class.
 
+{% include requirement/MUST id="dotnet-lro-constructor" %} provide a public constructor on subclasses of ```Operation<T>``` to allow users to access an existing LRO.
+
 {% include requirement/MUST id="dotnet-lro-constructor-for-mocking" %} provide protected parameterless constructor for mocking in subclasses of ```Operation<T>```.
 
 ```csharp


### PR DESCRIPTION
I noticed the Synapse team was missing a public constructor on their [`SparkBatchOperation` type](https://apiview.dev/Assemblies/Review/0ee110d9d296455a9fb663b95f1f8c2a#Azure.Analytics.Synapse.Spark.SparkBatchOperation).

I checked the guidelines so I could refer to it, and the guidance is in the text, but it's not called out in a specific guideline.  I'm hoping to add that for clarity.

This is the guidance in the [guidelines text](https://github.com/Azure/azure-sdk/pull/3359/files#diff-d1668aaa12d853c4d2a8d1bf803705a97fcbf6d557f2be15d17623030a556b7dR582):

> Client libraries need to inherit from Operation<T> not only to implement all abstract members, but also to provide a constructor required to access an existing LRO (an LRO initiated by a different process).
