### PR TITLE
Fix broken spark link

### DIFF
--- a/_data/releases/2021-05/java.yml
+++ b/_data/releases/2021-05/java.yml
@@ -79,7 +79,7 @@ entries:
     ##### Configuration Renames
     * Renamed data source name "cosmos.items" to "cosmos.oltp".
     * Renamed data source name "cosmos.changeFeed" to "cosmos.oltp.changeFeed".
-    * Configuration renamed. See [Configuration-Reference](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/cosmos/azure-cosmos-spark_3-1_2-12/docs/configuration-reference.md) for more details.
+    * Configuration renamed. See [Configuration-Reference](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/cosmos/azure-cosmos-spark_3_2-12/docs/configuration-reference.md) for more details.
 
     ##### Key Bug Fixes
     * Added validation for all config-settings with a name starting with "spark.cosmos."


### PR DESCRIPTION
@FabianMeiswinkel @kushagraThapar this looks to have been broken by https://github.com/Azure/azure-sdk-for-java/pull/26527. I updated it based on those changes but is there a more stable link we can use here so that it doesn't break again in the future? Do you guys have any release tags we can use to keep this stable?