### PR TITLE
Add go generate package index supported languages

### DIFF
--- a/eng/scripts/Generate-Package-Index.ps1
+++ b/eng/scripts/Generate-Package-Index.ps1
@@ -132,6 +132,7 @@ switch($language)
     Write-Markdown "js"
     Write-Markdown "dotnet"
     Write-Markdown "python"
+    Write-Markdown "go"
     break
   }
   "java" {
@@ -147,6 +148,10 @@ switch($language)
     break
   }
   "python" {
+    Write-Markdown $language
+    break
+  }
+  "go" {
     Write-Markdown $language
     break
   }


### PR DESCRIPTION
We want this to add a package list section to https://learn.microsoft.com/en-us/azure/developer/go/ for better SEO to the microsoft site.