### PR TITLE
manually update the package version for speech Client-SDK package.

### DIFF
--- a/_data/releases/latest/java-packages.csv
+++ b/_data/releases/latest/java-packages.csv
@@ -720,7 +720,7 @@
 "azure-serviceruntime","com.microsoft.azure","","0.9.8","Service Runtime","Other","NA","NA","NA","client","false","","","","","","","","","","",""
 "spark-streaming-eventhubs_2.10","com.microsoft.azure","1.6.3","","Spark - Streaming Eventhubs","Apache Spark Connector","NA","NA","NA","client","false","","","","","","true","","","","",""
 "spark-streaming-eventhubs_connector_2.10","com.microsoft.azure","1.6.3","","Spark - Streaming Eventhubs Connector","Apache Spark Connector","NA","NA","NA","client","false","","","","","","true","","","","",""
-"client-sdk","com.microsoft.cognitiveservices.speech","1.24.2","","Speech","Cognitive Services","https://msasg.visualstudio.com/Skyman/_git/Carbon","NA","NA","client","false","","","","","","","","","","",""
+"client-sdk","com.microsoft.cognitiveservices.speech","1.28.1","","Speech","Cognitive Services","https://msasg.visualstudio.com/Skyman/_git/Carbon","NA","NA","client","false","","","","","","","","","","",""
 "azure-cognitiveservices-spellcheck","com.microsoft.azure.cognitiveservices","1.0.2","","Spell Check","Cognitive Services","https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/cognitiveservices/ms-azure-cs-spellcheck","NA","NA","client","false","","","","maintenance","","","","","","",""
 "azure-spring-cloud-maven-plugin","com.microsoft.azure","1.11.0","","Spring Cloud Maven Plugin","Spring Cloud","NA","NA","NA","client","false","","","","","","","","","","",""
 "spring-data-azure-cosmosdb-documentdb","com.microsoft.azure","","0.1.1","Spring Data Azure CosmosDB DocumentDB","Spring Cloud","NA","NA","NA","client","false","","","","","","","","","","",""


### PR DESCRIPTION
Our java sdk docs have not been updated since end of last year.
unlike all our C# and Python packages, the docs pipeline does not seem to be automatically detecting and updating the package version in this file.  I'm manually updating it to see if that unblocks our docs, and gets them updated to the out latest public release.