### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 [.NET Packages]: https://azure.github.io/azure-sdk/releases/latest/dotnet.html
 [Java Packages]: https://azure.github.io/azure-sdk/releases/latest/java.html
-[Javascript Packages]: https://azure.github.io/azure-sdk/releases/latest/js.html
+[JavaScript Packages]: https://azure.github.io/azure-sdk/releases/latest/js.html
 [Python Packages]: https://azure.github.io/azure-sdk/releases/latest/python.html
 [C Packages]: https://azure.github.io/azure-sdk/releases/latest/c.html
 [C++ Packages]: https://azure.github.io/azure-sdk/releases/latest/cpp.html

--- a/eng/README.md
+++ b/eng/README.md
@@ -48,7 +48,7 @@ The values in these templates of the format `item.<property>` are replaced from 
 
 ## Editing the CSV files
 
-If you need to edit the CSV files please do not use Excel as it will remove all the quoting which is required by the consumers of the CSV (i.e. Jekyll and automation). Instead if it is a small edit please just use a normal text editor. If it is a larger edit the recomendation is to use the [Edit csv](https://marketplace.visualstudio.com/items?itemName=janisdd.vscode-edit-csv) extension for VS Code. When using that extension please set the following configuration options to ensure consistency.
+If you need to edit the CSV files please do not use Excel as it will remove all the quoting which is required by the consumers of the CSV (i.e. Jekyll and automation). Instead if it is a small edit please just use a normal text editor. If it is a larger edit the recommendation is to use the [Edit csv](https://marketplace.visualstudio.com/items?itemName=janisdd.vscode-edit-csv) extension for VS Code. When using that extension please set the following configuration options to ensure consistency.
 
 ```
 "csv-edit.quoteAllFields": true,


### PR DESCRIPTION
fix "Javascript" to "JavaScript" in README.md.
fix "recomendation" to "recommendation" in eng/README.md