### PR TITLE
Fix unordered list formatting on retired releases page

### DIFF
--- a/_includes/releases/header.md
+++ b/_includes/releases/header.md
@@ -10,16 +10,16 @@ This page contains links to all of the Azure SDK library packages, code, and doc
 
 *This page contains the list of packages that have been retired. Please see [support policy](https://aka.ms/azsdk/policies/support) for more information.*
 
-
 **On 31 March 2023, we will be retiring support for Azure SDK libraries which do not conform to our [current Azure SDK guidelines](https://azure.github.io/azure-sdk/general_introduction.html).** The new Azure SDK libraries are updated regularly to drive consistent experiences and strengthen your security posture. Please transition to the new Azure SDK libraries to take advantage of the new capabilities and critical security updates before 31 March 2023.
 
 Although the older libraries can still be used beyond 31 March 2023, they will no longer receive official support and updates from Microsoft. If you prefer not to transition to the new Azure SDK libraries, source code for the current Azure SDKs libraries will still be available on GitHub as open source. You can continue to use the code and apply your own fixes, as required.
 
 **Recommended action**
 
-•	Upgrade to the [new Azure SDK libraries](https://aka.ms/azsdk) by 31 March 2023 so that your applications continue receiving regular security and performance updates.
-•	Learn more about the retirement and replacement of older Azure SDK libraries in this [blog post](https://azure.microsoft.com/en-us/blog/previewing-azure-sdks-following-new-azure-sdk-api-standards/).
-
+<ul>
+    <li>Upgrade to the <a href="https://aka.ms/azsdk">new Azure SDK libraries</a> by 31 March 2023 so that your applications continue receiving regular security and performance updates.</li>
+    <li>Learn more about the retirement and replacement of older Azure SDK libraries in this <a href="https://azure.microsoft.com/blog/previewing-azure-sdks-following-new-azure-sdk-api-standards/" target="_blank">blog post</a>.</li>
+</ul>
 
 {% endif %}
 


### PR DESCRIPTION
Use HTML tags to correct the unordered list formatting. Also, remove the "en-us" locale string from the link.

After changes:
![image](https://user-images.githubusercontent.com/10702007/154185658-3bc58aa5-3d36-45aa-9ff4-ce3318311066.png)
