### PR TITLE
Remove partial duplicate entry for azure-mgmt-monitor

### DIFF
--- a/_data/releases/2021-11/python.yml
+++ b/_data/releases/2021-11/python.yml
@@ -319,7 +319,6 @@ entries:
   Hidden: false
   ChangelogUrl: https://github.com/Azure/azure-sdk-for-python/tree/azure-mgmt-monitor_3.0.0/sdk/monitor/azure-mgmt-monitor/CHANGELOG.md
   ChangelogContent: ""
-- Name: azure-mgmt-monitor
 - Name: azure-core
   Version: 1.20.1
   DisplayName: Core


### PR DESCRIPTION
This PR simply deletes a partial duplicate entry for azure-mgmt-monitor that my scripts tripped over in the 2022-11 python releases yaml.