### PR TITLE
Fix java guidelines typo

### DIFF
--- a/docs/java/introduction.md
+++ b/docs/java/introduction.md
@@ -901,7 +901,7 @@ See the [Azure Core readme](https://github.com/Azure/azure-sdk-for-java/tree/mai
 
 #### Using Primitive Types
 
-{% include requirement/MUSTNOT id="java-api-old-date-time" %} create API that exposes the old Java date library (e.g. `java.util.Date`, `java.util.Calendar`, and `java.util.Timezone`). All API must use the new date / time APIs that shipped in JDK 8 in the `java.util.time` package.
+{% include requirement/MUSTNOT id="java-api-old-date-time" %} create API that exposes the old Java date library (e.g. `java.util.Date`, `java.util.Calendar`, and `java.util.Timezone`). All API must use the new date / time APIs that shipped in JDK 8 in the `java.time` package.
 
 {% include requirement/MUSTNOT id="java-api-url" %} create API that exposes the `java.net.URL` API. This API is difficult to work with, and more frequently gets in the users way rather than provide any real assistance. Instead, use the String type to represent the URL. When it is necessary to parse this String into a URL, and if it fails to be parsed (throwing a checked `MalformedURLException`), catch this internally and throw an unchecked `IllegalArgumentException` instead.
 


### PR DESCRIPTION
There is a typo in the java.time package recommendation. 