### PR TITLE
Support profile directory as top level directory for package properties

### DIFF
--- a/eng/scripts/Query-Azure-Packages.ps1
+++ b/eng/scripts/Query-Azure-Packages.ps1
@@ -224,7 +224,7 @@ function Get-go-Packages
     $package = CreatePackage $tag $versions[0]
 
     # We should keep this regex in sync with what is in the go repo at https://github.com/Azure/azure-sdk-for-go/blob/main/eng/scripts/Language-Settings.ps1#L40
-    if ($package.Package -match "(?<modPath>sdk/(?<serviceDir>(.*?(?<serviceName>[^/]+)/)?(?<modName>[^/]+$)))")
+    if ($package.Package -match "(?<modPath>(sdk|profile)/(?<serviceDir>(.*?(?<serviceName>[^/]+)/)?(?<modName>[^/]+$)))")
     {
       #$modPath = $matches["modPath"] Not using modPath currently here but keeping the capture group to be consistent with the go repo
       $modName = $matches["modName"]


### PR DESCRIPTION
Change to support https://github.com/Azure/azure-sdk-for-go/pull/18841, see [discussion](https://github.com/Azure/azure-sdk-for-go/pull/18841#issuecomment-1451179175).

Paired with https://github.com/Azure/azure-sdk-for-go/pull/20344