### PR TITLE
Update the durable task version

### DIFF
--- a/_data/releases/latest/java-packages.csv
+++ b/_data/releases/latest/java-packages.csv
@@ -646,7 +646,7 @@
 "azure-documentdb-rx","com.microsoft.azure","","0.9.0-rc2","Document DB - Reactive Extension","Cosmos DB","NA","NA","NA","client","false","","","","","","","","","","",""
 "azure-documentdb-spring-boot-autoconfigure","com.microsoft.azure","","0.1.7","Document DB - Spring Boot Auto Configure","Cosmos DB","NA","NA","NA","client","false","","","","","","","","","","",""
 "azure-documentdb-spring-boot-starter","com.microsoft.azure","2.0.5","","Document DB - Spring Boot Starter","Cosmos DB","NA","NA","NA","client","false","","","","","","","","","","",""
-"durabletask-azure-functions","com.microsoft","1.0.0","","Durable Functions - Java Library","Functions","https://github.com/microsoft/durabletask-java","NA","NA","client","false","","","","","","","","","functions","",""
+"durabletask-azure-functions","com.microsoft","1.0.1","","Durable Functions - Java Library","Functions","https://github.com/microsoft/durabletask-java","NA","NA","client","false","","","","","","","","","functions","",""
 "azure-elasticdb-tools","com.microsoft.azure","1.0.0","","Elastic Database Tools","SQL Database","NA","NA","NA","client","false","","","","","","","","","","",""
 "elastic-db-tools","com.microsoft.azure","1.1.0","","Elastic Database Tools","SQL Database","NA","NA","NA","client","false","","","","","","true","","","","",""
 "azure-cognitiveservices-entitysearch","com.microsoft.azure.cognitiveservices","1.0.2","","Entity Search","Cognitive Services","https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/cognitiveservices/ms-azure-cs-entitysearch","NA","NA","client","false","","","","maintenance","","","","","","",""


### PR DESCRIPTION
We recently submitted a fix which we can read the version from csv for azure packages outside of our mono repo. The change has checked in, so we read the 1.0.0 version in csv instead of the latest 1.0.1. I have the PR to update the version