### PR TITLE
Classify spring-cloud-azure-resourcemanager as a spring package instead of mgmt

### DIFF
--- a/_data/releases/latest/java-packages.csv
+++ b/_data/releases/latest/java-packages.csv
@@ -233,7 +233,7 @@
 "azure-resourcemanager-vmwarecloudsimple","com.azure.resourcemanager","","1.0.0-beta.1","Resource Management - VMware Solution by CloudSimple","VMware Solution by CloudSimple","vmwarecloudsimple","","","mgmt","true","","","preview","","false","","","",""
 "azure-resourcemanager-webpubsub","com.azure.resourcemanager","","1.0.0-beta.2","Resource Management - Web PubSub","Web PubSub","webpubsub","","","mgmt","true","","","preview","","false","","","",""
 "azure-resourcemanager-workloads","com.azure.resourcemanager","","1.0.0-beta.1","Resource Management - Workloads","Workloads","workloads","","","mgmt","true","","","preview","","false","","","",""
-"spring-cloud-azure-resourcemanager","com.azure.spring","4.4.0","6.0.0-beta.1","Spring","Spring","spring","NA","NA","mgmt","true","","03/28/2022","","","","","","",""
+"spring-cloud-azure-resourcemanager","com.azure.spring","4.4.0","6.0.0-beta.1","Spring","Spring","spring","NA","NA","spring","true","","03/28/2022","","","","","","",""
 "spring-cloud-azure-starter-active-directory","com.azure.spring","4.4.0","6.0.0-beta.1","Active Directory","Active Directory","spring","NA","NA","spring","true","","03/28/2022","","","","","","",""
 "spring-cloud-azure-starter-active-directory-b2c","com.azure.spring","4.4.0","6.0.0-beta.1","Active Directory B2C","Active Directory B2C","spring","NA","NA","spring","true","","03/28/2022","","","","","","",""
 "spring-cloud-azure-starter-appconfiguration","com.azure.spring","4.4.0","6.0.0-beta.1","App Configuration","App Configuration","spring","NA","NA","spring","true","","03/28/2022","","","","","","",""


### PR DESCRIPTION
spring-cloud-azure-resourcemanager is currently a `mgmt` package. It should be a `spring` package. We [skip](https://github.com/Azure/azure-sdk-for-java/blob/main/eng/scripts/Language-Settings.ps1#L467) onboarding spring packages to docs and this package should not be in our docs. 