### PR TITLE
Use 1ES pools

### DIFF
--- a/eng/ci.yml
+++ b/eng/ci.yml
@@ -10,6 +10,7 @@ resources:
       ref: refs/tags/azure-sdk-tools_20220404.3
 
 pool:
+  name: 'azsdk-pool-mms-ubuntu-2204-general'
   vmImage: 'ubuntu-22.04'
 
 variables:

--- a/eng/pipelines/generate-release-structure.yml
+++ b/eng/pipelines/generate-release-structure.yml
@@ -2,6 +2,7 @@ trigger:
 - master
 
 pool:
+  name: 'azsdk-pool-mms-win-2022-general'
   vmImage: 'windows-2022'
 
 resources:

--- a/eng/pipelines/version-updater.yml
+++ b/eng/pipelines/version-updater.yml
@@ -1,5 +1,6 @@
 pool:
-  vmImage: "windows-2022"
+  name: 'azsdk-pool-mms-win-2022-general'
+  vmImage: 'windows-2022'
 
 resources:
   repositories:


### PR DESCRIPTION
All Windows and Linux pipelines should use 1ES pools by default, unless they need to run in the DevOps Pool for a specific reason.