### PR TITLE
Added first draft for event handling guidelines for Android.

### DIFF
--- a/docs/android/design.md
+++ b/docs/android/design.md
@@ -599,15 +599,11 @@ Android applications commonly need to react to events from the UI or service. Th
 
 ##### Event Handlers
 
-{% include requirement/MAY id="android-event-handler-mutable" %} mutate individual event handlers after client instantiation, unlike most client configuration which is required to be immutable.
-
-{% include requirement/MUST id="android-event-handler-collection" %} use Azure Core's `EventHandlerCollection` internally to keep track of registered event handlers and their associations with different event types within a client.
-
-{% include requirement/MUST id="android-event-types" %} declare event types to associate event handlers with as package private client constants of the type `String`.
+{% include requirement/MAY id="android-event-handler-mutable" %} allow users to add and remove individual event handlers after client instantiation through the `add` and `remove` methods detailed below. This is not considered to be mutating the state of the client.
 
 {% include requirement/MUST id="android-event-handler-registration" %} register event handlers on clients via methods whose names start with the `addOn` prefix and end with the `Handler` suffix.
 
-{% include requirement/MUST id="android-event-handler-registration-arguments" %} have said methods take one argument that is an implementation of the `EventHandler` interface from Azure Core. This argument must be named `handler`.
+{% include requirement/MUST id="android-event-handler-registration-arguments" %} define event handler methods as taking a single argument of type `EventHandler` (from Azure Core). This argument must be named `handler`.
 
 ```java
 public void addOnMessageReceivedHandler(EventHandler<MessageReceivedEvent> handler) {

--- a/docs/android/design.md
+++ b/docs/android/design.md
@@ -595,9 +595,9 @@ The `PagedAsyncCollection.forEachPage()` offers an overload to accept a `continu
 
 #### Event handling
 
-Android applications commonly need to react to events from the UI or service. The following guidelines apply to SDKs that expose events to the customer.
+Android applications commonly need to react to events from the UI or service. The following guidelines apply to client libraries that provide APIs to handle events.
 
-##### Handlers
+##### Event Handlers
 
 {% include requirement/MUST id="android-event-unicast-handler" %} declare unicast event handlers as functional interfaces that use the `@FunctionalInterface` annotation.
 
@@ -613,9 +613,9 @@ interface MessageHandler<E extends MessagingEvent> {
 }
 ```
 
-{% include requirement/MUST id="android-event-without-properties %} group related types of events together in an enumeration (see [Enumerations](#Enumerations)) based on `azure-core`'s `ExpandableStringEnum`. Said enumeration should end with the `EventType` suffix.
+{% include requirement/MUST id="android-event-type %} group related types of events together in an enumeration (see [Enumerations](#Enumerations)) based on `azure-core`'s `ExpandableStringEnum`. Said enumeration should end with the `EventType` suffix.
 
-If you need to provide additional details about an event to a handler, {% include requirement/MUST id="android-event-with-properties %} do so by declaring a class that extends from `Event` in `azure-core` and passing an instance of said class to the handler in question. The name for the aforementioned class should end with the `Event` suffix. For example:
+{% include requirement/MUST id="android-event-properties %} provide additional details about an event to a handler do by using a class that extends from `Event` in `azure-core` and passing an instance of said class to the handler in question. The name for the aforementioned class should end with the `Event` suffix. For example:
 
 ```java
 class MessagingEvent extends Event<MessagingEventType> {
@@ -641,13 +641,6 @@ class MessagingEvent extends Event<MessagingEventType> {
 {% include requirement/MUST id="android-event-multicast" %} expose multicast event handlers using the `MulticastEventCollection` type from `azure-core`. This type contains an `addEventHandler` method which accepts the event alongside an implementation of the `EventHandler` interface to handle it and returns a UUID string identifier which can be used to remove the handler via the `removeEventHandler` method. Here's an example:
 
 ```java
-public class MessagingEventHandler implements EventHandler<MessagingEvent> {
-    @Override
-    public void handle(MessagingEvent messagingEvent) {
-        // Code that handles the event.
-    }
-}
-
 public class MessagingClient {
     MulticastEventCollection<MessagingEventType, MessagingEvent> messagingEventCollection;
             

--- a/docs/android/design.md
+++ b/docs/android/design.md
@@ -603,11 +603,11 @@ Android applications commonly need to react to events from the UI or service. Th
 
 {% include requirement/MUST id="android-event-handler-collection" %} use Azure Core's `EventHandlerCollection` internally to keep track of registered event handlers and their associations with different event types within a client.
 
-{% include requirement/MUST id="android-event-types" %} declare event types to associate event handlers with as package private client constants.
+{% include requirement/MUST id="android-event-types" %} declare event types to associate event handlers with as package private client constants of the type `String`.
 
 {% include requirement/MUST id="android-event-handler-registration" %} register event handlers on clients via methods whose names start with the `addOn` prefix and end with the `Handler` suffix.
 
-{% include requirement/MUST id="android-event-handler-registration-minimum-arguments" %} have said methods take one argument that is an implementation of the `EventHandler` interface from Azure Core. This argument must be named `handler`.
+{% include requirement/MUST id="android-event-handler-registration-arguments" %} have said methods take one argument that is an implementation of the `EventHandler` interface from Azure Core. This argument must be named `handler`.
 
 ```java
 public void addOnMessageReceivedHandler(EventHandler<MessageReceivedEvent> handler) {
@@ -615,15 +615,7 @@ public void addOnMessageReceivedHandler(EventHandler<MessageReceivedEvent> handl
 }
 ```
 
-{% include requirement/MUST id="android-event-handler-removal" %} provide at least one method for unregistering event handlers named `removeEventHandler`, which takes one argument named `handler`.
-
-```java
-public void removeEventHandler(EventHandler handler) {
-    ...
-}
-```
-
-{% include requirement/MAY id="android-event-handler-specific-removal" %} instead provide individual methods for unregistering event handlers whose names start with the `removeOn` prefix and end with the `Handler` suffix. This method must take one argument named `handler`.
+{% include requirement/MUST id="android-event-handler-removal" %} provide methods for unregistering event handlers whose names start with the `removeOn` prefix and end with the `Handler` suffix. said methods method must take one argument named `handler`.
 
 ```java
 public void removeOnMessageReceivedHandler(EventHandler<MessageReceivedEvent> handler) {

--- a/docs/android/design.md
+++ b/docs/android/design.md
@@ -605,9 +605,9 @@ Android applications commonly need to react to events from the UI or service. Th
 
 {% include requirement/MUST id="android-event-types" %} declare event types to associate event handlers with as package private client constants.
 
-{% include requirement/MUST id="android-event-handler-registration %} register event handlers on clients via methods whose names start with the `addOn` prefix and end with the `Handler` suffix.
+{% include requirement/MUST id="android-event-handler-registration" %} register event handlers on clients via methods whose names start with the `addOn` prefix and end with the `Handler` suffix.
 
-{% include requirement/MUST id="android-event-handler-registration-minimum-arguments %} have said methods take one argument that is an implementation of the `EventHandler` interface from Azure Core. This argument must be named `handler`.
+{% include requirement/MUST id="android-event-handler-registration-minimum-arguments" %} have said methods take one argument that is an implementation of the `EventHandler` interface from Azure Core. This argument must be named `handler`.
 
 ```java
 public void addOnMessageReceivedHandler(EventHandler<MessageReceivedEvent> handler) {
@@ -615,7 +615,7 @@ public void addOnMessageReceivedHandler(EventHandler<MessageReceivedEvent> handl
 }
 ```
 
-{% include requirement/MUST id="android-event-handler-removal %} provide at least one method for unregistering event handlers named `removeEventHandler`, which takes one argument named `handler`.
+{% include requirement/MUST id="android-event-handler-removal" %} provide at least one method for unregistering event handlers named `removeEventHandler`, which takes one argument named `handler`.
 
 ```java
 public void removeEventHandler(EventHandler handler) {
@@ -623,7 +623,7 @@ public void removeEventHandler(EventHandler handler) {
 }
 ```
 
-{% include requirement/MAY id="android-event-handler-specific-removal %} instead provide individual methods for unregistering event handlers whose names start with the `removeOn` prefix and end with the `Handler` suffix. This method must take one argument named `handler`.
+{% include requirement/MAY id="android-event-handler-specific-removal" %} instead provide individual methods for unregistering event handlers whose names start with the `removeOn` prefix and end with the `Handler` suffix. This method must take one argument named `handler`.
 
 ```java
 public void removeOnMessageReceivedHandler(EventHandler<MessageReceivedEvent> handler) {
@@ -631,7 +631,7 @@ public void removeOnMessageReceivedHandler(EventHandler<MessageReceivedEvent> ha
 }
 ```
 
-{% include requirement/SHOULD id="android-group-event-details %} bundle together event details to pass to an event handler via an instance of a class whose name ends with the `Event` suffix. For example:
+{% include requirement/SHOULD id="android-group-event-details" %} bundle together event details to pass to an event handler via an instance of a class whose name ends with the `Event` suffix. For example:
 
 ```java
 public static class MessageReceivedEvent {
@@ -660,7 +660,7 @@ public static class MessageReceivedEvent {
 }
 ```
 
-{% include requirement/MAY id="android-event-details-other-classes %} instead provide other types of objects to event handlers when grouping event details together is not necessary. For example:
+{% include requirement/MAY id="android-event-details-other-classes" %} instead provide other types of objects to event handlers when grouping event details together is not necessary. For example:
 
 ```java
 public void addOnAlertTriggeredHandler(EventHandler<String> handler) {


### PR DESCRIPTION
Based on previous discussions, I created a first draft for the adding event handling guidelines for Android, similar to [the effort for iOS](https://github.com/Azure/azure-sdk/pull/4229). I also [opened a PR](https://github.com/Azure/azure-sdk-for-android/pull/1119) containing the `azure-core` classes and interfaces mentioned in this draft.