### PR TITLE
Updates to JS & Python Monitor resource mgmt packages

### DIFF
--- a/_data/releases/latest/js-packages.csv
+++ b/_data/releases/latest/js-packages.csv
@@ -422,7 +422,7 @@
 "azure-common","","0.9.27","azure-common","","NA","NA","NA","","false","","","","","","","","","","",""
 "azure-graph","4.3.0","","azure-graph","","NA","NA","NA","","false","","","","deprecated","3/31/2023","","@microsoft/microsoft-graph-client","","","",""
 "azure-loganalytics","","0.2.0","Log Analytics - Query","Log Analytics","NA","NA","NA","","false","","","","deprecated","3/31/2023","true","@azure/loganalytics","","","","This package was replaced by @azure/loganalytics, which was replaced by @azure/monitor-query."
-"azure-monitoring","","0.10.6","azure-monitoring","Monitor","NA","NA","NA","","false","","","","deprecated","3/31/2023","","@azure/arm-monitor","","","",""
+"azure-monitoring","","0.10.6","azure-monitoring","Resource Management - Monitor","NA","NA","NA","","false","","","","deprecated","3/31/2023","","@azure/arm-monitor","","","",""
 "azure-scheduler","","0.10.4","azure-scheduler","","NA","NA","NA","","false","","","","deprecated","3/31/2023","","@azure/arm-logic","https://docs.microsoft.com/en-us/azure/scheduler/migrate-from-scheduler-to-logic-apps","","",""
 "azure-servicefabric","3.0.0","","azure-servicefabric","","NA","NA","NA","","false","","","","deprecated","3/31/2023","","@azure/servicefabric","","","",""
 "cadl-msbuild-target","","0.1.0","cadl-msbuild-target","","NA","NA","NA","","false","","","","","","","","","","",""

--- a/_data/releases/latest/python-packages.csv
+++ b/_data/releases/latest/python-packages.csv
@@ -391,7 +391,7 @@
 "azure-cognitiveservices-language-luis","","0.7.0","Language Understanding (LUIS)","Cognitive Services","cognitiveservices","","","client","false","","","","","","","","","","",""
 "azure-loganalytics","","0.1.1","Log Analytics - Query","Log Analytics","https://github.com/Azure/azure-sdk-for-python/tree/azure-loganalytics_0.1.0/azure-loganalytics/","NA","","client","false","","","","deprecated","3/31/2023","","azure-monitor-query","https://azsdk/python/migrate/la-to-monitor-query","","",""
 "azureml-sdk","1.2.0","","Machine Learning","Machine Learning","NA","NA","NA","client","false","","","","active","","","","","","",""
-"azure-monitor","","0.4.0","Monitor","Monitor","https://github.com/Azure/azure-sdk-for-python/tree/azure-monitor_0.3.1/azure-monitor/","NA","NA","client","false","","","","","","","","","","",""
+"azure-monitor","","0.4.0","Resource Management - Monitor","Monitor","https://github.com/Azure/azure-sdk-for-python/tree/azure-monitor_0.3.1/azure-monitor/","NA","NA","client","false","","","","deprecated","6/30/2021","","azure-mgmt-monitor","","","",""
 "microsoft-opentelemetry-exporter-azuremonitor","","1.0.0b1","Monitor Exporter for OpenTelemetry","Monitor","monitor","NA","NA","client","true","1.0.0,04/13/2021","","","","","true","","","","",""
 "msrest","","0.7.1","MsRest","MsRest","https://github.com/Azure/msrest-for-python/tree/v0.6.18/msrest","NA","NA","client","false","","","","maintenance","","","","","","",""
 "msrestazure","","0.6.4","MsRest Azure","MsRest","https://github.com/Azure/msrestazure-for-python/tree/v0.6.4/msrestazure","NA","NA","client","false","","","","maintenance","","","","","","",""


### PR DESCRIPTION
**Summary of changes**
- Mark the Track 1 `azure-monitor` Python package as deprecated and update its name to "Resource Management - Monitor"
- Update the Track 1 `azure-monitoring` JS library's name to "Resource Management - Monitor"