### PR TITLE
[Python] Broken link in documentation.md

### DIFF
--- a/docs/python/documentation.md
+++ b/docs/python/documentation.md
@@ -29,7 +29,7 @@ As you write your code, *doc it so you never hear about it again.* The less ques
 
 ## Docstrings
 
-{% include requirement/MUST id="python-docstrings-pydocs" %} follow the [documentation guidelines](http://aka.ms/pydocs) unless explicitly overridden in this document.
+{% include requirement/MUST id="python-docstrings-pydocs" %} follow the [documentation guidelines](https://review.docs.microsoft.com/en-us/help/onboard/admin/reference/python/documenting-api?branch=main) unless explicitly overridden in this document.
 
 {% include requirement/MUST id="python-docstrings-all" %} provide docstrings for all public modules, types, and methods.
 

--- a/docs/python/documentation.md
+++ b/docs/python/documentation.md
@@ -29,7 +29,7 @@ As you write your code, *doc it so you never hear about it again.* The less ques
 
 ## Docstrings
 
-{% include requirement/MUST id="python-docstrings-pydocs" %} follow the [documentation guidelines](https://review.docs.microsoft.com/en-us/help/onboard/admin/reference/python/documenting-api?branch=main) unless explicitly overridden in this document.
+{% include requirement/MUST id="python-docstrings-pydocs" %} follow the [documentation guidelines](https://review.docs.microsoft.com/help/onboard/admin/reference/python/documenting-api?branch=main) unless explicitly overridden in this document.
 
 {% include requirement/MUST id="python-docstrings-all" %} provide docstrings for all public modules, types, and methods.
 


### PR DESCRIPTION
Fixes #4121 

Not 100% if this is the right link, but it does explain docstrings