### PR TITLE
Add language navigation to retired releases page

### DIFF
--- a/_includes/releases/nav.md
+++ b/_includes/releases/nav.md
@@ -3,9 +3,13 @@
   <div class="nav-language-filter-cell"><a href="#java">Java</a></div>
   <div class="nav-language-filter-cell"><a href="#javascript">JavaScript/TypeScript</a></div>
   <div class="nav-language-filter-cell"><a href="#python">Python</a></div>
+
+{% if include.type != "retired" %}
   <div class="nav-language-filter-cell"><a href="#c">C++</a></div>
   <div class="nav-language-filter-cell"><a href="#embedded-c">Embedded C</a></div>
   <div class="nav-language-filter-cell"><a href="#android">Android</a></div>
   <div class="nav-language-filter-cell"><a href="#ios">iOS</a></div>
   <div class="nav-language-filter-cell"><a href="#go">Go</a></div>
+{% endif %}
+
 </div>

--- a/releases/retired/index.md
+++ b/releases/retired/index.md
@@ -4,7 +4,7 @@ layout: default
 sidebar: releases_sidebar
 ---
 {% include releases/header.md type="retired" %}
-{% include releases/nav.md %}
+{% include releases/nav.md type="retired" %}
 
 {% include releases/dotnet.md type="retired" %}
 {% include releases/java.md type="retired" %}

--- a/releases/retired/index.md
+++ b/releases/retired/index.md
@@ -4,6 +4,7 @@ layout: default
 sidebar: releases_sidebar
 ---
 {% include releases/header.md type="retired" %}
+{% include releases/nav.md %}
 
 {% include releases/dotnet.md type="retired" %}
 {% include releases/java.md type="retired" %}


### PR DESCRIPTION
Add the standard language navigation bar to the retired releases page. Without it, you could be scrolling for days.

![image](https://user-images.githubusercontent.com/10702007/153637047-41e52e93-8bff-4b9b-8de8-213578e68152.png)

@mario-guerra As of right now, there are no retired packages to list for non-Tier 1 languages. Do you want those non-Tier 1 languages removed from this navigation bar?