### PR TITLE
Use `var` for .NET docs where acceptable

### DIFF
--- a/docs/dotnet/implementation.md
+++ b/docs/dotnet/implementation.md
@@ -48,7 +48,7 @@ public virtual async Task<Response<ConfigurationSetting>> AddAsync(Configuration
         request.Content = HttpPipelineRequestContent.Create(content);
 
         // send the request
-        var response = await Pipeline.SendRequestAsync(request).ConfigureAwait(false);
+        Response response = await Pipeline.SendRequestAsync(request).ConfigureAwait(false);
 
         if (response.Status == 200) {
             // deserialize content
@@ -136,7 +136,7 @@ using (JsonDocument json = await JsonDocument.ParseAsync(content, default, cance
     setting.Key = root.GetProperty("key").GetString();
 
     // optional property
-    if (root.TryGetProperty("last_modified", out var lastModified)) {
+    if (root.TryGetProperty("last_modified", out JsonElement lastModified)) {
         if(lastModified.Type == JsonValueType.Null) {
             setting.LastModified = null;
         }
@@ -477,7 +477,7 @@ For example:
 public void MatchesNameAndGuid()
 {
     // Arrange & Act
-    var eventSourceType = typeof(AzureCoreEventSource);
+    Type eventSourceType = typeof(AzureCoreEventSource);
 
     // Assert
     Assert.NotNull(eventSourceType);

--- a/docs/dotnet/introduction.md
+++ b/docs/dotnet/introduction.md
@@ -601,8 +601,8 @@ BlobBaseClient client = ...
 
 // automatic polling
 {
-    var value = await client.StartCopyFromUri(...).WaitForCompletionAsync();
-    Console.WriteLine(value);
+    Response<long> response = await client.StartCopyFromUri(...).WaitForCompletionAsync();
+    Console.WriteLine(response.Value);
 }
 
 // manual polling
@@ -624,7 +624,7 @@ BlobBaseClient client = ...
 
     // two days later
     var operation2 = new CopyFromUriOperation(operationId, client);
-    var value = await operation2.WaitForCompletionAsync();
+    long value = await operation2.WaitForCompletionAsync();
 }
 ```
 


### PR DESCRIPTION
.NET style only allows `var` for obvious types, like instantiation. .NET SDK guidelines should match this guidance to avoid confusion.
