### PR TITLE
Change 'Deprecated on' to 'End of life on'

### DIFF
--- a/_includes/releases/links.md
+++ b/_includes/releases/links.md
@@ -50,7 +50,7 @@
     {% if item.Support != "" and include.version == "VersionGA" %}
         <div>Support: <a href="https://aka.ms/azsdk/policies/support">{{ item.Support | capitalize }}</a></div>
         {% if item.Support == "deprecated" and item.DeprecatedDate != "" %}
-        <div>Deprecated on {{ item.DeprecatedDate }}</div>
+        <div>End of life on {{ item.DeprecatedDate }}</div>
         {% endif %}
     {% endif %}
 {% endif %}


### PR DESCRIPTION
Change 'Deprecated on {date}' to 'End of life on {date}' to better reflect the state of the library while in transition between date of deprecation and end of life date.