### PR TITLE
Remove etc from distributed tracing header list

### DIFF
--- a/docs/general/implementation.md
+++ b/docs/general/implementation.md
@@ -177,7 +177,7 @@ Distributed tracing mechanisms allow the consumer to trace their code from front
 
 {% include requirement/MUST id="general-tracing-accept-context" %} accept a context from calling code to establish a parent span.
 
-{% include requirement/MUST id="general-tracing-pass-context" %} pass the context to the backend service through the appropriate headers (`traceparent`, `tracestate`, etc.) to support [Azure Monitor].  This is generally done with the HTTP pipeline.
+{% include requirement/MUST id="general-tracing-pass-context" %} pass the context to the backend service through the appropriate headers (`traceparent` and `tracestate` per [W3C Trace-Context](https://www.w3.org/TR/trace-context/) standard)) to support [Azure Monitor].  This is generally done with the HTTP pipeline.
 
 {% include requirement/MUST id="general-tracing-new-span-per-method" %} create a new span for each method that user code calls.  New spans must be children of the context that was passed in.  If no context was passed in, a new root span must be created.
 


### PR DESCRIPTION
Limit distributed tracing headers to W3C Trace-Context. This is important to keep this set closed, especially for CORS configuration in Azure.

Similar to https://github.com/Azure/azure-sdk/pull/3554. Apparently we have it in multiple places