### PR TITLE
Specify HTTP sampling-relevant attributes

### DIFF
--- a/docs/tracing/distributed-tracing-conventions.yml
+++ b/docs/tracing/distributed-tracing-conventions.yml
@@ -39,13 +39,13 @@ groups:
       - id: http.url
         type: string
         required: always
+        sampling_relevant: true        
         brief: Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]`
         examples: ['https://www.foo.bar/search?q=OpenTelemetry#SemConv']
       - id: http.status_code
         type: int
         required:
           conditional: If and only if one was received/sent.
-        sampling_relevant: true
         brief: '[HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6).'
         examples: [200]
       - id: http.user_agent


### PR DESCRIPTION
[OTel HTTP spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/semantic_conventions/trace/http.yaml) requires `http.url` and `http.method` to be provided before span is started, so users can make sampling decisions based on them.

Enables new  [Azure Monitor sampling scenarios](https://docs.microsoft.com/en-us/azure/azure-monitor/app/java-standalone-sampling-overrides)