### PR TITLE
Deprecate Microsoft.OpenTelemetry.Exporter.AzureMonitor package

### DIFF
--- a/_data/releases/latest/dotnet-packages.csv
+++ b/_data/releases/latest/dotnet-packages.csv
@@ -426,7 +426,7 @@
 "Azure.Base","","1.0.0-preview.3","Azure Base","Base","NA","NA","NA","client","False","","","","","","true","","","","",""
 "Azure.Batch.FileStaging","8.0.1","","Azure Batch - File Staging","Batch","NA","NA","NA","client","False","","","","active","","true","","","","",""
 "Azure.Extensions.Configuration.Secrets","","1.0.0-preview.1","Azure Extensions Configuration Secrets","Extensions","NA","NA","NA","client","False","","","","","","true","","","","","Renamed to Azure.Extensions.AspNetCore.Configuration.Secrets before GA"
-"Microsoft.OpenTelemetry.Exporter.AzureMonitor","","1.0.0-beta.1","Azure Monitor Exporter for OpenTelemetry","Monitor","NA","NA","","client","False","","","","","","","","","","",""
+"Microsoft.OpenTelemetry.Exporter.AzureMonitor","","1.0.0-beta.1","Azure Monitor Exporter for OpenTelemetry","Monitor","NA","NA","","client","False","","","","deprecated","3/31/2023","","Azure.Monitor.OpenTelemetry.Exporter","","","","Renamed to Azure.Monitor.OpenTelemetry.Exporter before GA"
 "Microsoft.AzureStack.AzureConsistentStorage","","0.10.8-preview","Azure Stack - Azure Consistent Storage","Stack","NA","NA","NA","client","False","","","","","","","","","","",""
 "Azure.Template","","1.0.3-beta.20201117","Azure Template","template","C:\Git\azure-sdk-for-net\sdk\template","NA","NA","client","true","","","","","","true","","","","",""
 "Microsoft.Azure.Batch","15.4.0","","Batch","Batch","batch","NA","","client","False","","","","active","","","","","","",""


### PR DESCRIPTION
This package was renamed to Azure.Monitor.OpenTelemetry.Exporter in https://github.com/Azure/azure-sdk/pull/2359