### PR TITLE
Client guidelines

### DIFF
--- a/docs/general/design.md
+++ b/docs/general/design.md
@@ -61,11 +61,13 @@ Here are some namespaces that do not meet the guidelines:
 
 The API surface will consist of one of more _service clients_ that the consumer will instantiate to connect to your service, plus a set of supporting types.
 
-The number of service clients in a client library should be minimized to provide consumers a clear starting point for using the library. However, multiple service clients are appropriate in the following situations:
+The number of service clients in a client library should be minimized to provide consumers a clear starting point for using the library. However, multiple service clients may be appropriate in the following situations:
 
 - The service supports two distinct use cases, such as "authoring" and "inference", or "administration" and "runtime", that are unlikely to be used together.
 - The service has a small subset of methods that are needed for its hero scenarios.
 - A subset of service requests require special/different permissions.
+
+When a client library has multiple service clients, these must have descriptive names so that the consumer can quickly determine which client to use to accomplish their task.
 
 {% include requirement/MUST id="general-client-naming" %} name service client types with the `client` suffix.
 

--- a/docs/general/design.md
+++ b/docs/general/design.md
@@ -93,6 +93,8 @@ The purposes of the client library is to communicate with an Azure service.  Azu
 
 {% include requirement/MUST id="general-service-apiversion-1" %} only target generally available service API versions when releasing a stable version of the client library.
 
+{% include requirement/MUST id="general-service-apiversion-8" %} allow the consumer to explicitly select a supported service API version when instantiating the client.
+
 {% include requirement/MUST id="general-service-apiversion-2" %} target the latest generally available service API version by default in stable versions of the client library.
 
 {% include requirement/MUST id="general-service-apiversion-5" %} document the service API version that is used by default.

--- a/docs/general/design.md
+++ b/docs/general/design.md
@@ -61,6 +61,12 @@ Here are some namespaces that do not meet the guidelines:
 
 The API surface will consist of one of more _service clients_ that the consumer will instantiate to connect to your service, plus a set of supporting types.
 
+The number of service clients in a client library should be minimized to provide consumers a clear starting point for using the library. However, multiple service clients are appropriate in the following situations:
+
+- The service supports two distinct use cases, such as "authoring" and "inference", or "administration" and "runtime", that are unlikely to be used together.
+- The service has a small subset of methods that are needed for its hero scenarios.
+- A subset of service requests require special/different permissions.
+
 {% include requirement/MUST id="general-client-naming" %} name service client types with the `client` suffix.
 
 There are times when operations require the addition of optional data, provided in what is colloquially known as an "options bag".  Libraries should strive for consistent naming.

--- a/docs/general/terminology.md
+++ b/docs/general/terminology.md
@@ -17,6 +17,9 @@ Azure SDK
 Azure Core
 : A dependency of many client libraries.  The Azure Core library provides access to the HTTP pipeline, common credential types, and other types that are appropriate to the Azure SDK as a whole.
 
+Client
+: A class that provides methods to send requests to the service.
+
 Client Library
 : A library (and associated tools, documentation, and samples) that _consumers_ use to ease working with an Azure service.  There is generally a client library per Azure service and per target language.  Sometimes a single client library will contain the ability to connect to multiple services.
 
@@ -37,6 +40,9 @@ Package Repository
 
 Progressive Concept Disclosure
 : The first interaction with the client library should not rely on advanced service concepts.  As the consumer of the library becomes more adept, we expose the concepts necessary at the point at which the consumer needs those concepts for implementation. [Progressive Disclosure] was first discussed by the Nielson Norman Group as an approach to designing better user interfaces.
+
+Service client
+: The starting points for consumers calling Azure services with the Azure SDK. A service client is distinguished from other clients in that it can be directly constructed. Each client library should have at least one service client in its main namespace, so it’s easy to discover.
 
 ## Requirements
 


### PR DESCRIPTION
Add guidance on number of service clients and situations to consider multiple service clients.

Also added guideline to support api version parameter on client constructors.

Fixes #4486