### PR TITLE
Add verb for `GetAll`

### DIFF
--- a/_data/tables/net_standard_verbs.yaml
+++ b/_data/tables/net_standard_verbs.yaml
@@ -23,7 +23,7 @@ entries:
   - Verb: GetAll\<resource_name>
     Parameters: key, item
     Returns: item
-    Comments: Retrieves one or more resources. Returns empty set if no resources found. This verb should be used when <resource_name> is itself plural in nature, like `Properties`.
+    Comments: Retrieves one or more resources. Returns empty set if no resources found. This verb should be used when <resource_name> is itself plural in nature, like `Properties` or when <resource_name> and <resource_name_plural> have the same value, like `Moose`.
   - Verb: Delete
     Parameters: item
     Returns: item

--- a/_data/tables/net_standard_verbs.yaml
+++ b/_data/tables/net_standard_verbs.yaml
@@ -20,6 +20,10 @@ entries:
     Parameters: key, item
     Returns: item
     Comments: Retrieves one or more resources. Returns empty set if no resources found.
+  - Verb: GetAll\<resource_name>
+    Parameters: key, item
+    Returns: item
+    Comments: Retrieves one or more resources. Returns empty set if no resources found. This verb should be used when <resource_name> is itself plural in nature, like `Properties`.
   - Verb: Delete
     Parameters: item
     Returns: item


### PR DESCRIPTION
When `resource_name` is plural, we need a verb to specify getting one or more resources.