### PR TITLE
Clean-up of various Go design guidelines

### DIFF
--- a/docs/golang/implementation.md
+++ b/docs/golang/implementation.md
@@ -84,13 +84,9 @@ const (
 	WidgetColorRed   WidgetColor = "red"
 )
 
-// WidgetColorValues returns a slice of possible values for WidgetColor.
-func WidgetColorValues() []WidgetColor {
+// PossibleWidgetColorValues returns a slice of possible values for WidgetColor.
+func PossibleWidgetColorValues() []WidgetColor {
 	// ...
-}
-
-func (c WidgetColor) ToPtr() *WidgetColor {
-	return &c
 }
 
 ```


### PR DESCRIPTION
Updates reflect the current state of the world for naming of options and
response envelope types.
Promote client constructors that use AAD token auth or the service
preferred authentication mechanism.
Paged and long-running operations now return their respective generic
types.
Resuming an LRO now uses the resume token in the Begin* method.