### PR TITLE
Mark Python azure-applicationinsights package as deprecated

### DIFF
--- a/_data/releases/latest/python-packages.csv
+++ b/_data/releases/latest/python-packages.csv
@@ -311,7 +311,7 @@
 "iothub-client","1.1.2.0","","iothub-client","","NA","NA","NA","","false","","","active","true","","",""
 "iothub-service-client","1.1.0.0","","iothub-service-client","","NA","NA","NA","","false","","","active","true","","",""
 "azure-cognitiveservices-anomalydetector","","0.3.0","Anomaly Detector","Anomaly Detector","cognitiveservices","","","client","false","","","retired","","azure-ai-anomalydetector","",""
-"azure-applicationinsights","","0.1.0","Application Insights","Monitor","https://github.com/Azure/azure-sdk-for-python/tree/azure-applicationinsights_0.1.0/azure-applicationinsights","NA","","client","false","","","preview","","","",""
+"azure-applicationinsights","","0.1.0","Application Insights","Monitor","https://github.com/Azure/azure-sdk-for-python/tree/azure-applicationinsights_0.1.0/azure-applicationinsights","NA","","client","false","","","retired","","azure-monitor-query","https://aka.ms/azsdk/python/migrate/ai-to-monitor-query",""
 "azure-cognitiveservices-search-autosuggest","","0.2.0","Autosuggest","Autosuggest","cognitiveservices","NA","","client","false","","","preview","","","",""
 "azure","5.0.0","","Azure","Azure","NA","NA","NA","client","false","","","active","true","","",""
 "azure-batch","12.0.0","","Batch","Batch","batch","","","client","false","","","active","","","",""


### PR DESCRIPTION
The package was deprecated today. Update CSV with replacement package name and migration guide.