### PR TITLE
Add type for AgriFood pacakge

### DIFF
--- a/_data/releases/latest/java-packages.csv
+++ b/_data/releases/latest/java-packages.csv
@@ -1,5 +1,5 @@
 "Package","GroupId","VersionGA","VersionPreview","DisplayName","ServiceName","RepoPath","MSDocs","GHDocs","Type","New","PlannedVersions","FirstGADate","Support","Hide","Replace","ReplaceGuide","MSDocService","Notes"
-"azure-verticals-agrifood-farming","com.azure","","1.0.0-beta.2","azure-verticals-agrifood-farming","AgriFood","farmbeats","NA","NA","","true","","","","","","","",""
+"azure-verticals-agrifood-farming","com.azure","","1.0.0-beta.2","azure-verticals-agrifood-farming","AgriFood","farmbeats","NA","NA","client","true","","","","","","","",""
 "azure-ai-anomalydetector","com.azure","","3.0.0-beta.4","Anomaly Detector","Anomaly Detector","anomalydetector","","","client","true","","","","","","","",""
 "azure-data-appconfiguration","com.azure","1.3.1","","App Configuration","App Configuration","appconfiguration","","","client","true","","01/07/2020","active","","","","",""
 "azure-security-attestation","com.azure","1.1.0","","Attestation","Attestation","attestation","","","client","true","","02/08/2022","","","","","",""


### PR DESCRIPTION
Fixed the package has no type on it. 

The issue will cause the package toc has no children for APIs to categorized.
![image](https://user-images.githubusercontent.com/48036328/159813236-fa1e1550-755f-49db-b937-5899cdc6d1e8.png)
