### PR TITLE
Add DPG checkbox to archboard issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/adp_api_review_and_signoff.md
+++ b/.github/ISSUE_TEMPLATE/adp_api_review_and_signoff.md
@@ -40,6 +40,7 @@ For Tier-2 languages (C, C++, Go, Android, iOS), the review will be on an as-nee
 
 * Name of the client library:
 * Languages for this review:
+* Library uses [Data Plane Code Generation](https://aka.ms/azsdk/dpcodegen): [ ]
 
 ## Artifacts required (per language)
 

--- a/.github/ISSUE_TEMPLATE/adp_api_review_and_signoff.md
+++ b/.github/ISSUE_TEMPLATE/adp_api_review_and_signoff.md
@@ -40,7 +40,7 @@ For Tier-2 languages (C, C++, Go, Android, iOS), the review will be on an as-nee
 
 * Name of the client library:
 * Languages for this review:
-* Library uses [Data Plane Code Generation](https://aka.ms/azsdk/dpcodegen): [ ]
+* Library uses [Data Plane Code Generation](https://aka.ms/azsdk/dpcodegen): Yes / No
 
 ## Artifacts required (per language)
 

--- a/.github/ISSUE_TEMPLATE/adp_review_service_intro.md
+++ b/.github/ISSUE_TEMPLATE/adp_review_service_intro.md
@@ -33,7 +33,8 @@ Please reference our [review process guidelines](https://azure.github.io/azure-s
 
 * Name of client library:
 * Link to library reference documentation:
-* Is there an existing SDK library? If yes, provide link: 
+* Is there an existing SDK library? If yes, provide link:
+* Library uses [Data Plane Code Generation](https://aka.ms/azsdk/dpcodegen): [ x ]
 
 
 ## Step 1: Champion Scenarios 

--- a/.github/ISSUE_TEMPLATE/adp_review_service_intro.md
+++ b/.github/ISSUE_TEMPLATE/adp_review_service_intro.md
@@ -34,7 +34,7 @@ Please reference our [review process guidelines](https://azure.github.io/azure-s
 * Name of client library:
 * Link to library reference documentation:
 * Is there an existing SDK library? If yes, provide link:
-* Library uses [Data Plane Code Generation](https://aka.ms/azsdk/dpcodegen): **Yes** / No
+* Library uses [Data Plane Code Generation](https://aka.ms/azsdk/dpcodegen): **Yes**
 
 
 ## Step 1: Champion Scenarios 

--- a/.github/ISSUE_TEMPLATE/adp_review_service_intro.md
+++ b/.github/ISSUE_TEMPLATE/adp_review_service_intro.md
@@ -34,7 +34,7 @@ Please reference our [review process guidelines](https://azure.github.io/azure-s
 * Name of client library:
 * Link to library reference documentation:
 * Is there an existing SDK library? If yes, provide link:
-* Library uses [Data Plane Code Generation](https://aka.ms/azsdk/dpcodegen): [ x ]
+* Library uses [Data Plane Code Generation](https://aka.ms/azsdk/dpcodegen): **Yes** / No
 
 
 ## Step 1: Champion Scenarios 


### PR DESCRIPTION
We don't currently have a way to know whether or not an arch board meeting is discussing a service library built with the new DPG code generator, or a legacy Generation1 Convenience Client (i.e. HLC) library.

Adding checkboxes to the issue templates to assist in this determination, and will also plan to rely on human intervention from the Azure SDK team side until we find a way to automate this.