### PR TITLE
Update support end dates and deprecate NuGet packages

### DIFF
--- a/_data/releases/latest/dotnet-packages.csv
+++ b/_data/releases/latest/dotnet-packages.csv
@@ -626,7 +626,7 @@
 "Microsoft.Azure.WebJobs.Extensions.ApiHub","","1.0.0-beta9","WebJobs Extensions - API Hub","Functions","https://github.com/Azure/azure-webjobs-sdk-extensions","NA","NA","client","False","","","","deprecated","","","","","","",""
 "Microsoft.Azure.WebJobs.Extensions.WebHooks","","1.0.0-beta4","WebJobs Extensions - WebHooks","Functions","https://github.com/Azure/azure-webjobs-sdk-extensions","NA","NA","client","False","","","","deprecated","","","","","","",""
 "Microsoft.Azure.WebSites.DataProtection","","0.1.78-alpha","WebSites - DataProtection","App Service","NA","NA","NA","client","False","","","","","","","","","","",""
-"Microsoft.WindowsAzure.Caching","2.9.5","","WindowsAzure Caching","Redis","NA","NA","NA","client","False","","","","deprecated","3/31/2023","true","","","","",""
+"Microsoft.WindowsAzure.Caching","2.9.5","","WindowsAzure Caching","Redis","NA","NA","NA","client","False","","","","deprecated","11/30/2016","true","","","","",""
 "WindowsAzure.Caching","1.7.0","","WindowsAzure Caching","Redis","NA","NA","NA","client","False","","","","deprecated","3/31/2023","true","","","","",""
 "Microsoft.WindowsAzure.Caching.MemcacheShim","2.9.5","","WindowsAzure Caching - Memcache Shim","Redis","NA","NA","NA","client","False","","","","deprecated","3/31/2023","true","","","","",""
 "Microsoft.WindowsAzure.Common","1.4.1","","WindowsAzure Common","Common","NA","NA","NA","client","False","","","","maintenance","","","","","","",""

--- a/_data/releases/latest/dotnet-packages.csv
+++ b/_data/releases/latest/dotnet-packages.csv
@@ -458,7 +458,7 @@
 "Microsoft.Azure.Common.Authentication","","1.7.0-preview","Common - Authentication","Common","NA","NA","NA","client","False","","","","","","","","","","",""
 "Microsoft.Azure.Common.Dependencies","1.0.0","","Common - Dependencies","Common","NA","NA","NA","client","False","","","","active","","","","","","",""
 "Microsoft.Azure.CognitiveServices.Vision.ComputerVision","7.0.1","","Computer Vision","Computer Vision","https://github.com/Azure/azure-sdk-for-net/tree/Microsoft.Azure.CognitiveServices.Vision.ComputerVision_6.0.0-preview.1/sdk/cognitiveservices/Vision.ComputerVision","NA","","client","False","","","","active","","","","","","",""
-"Microsoft.Azure.ConfigurationManager","4.0.0","","Configuration Manager","Configuration Manager","NA","NA","NA","client","False","","","","active","","","","","","",""
+"Microsoft.Azure.ConfigurationManager","4.0.0","","Configuration Manager","Configuration Manager","NA","NA","NA","client","False","","","","deprecated","3/31/2023","","","","","",""
 "Microsoft.Azure.ContainerRegistry","","1.0.0-preview.2","Container Registry","Container Registry","containerregistry","NA","","client","False","","","","","","","","","","",""
 "Microsoft.Azure.CognitiveServices.ContentModerator","2.0.0","","Content Moderator","Content Moderator","NA","NA","NA","client","False","","","","active","","","","","","",""
 "Azure.Core.Experimental","","0.1.0-preview.23","Core - Client - Experimental","Other","core","NA","","client","true","","","","","","true","","","","","Hiding as it is only for experimenting with new Azure.Core features"

--- a/_data/releases/latest/dotnet-packages.csv
+++ b/_data/releases/latest/dotnet-packages.csv
@@ -628,7 +628,7 @@
 "Microsoft.Azure.WebSites.DataProtection","","0.1.78-alpha","WebSites - DataProtection","App Service","NA","NA","NA","client","False","","","","","","","","","","",""
 "Microsoft.WindowsAzure.Caching","2.9.5","","WindowsAzure Caching","Redis","NA","NA","NA","client","False","","","","deprecated","11/30/2016","true","","","","",""
 "WindowsAzure.Caching","1.7.0","","WindowsAzure Caching","Redis","NA","NA","NA","client","False","","","","deprecated","3/31/2023","true","","","","",""
-"Microsoft.WindowsAzure.Caching.MemcacheShim","2.9.5","","WindowsAzure Caching - Memcache Shim","Redis","NA","NA","NA","client","False","","","","deprecated","3/31/2023","true","","","","",""
+"Microsoft.WindowsAzure.Caching.MemcacheShim","2.9.5","","WindowsAzure Caching - Memcache Shim","Redis","NA","NA","NA","client","False","","","","deprecated","11/30/2016","true","","","","",""
 "Microsoft.WindowsAzure.Common","1.4.1","","WindowsAzure Common","Common","NA","NA","NA","client","False","","","","maintenance","","","","","","",""
 "Microsoft.WindowsAzure.Common.Dependencies","1.1.1","","WindowsAzure Common - Dependencies","Common","NA","NA","NA","client","False","","","","maintenance","","","","","","",""
 "Microsoft.WindowsAzure.Common.Tracing.Etw","1.0.0","","WindowsAzure Common - Tracing ETW","Common","NA","NA","NA","client","False","","","","maintenance","","","","","","",""

--- a/_data/releases/latest/dotnet-packages.csv
+++ b/_data/releases/latest/dotnet-packages.csv
@@ -633,7 +633,7 @@
 "Microsoft.WindowsAzure.Common.Dependencies","1.1.1","","WindowsAzure Common - Dependencies","Common","NA","NA","NA","client","False","","","","maintenance","","","","","","",""
 "Microsoft.WindowsAzure.Common.Tracing.Etw","1.0.0","","WindowsAzure Common - Tracing ETW","Common","NA","NA","NA","client","False","","","","maintenance","","","","","","",""
 "Microsoft.WindowsAzure.Common.Tracing.Log4Net","1.0.0","","WindowsAzure Common - Tracing Log4Net","Common","NA","NA","NA","client","False","","","","maintenance","","","","","","",""
-"Microsoft.WindowsAzure.ConfigurationManager","3.2.3","","WindowsAzure Configuration Manager","Configuration Manager","NA","NA","NA","client","False","","","","maintenance","","","","","","",""
+"Microsoft.WindowsAzure.ConfigurationManager","3.2.3","","WindowsAzure Configuration Manager","Configuration Manager","NA","NA","NA","client","False","","","","deprecated","3/31/2023","","","","","","Renamed to Microsoft.Azure.ConfigurationManager"
 "windowsazure.mediaservices","4.2.0","","WindowsAzure Media Services","Media Services","https://github.com/Azure/azure-sdk-for-media-services","https://docs.microsoft.com/dotnet/api/overview/azure/media-services","NA","client","False","","","","maintenance","","","","","","",""
 "WindowsAzure.MobileServices","1.3.2","","WindowsAzure Mobile Services","App Service","NA","NA","NA","client","False","","","","deprecated","3/31/2023","","","","","",""
 "WindowsAzure.MobileServices.Backend","1.0.478","","WindowsAzure Mobile Services - Backend","App Service","NA","NA","NA","client","False","","","","deprecated","3/31/2023","","","","","",""


### PR DESCRIPTION
**Summary of changes**
- Update support end dates for `Microsoft.WindowsAzure.Caching` and `Microsoft.WindowsAzure.Caching.MemcacheShim`, per a conversation with @lfraleigh
- Deprecate `Microsoft.Azure.ConfigurationManager` and `Microsoft.WindowsAzure.ConfigurationManager`