### PR TITLE
Remove Azure Security KeyVault Common package from the C++ index since it never GA'd

### DIFF
--- a/_data/releases/latest/cpp-packages.csv
+++ b/_data/releases/latest/cpp-packages.csv
@@ -12,4 +12,3 @@
 "azure-storage-queues","12.0.0","","Storage - Queues","Storage","storage","","","client","true","","04/05/2022","04/05/2022","","","","","","","",""
 "azure-core-tracing-opentelemetry","","1.0.0-beta.3","Tracing","Other","core","NA","","client","true","","","","","","","","","","",""
 "azure-template","1.0.0","1.1.0-beta.1856252","","Template","template","NA","NA","client","true","","","","","","true","","","","",""
-"azure-security-keyvault-common","","4.0.0-beta.3","Key Vault - Common","Key Vault","keyvault","NA","NA","client","true","","","","","","true","","","","",""


### PR DESCRIPTION
We decided against having a KeyVault Common package in C++ and instead went with a source file sharing approach. We don't need this artifact visible anymore, especially since I don't think it is adding any value.

@weshaggard please correct me if I am mistaken and if we need to keep this entry for some reason. If we **really** need to keep it, we should at least mark is at deprecated.

It was removed from the vcpkg package registry before GA:
https://github.com/microsoft/vcpkg/pull/22491

And from the source:
https://github.com/Azure/azure-sdk-for-cpp/pull/2905

The last update to the package index was here, for `beta.3`:
https://github.com/Azure/azure-sdk/pull/2970

Here are the current documented/visible C++ releases for reference:
https://azure.github.io/azure-sdk/releases/latest/#c