### PR TITLE
Converge Azure SDK with OpenTelemetry semantic conventions

### DIFF
--- a/docs/tracing/distributed-tracing-conventions.md
+++ b/docs/tracing/distributed-tracing-conventions.md
@@ -18,6 +18,11 @@ When writing instrumentation in Azure SDK or Core:
 
 {% include requirement/MUST id="general-tracing-convention-describe-attributes" %} update [distributed-tracing-conventions.yml](./distributed-tracing-conventions.yml) when adding new attributed.
 
+{% include requirement/MUST id="general-tracing-convention-set-schema-version" %} set OpenTelemetry [Schema URL](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/schemas/README.md?plain=1) when [creating OpenTelemetry tracer](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#get-a-tracer).
+
+{% include requirement/SHOULD id="general-tracing-convention-set-library" %} set Azure Client Library name and version [Schema URL](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#get-a-tracer) when [creating OpenTelemetry tracer](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#get-a-tracer).
+
+
 {% include requirement/SHOULD id="general-tracing-convention-new-otel" %} contribute new conventions (or patch existing ones) to OpenTelemetry when there is no suitable one or some scenarios are missing.
 
 {% include requirement/MAY id="general-tracing-convention-add-attributes" %} extend list of attributes on top of OpenTelemetry contentions with Azure-specific ones.

--- a/docs/tracing/distributed-tracing-conventions.yml
+++ b/docs/tracing/distributed-tracing-conventions.yml
@@ -55,7 +55,7 @@ groups:
       - ref: messaging.system
         sampling_relevant: true
         examples: ['eventhubs', 'servicebus']
-      - ref: messaging.url
+      - ref: net.peer.name
         sampling_relevant: true
         brief: 'Fully qualified Azure messaging service name.'
         examples: 'http://myEventHubNamespace.servicebus.windows.net/'

--- a/docs/tracing/distributed-tracing-conventions.yml
+++ b/docs/tracing/distributed-tracing-conventions.yml
@@ -1,7 +1,6 @@
 # This document describes Azure SDK semantic conventions for tracing in [OpenTelemetry format](https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md).
 # DO NOT add new conventions - use [OpenTelemetry conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/main/semantic_conventions), but it's ok to extend existing ones.
-# DO remove conventions when moving to OpenTelemetry one - it's not breaking.
-# Version: 0.0.0
+# Version: 0.1.0
 
 groups:
   # common
@@ -30,58 +29,43 @@ groups:
       This conventions follows [OpenTelemetry HTTP](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md)
       but omits all optional attributes, providing only `http.url` to describe destination. It adds request-id attributes supported by Azure services.
     attributes:
-      - id: http.method
-        type: string
-        requirement_level: required
-        sampling_relevant: true
-        brief: 'HTTP request method.'
-        examples: ["GET", "POST", "HEAD"]
-      - id: http.url
-        type: string
-        requirement_level: required
-        sampling_relevant: true
-        brief: Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]`
-        examples: ['https://www.foo.bar/search?q=OpenTelemetry#SemConv']
-      - id: http.status_code
-        type: int
-        requirement_level:
-          conditionally_required: If and only if one was received/sent.
-        brief: '[HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6).'
-        examples: [200]
-      - id: http.user_agent
-        type: string
-        requirement_level:
-          conditionally_required: only if present
-        brief: 'Value of the [HTTP User-Agent](https://tools.ietf.org/html/rfc7231#section-5.5.3) header sent by the client.'
-        examples: ['CERN-LineMode/2.15 libwww/2.17b3']
-      - id: requestId
+      - ref: http.method
+      - ref: http.url
+      - ref: http.status_code
+      - id: az.client_request_id
         type: string
         requirement_level:
           conditionally_required: only if present
         brief: 'Value of the [x-ms-client-request-id] header (or other request-id header, depending on the service) sent by the client.'
         examples: ['eb178587-c05a-418c-a695-ae9466c5303c']
-      - id: serviceRequestId
+      - id: az.service_request_id
         type: string
         requirement_level:
           conditionally_required: if and only if one was received
         brief: 'Value of the [x-ms-request-id]  header (or other request-id header, depending on the service) sent by the server in response.'
         examples: ['3f828ae5-ecb9-40ab-88d9-db0420af30c6']
+    constraints:
+      - include: http.client #https://github.com/open-telemetry/opentelemetry-specification/blob/main/semantic_conventions/trace/http.yaml
 
   # messaging
   - id: azure-sdk.messaging
     brief: 'Describes Azure messaging SDKs spans.'
     extends: azure-sdk
     attributes:
-      - id: message_bus.destination
-        type: string
-        requirement_level: required
+      - ref: messaging.system
+        sampling_relevant: true
+        examples: ['eventhubs', 'servicebus']
+      - ref: messaging.url
+        sampling_relevant: true
+        brief: 'Fully qualified Azure messaging service name.'
+        examples: 'http://myEventHubNamespace.servicebus.windows.net/'
+      - ref: messaging.destination
+        sampling_relevant: true
         brief: 'Name of the messaging entity within namespace: e.g EventHubs name, ServiceBus queue or topic name.'
         examples: ['myqueue', 'myhub']
-      - id: peer.address
-        type: string
-        brief: 'Fully qualified messaging service name.'
-        requirement_level: required
-        examples: ['myEventHubNamespace.servicebus.windows.net']
+    constraints:
+      - include: messaging #https://github.com/open-telemetry/opentelemetry-specification/blob/main/semantic_conventions/trace/messaging.yaml
+
   - id: azure-sdk.messaging.producer
     span_kind: producer
     extends: azure-sdk.messaging
@@ -90,7 +74,7 @@ groups:
   - id: azure-sdk.messaging.send
     span_kind: client
     extends: azure-sdk.messaging
-    brief: 'Describes send (transport call) span.'
+    brief: 'Describes Azure messaging SDKs producer client spans.'
     note: 'Contains links to all messages contexts being sent.'
 
   - id: azure-sdk.messaging.process
@@ -109,23 +93,32 @@ groups:
       Events with additional debug info are added for long running operations.
     extends: azure-sdk
     attributes:
-      - id: db.url
+      - ref: net.peer.name
+        requirement_level: required
+        sampling_relevant: true
+        brief: 'Fully qualified database service name.'
+        examples: ['https://my-cosmos.documents.azure.com']
+      - ref: net.peer.port
+        requirement_level: 
+        conditionally_required: if using a port other than the default port for this DBMS.
+        sampling_relevant: true
+        brief: 'Database port'
+        examples: 443
+      - ref: db.operation
         type: string
         requirement_level: required
-        brief: 'Cosmos DB URI'
-        examples: ['https://my-cosmos.documents.azure.com:443/']
-      - id: db.statement
-        type: string
-        requirement_level: required
+        sampling_relevant: true
         brief: 'Database statement'
         examples: ['createContainerIfNotExists.myContainer']
-      - id: db.instance
-        type: string
+      - ref: db.name
         requirement_level: required
+        sampling_relevant: true
         brief: 'Database name'
         examples: ['mydb']
-      - id: db.type
-        type: string
+      - ref: db.system
         requirement_level: required
+        sampling_relevant: true
         brief: 'Database type'
-        examples: ['Cosmos']
+        examples: ['cosmosdb']
+    constraints:
+      - include: db #https://github.com/open-telemetry/opentelemetry-specification/blob/main/semantic_conventions/trace/database.yaml

--- a/docs/tracing/distributed-tracing-conventions.yml
+++ b/docs/tracing/distributed-tracing-conventions.yml
@@ -8,10 +8,16 @@ groups:
     brief: 'Describes Azure SDK spans.'
     attributes:
       - id: az.namespace
-        required: always
+        requirement_level: required
         type: string
         brief: '[Namespace](https://docs.microsoft.com/azure/azure-resource-manager/management/azure-services-resource-providers) of Azure service request is made against.'
         examples: ['Microsoft.Storage', 'Microsoft.KeyVault', 'Microsoft.ServiceBus']
+      - id: az.schema_url
+        requirement_level:
+          conditionally_required: if and only if OpenTelemetry in given language does not provide standard way to set schema_url (i.e. .NET) # https://opentelemetry.io/docs/reference/specification/schemas/#schema-url
+        type: string
+        brief: 'OpenTelemetry Schema URL including schema version. Only 1.17.0 is supported.'
+        examples: ['https://opentelemetry.io/schemas/1.17.0']
 
   # public API
   - id: azure-sdk.api
@@ -30,8 +36,24 @@ groups:
       but omits all optional attributes, providing only `http.url` to describe destination. It adds request-id attributes supported by Azure services.
     attributes:
       - ref: http.method
+        requirement_level: required    
+        sampling_relevant: true  
       - ref: http.url
+        requirement_level: required      
+        sampling_relevant: true
       - ref: http.status_code
+        requirement_level: required      
+      - ref: net.peer.name
+        requirement_level: required
+        sampling_relevant: true
+        brief: brief: 'Fully qualified Azure service endpoint (host name component).'
+        examples: 'http://my-account.servicebus.windows.net/'
+      - ref: net.peer.port
+        requirement_level: 
+          conditionally_required: if not 80 or 443.
+        sampling_relevant: true
+        brief: brief: 'Port of Azure service endpoint.'
+        examples: 'http://my-account.servicebus.windows.net/'
       - id: az.client_request_id
         type: string
         requirement_level:
@@ -53,16 +75,19 @@ groups:
     extends: azure-sdk
     attributes:
       - ref: messaging.system
+        requirement_level: required      
         sampling_relevant: true
         examples: ['eventhubs', 'servicebus']
       - ref: net.peer.name
+        requirement_level: required
         sampling_relevant: true
-        brief: 'Fully qualified Azure messaging service name.'
+        brief: 'Fully qualified Azure messaging service endpoint (host name only).'
         examples: 'http://myEventHubNamespace.servicebus.windows.net/'
-      - ref: messaging.destination
+      - ref: messaging.destination.name
+        requirement_level: required
         sampling_relevant: true
-        brief: 'Name of the messaging entity within namespace: e.g EventHubs name, ServiceBus queue or topic name.'
-        examples: ['myqueue', 'myhub']
+        brief: 'Name of the messaging entity within namespace: e.g EventHubs name, ServiceBus queue or topic name. Must not include partition or subscription'
+        examples: ['myqueue', 'myhub']       
     constraints:
       - include: messaging #https://github.com/open-telemetry/opentelemetry-specification/blob/main/semantic_conventions/trace/messaging.yaml
 
@@ -86,39 +111,5 @@ groups:
       attribute with unix epoch time with milliseconds precision representing when message was enqueued.
 
   # db
-  - id: azure-sdk.cosmos
-    span_kind: client
-    brief: 'Describes Azure CosmosDB spans.'
-    note: >
-      Events with additional debug info are added for long running operations.
-    extends: azure-sdk
-    attributes:
-      - ref: net.peer.name
-        requirement_level: required
-        sampling_relevant: true
-        brief: 'Fully qualified database service name.'
-        examples: ['https://my-cosmos.documents.azure.com']
-      - ref: net.peer.port
-        requirement_level: 
-        conditionally_required: if using a port other than the default port for this DBMS.
-        sampling_relevant: true
-        brief: 'Database port'
-        examples: 443
-      - ref: db.operation
-        type: string
-        requirement_level: required
-        sampling_relevant: true
-        brief: 'Database statement'
-        examples: ['createContainerIfNotExists.myContainer']
-      - ref: db.name
-        requirement_level: required
-        sampling_relevant: true
-        brief: 'Database name'
-        examples: ['mydb']
-      - ref: db.system
-        requirement_level: required
-        sampling_relevant: true
-        brief: 'Database type'
-        examples: ['cosmosdb']
-    constraints:
-      - include: db #https://github.com/open-telemetry/opentelemetry-specification/blob/main/semantic_conventions/trace/database.yaml
+  # is being moved here: https://github.com/open-telemetry/opentelemetry-specification/pull/3097
+

--- a/docs/tracing/distributed-tracing-conventions.yml
+++ b/docs/tracing/distributed-tracing-conventions.yml
@@ -26,9 +26,29 @@ groups:
     brief: 'Describes Azure SDK API calls spans.'
     note: 'Represents public surface API calls that wrap an Azure service call.'
 
+  # network calls
+  - id: azure-sdk.network
+    extends: azure-sdk
+    brief: 'Describes Azure SDK client spans.'
+    note: 'Represents calls that include network attributes'
+    attributes:
+      - ref: net.peer.name
+        requirement_level: required
+        sampling_relevant: true
+        brief: brief: 'Fully qualified Azure service endpoint (host name component).'
+        examples: 'http://my-account.servicebus.windows.net/'
+      - ref: net.peer.port
+        requirement_level: 
+          conditionally_required: if not 80 or 443.
+        sampling_relevant: true
+        brief: brief: 'Port of Azure service endpoint.'
+        examples: [8080]
+    constraints:
+      - include: network #https://github.com/open-telemetry/opentelemetry-specification/blob/main/semantic_conventions/trace/general.yaml
+      
   # http
   - id: azure-sdk.http
-    extends: azure-sdk
+    extends: azure-sdk.network
     span_kind: client
     brief: 'Describes HTTP client spans created per HTTP request (try).'
     note: >
@@ -43,17 +63,6 @@ groups:
         sampling_relevant: true
       - ref: http.status_code
         requirement_level: required      
-      - ref: net.peer.name
-        requirement_level: required
-        sampling_relevant: true
-        brief: brief: 'Fully qualified Azure service endpoint (host name component).'
-        examples: 'http://my-account.servicebus.windows.net/'
-      - ref: net.peer.port
-        requirement_level: 
-          conditionally_required: if not 80 or 443.
-        sampling_relevant: true
-        brief: brief: 'Port of Azure service endpoint.'
-        examples: 'http://my-account.servicebus.windows.net/'
       - id: az.client_request_id
         type: string
         requirement_level:
@@ -72,22 +81,19 @@ groups:
   # messaging
   - id: azure-sdk.messaging
     brief: 'Describes Azure messaging SDKs spans.'
-    extends: azure-sdk
+    extends: azure-sdk.network
     attributes:
       - ref: messaging.system
         requirement_level: required      
         sampling_relevant: true
         examples: ['eventhubs', 'servicebus']
-      - ref: net.peer.name
-        requirement_level: required
-        sampling_relevant: true
-        brief: 'Fully qualified Azure messaging service endpoint (host name only).'
-        examples: 'http://myEventHubNamespace.servicebus.windows.net/'
       - ref: messaging.destination.name
         requirement_level: required
         sampling_relevant: true
         brief: 'Name of the messaging entity within namespace: e.g EventHubs name, ServiceBus queue or topic name. Must not include partition or subscription'
-        examples: ['myqueue', 'myhub']       
+        examples: ['myqueue', 'myhub']
+      - ref: messaging.operation
+      - ref: messaging.batch.message_count
     constraints:
       - include: messaging #https://github.com/open-telemetry/opentelemetry-specification/blob/main/semantic_conventions/trace/messaging.yaml
 

--- a/docs/tracing/distributed-tracing-conventions.yml
+++ b/docs/tracing/distributed-tracing-conventions.yml
@@ -6,6 +6,7 @@ groups:
   # common
   - id: azure-sdk
     brief: 'Describes Azure SDK spans.'
+    type: attribute_group
     attributes:
       - id: az.namespace
         requirement_level: required
@@ -21,13 +22,21 @@ groups:
 
   # public API
   - id: azure-sdk.api
+    type: span
     span_kind: internal
     extends: azure-sdk
     brief: 'Describes Azure SDK API calls spans.'
-    note: 'Represents public surface API calls that wrap an Azure service call.'
+    note: > 
+      Represents public surface API calls that wrap an Azure service call.
+
+      Span name SHOULD match `<short-class-name.method>` pattern. Class and method name SHOULD match API user called close enough for users
+      to understand which method span matches to.
+      For example, `BlobClient.Download` could be used for different overloads of download method, it can also coexist with `BlobClient.DownloadToFile` or
+      `BlobClient.DownloadAsync`.  
 
   # network calls
   - id: azure-sdk.network
+    type: attribute_group
     extends: azure-sdk
     brief: 'Describes Azure SDK client spans.'
     note: 'Represents calls that include network attributes'
@@ -50,12 +59,15 @@ groups:
       
   # http
   - id: azure-sdk.http
-    extends: azure-sdk.network
+    type: span
     span_kind: client
+    extends: azure-sdk.network
     brief: 'Describes HTTP client spans created per HTTP request (try).'
     note: >
       This conventions follows [OpenTelemetry HTTP](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md)
       but omits all optional attributes, providing only `http.url` to describe destination. It adds request-id attributes supported by Azure services.
+
+      Span name MUST NOT include dynamic parts and SHOULD follow `HTTP <method>` pattern. E.g. `HTTP GET`.
     attributes:
       - ref: http.method
         requirement_level: required    
@@ -85,6 +97,7 @@ groups:
 
   # messaging
   - id: azure-sdk.messaging
+    type: span
     brief: 'Describes Azure messaging SDKs spans.'
     extends: azure-sdk.network
     attributes:
@@ -104,14 +117,18 @@ groups:
 
   - id: azure-sdk.messaging.producer
     span_kind: producer
-    extends: azure-sdk.messaging
+    extends: azure-sdk
     brief: 'Describes producer span created per message.'
+    note: Span name SHOULD match `<queue/topic_name> message`. E.g. `orders message`. 
 
   - id: azure-sdk.messaging.send
     span_kind: client
     extends: azure-sdk.messaging
     brief: 'Describes Azure messaging SDKs producer client spans.'
-    note: 'Contains links to all messages contexts being sent.'
+    note: >
+      Contains links to all messages contexts being sent.
+      Span name SHOULD match `<queue/topic_name> publish`. E.g. `orders publish`. 
+      
 
   - id: azure-sdk.messaging.process
     span_kind: consumer
@@ -120,6 +137,7 @@ groups:
     note: >
       Contains links to all messages contexts being consumed. Each link has attribute `enqueuedTime` (with `long` type)
       attribute with unix epoch time with milliseconds precision representing when message was enqueued.
+      Span name SHOULD match `<queue/topic_name> process`. E.g. `orders process`. 
 
   # db
   # is being moved here: https://github.com/open-telemetry/opentelemetry-specification/pull/3097

--- a/docs/tracing/distributed-tracing-conventions.yml
+++ b/docs/tracing/distributed-tracing-conventions.yml
@@ -35,13 +35,15 @@ groups:
       - ref: net.peer.name
         requirement_level: required
         sampling_relevant: true
-        brief: brief: 'Fully qualified Azure service endpoint (host name component).'
+        type: string
+        brief: 'Fully qualified Azure service endpoint (host name component).'
         examples: 'http://my-account.servicebus.windows.net/'
       - ref: net.peer.port
         requirement_level: 
           conditionally_required: if not 80 or 443.
         sampling_relevant: true
-        brief: brief: 'Port of Azure service endpoint.'
+        brief: Port of Azure service endpoint.'
+        type: int        
         examples: [8080]
     constraints:
       - include: network #https://github.com/open-telemetry/opentelemetry-specification/blob/main/semantic_conventions/trace/general.yaml
@@ -63,6 +65,9 @@ groups:
         sampling_relevant: true
       - ref: http.status_code
         requirement_level: required      
+      - ref: http.user_agent
+        type: string
+        brief: 'Value of the HTTP User-Agent or x-ms-user-agent header'
       - id: az.client_request_id
         type: string
         requirement_level:


### PR DESCRIPTION
This change aligns Azure SDK with OpenTelemetry semantic conventions [v1.17.0](https://github.com/open-telemetry/opentelemetry-specification/releases/tag/v1.17.0):
- unifies attribute names for messaging
- requires Azure SDKs to populate OTel schema versions
- recommends adding library name and version to tracer.

With this, we'll have 3 azure-specific attributes (with the opportunity to add more in the future if needed):
- `az.namespace` for RP namespace
- `az.client_request_id` for `x-ms-client-request-id
- `az.service_request_id` for `x-ms-request-id`

And will reuse available attributes defined in otel.