### PR TITLE
Recategorize azure-common to exist under the 'Other' label on github.io

### DIFF
--- a/_data/releases/latest/python-packages.csv
+++ b/_data/releases/latest/python-packages.csv
@@ -332,7 +332,7 @@
 "azure-cognitiveservices-nspkg","3.0.1","","Cognitive Services Namespace Package","Cognitive Services","https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/nspkg/azure-cognitiveservices-nspkg/","NA","NA","client","false","","","","","","","","",""
 "azure-cognitiveservices-search-nspkg","3.0.1","","Cognitive Services Search Namespace Package","Cognitive Services","https://github.com/Azure/azure-sdk-for-python/tree/azure-cognitiveservices-search-nspkg_3.0.1/azure-cognitiveservices-search-nspkg/","NA","NA","client","false","","","","","","","","",""
 "azure-cognitiveservices-vision-nspkg","3.0.1","","Cognitive Services Vision Namespace Package","Cognitive Services","https://github.com/Azure/azure-sdk-for-python/tree/azure-cognitiveservices-vision-nspkg_3.0.1/azure-cognitiveservices-vision-nspkg/","NA","NA","client","false","","","","","","","","",""
-"azure-common","1.1.28","","Common","Core","core","","","client","false","","","active","","","","","",""
+"azure-common","1.1.28","","Common","Other","core","","","client","false","","","active","","","","","",""
 "azure-storage-common","2.1.0","","Common","Storage","https://github.com/Azure/azure-storage-python/tree/v2.1.0-common/azure-storage-common","NA","NA","client","false","","","active","","","","","",""
 "azure-communication-nspkg","","0.0.0b1","Communication Namespace Package","Communication","NA","","NA","client","false","","","","","","","","","namespace package"
 "azure-cognitiveservices-vision-computervision","","0.9.0","Computer Vision","Cognitive Services","cognitiveservices","","","client","false","","","preview","","","","","",""


### PR DESCRIPTION
Resolves Azure/azure-sdk-for-python#24775

@danieljurek @sima-zhu can you double check this?

The "core" page: https://azure.github.io/azure-sdk-for-python/core.html

Doesn't have `core` showing up on it. This is because we've recategorized `core` service under `Other` category.

To keep it consistent, let's move `azure-common` to `Other`. Can you double check the space I updated? I'm pretty it should get used as we expect.