### PR TITLE
Rearrange C++ release notes order to tell a consecutive story

### DIFF
--- a/_data/releases/2023-05/cpp.yml
+++ b/_data/releases/2023-05/cpp.yml
@@ -10,34 +10,6 @@ entries:
     #### Bugs Fixed
 
     - [[#4490]](https://github.com/Azure/azure-sdk-for-cpp/issues/4490) Fixed WinHTTP memory leak during failed requests.
-- Name: azure-identity
-  Version: 1.5.0
-  DisplayName: Identity
-  ServiceName: Identity
-  VersionType: GA
-  Hidden: false
-  ChangelogUrl: https://github.com/Azure/azure-sdk-for-cpp/tree/azure-identity_1.5.0/sdk/identity/azure-identity/CHANGELOG.md
-  ChangelogContent: |-
-    #### Features Added
-
-    - Added support for challenge-based and multi-tenant authentication.
-    - Added `DefaultAzureCredential`.
-
-    #### Bugs Fixed
-
-    - [[#4443]](https://github.com/Azure/azure-sdk-for-cpp/issues/4443) Fixed potentially high CPU usage on Windows.
-- Name: azure-core
-  Version: 1.10.0-beta.1
-  DisplayName: Core
-  ServiceName: Other
-  VersionType: Beta
-  Hidden: false
-  ChangelogUrl: https://github.com/Azure/azure-sdk-for-cpp/tree/azure-core_1.10.0-beta.1/sdk/core/azure-core/CHANGELOG.md
-  ChangelogContent: |-
-    #### Features Added
-
-    - Added `Azure::Core::Uuid::AsArray()` and `Azure::Core::Uuid::CreateFromArray()` to enable reading or writing from an existing UUID.
-    This is useful when the UUID was generated outside the Azure SDK, or needs to be used from a component outside the Azure SDK.
 - Name: azure-core
   Version: 1.9.0
   DisplayName: Core
@@ -56,6 +28,34 @@ entries:
     #### Bugs Fixed
 
     - Fixed the UUID generation so the variant is RFC 4122 conforming.
+- Name: azure-core
+  Version: 1.10.0-beta.1
+  DisplayName: Core
+  ServiceName: Other
+  VersionType: Beta
+  Hidden: false
+  ChangelogUrl: https://github.com/Azure/azure-sdk-for-cpp/tree/azure-core_1.10.0-beta.1/sdk/core/azure-core/CHANGELOG.md
+  ChangelogContent: |-
+    #### Features Added
+
+    - Added `Azure::Core::Uuid::AsArray()` and `Azure::Core::Uuid::CreateFromArray()` to enable reading or writing from an existing UUID.
+    This is useful when the UUID was generated outside the Azure SDK, or needs to be used from a component outside the Azure SDK.
+- Name: azure-identity
+  Version: 1.5.0
+  DisplayName: Identity
+  ServiceName: Identity
+  VersionType: GA
+  Hidden: false
+  ChangelogUrl: https://github.com/Azure/azure-sdk-for-cpp/tree/azure-identity_1.5.0/sdk/identity/azure-identity/CHANGELOG.md
+  ChangelogContent: |-
+    #### Features Added
+
+    - Added support for challenge-based and multi-tenant authentication.
+    - Added `DefaultAzureCredential`.
+
+    #### Bugs Fixed
+
+    - [[#4443]](https://github.com/Azure/azure-sdk-for-cpp/issues/4443) Fixed potentially high CPU usage on Windows.
 - Name: azure-security-keyvault-certificates
   Version: 4.2.0
   DisplayName: Key Vault - Certificates

--- a/_data/releases/2023-05/cpp.yml
+++ b/_data/releases/2023-05/cpp.yml
@@ -67,6 +67,32 @@ entries:
     #### Features Added
 
     - Added support for challenge-based and multi-tenant authentication.
+- Name: azure-security-keyvault-keys
+  Version: 4.4.0
+  DisplayName: Key Vault - Keys
+  ServiceName: Key Vault
+  VersionType: GA
+  Hidden: false
+  ChangelogUrl: https://github.com/Azure/azure-sdk-for-cpp/tree/azure-security-keyvault-keys_4.4.0/sdk/keyvault/azure-security-keyvault-keys/CHANGELOG.md
+  ChangelogContent: |-
+    #### Bugs Fixed
+
+    - [3366](https://github.com/Azure/azure-sdk-for-cpp/issues/4466) Fixed the user-agent string sent to the service to include the "keys" suffix in the value, when using `CryptographyClient`.
+
+    #### Features Added
+
+    - Added support for challenge-based and multi-tenant authentication.
+- Name: azure-security-keyvault-secrets
+  Version: 4.2.0
+  DisplayName: 'Key Vault - Secrets '
+  ServiceName: Key Vault
+  VersionType: GA
+  Hidden: false
+  ChangelogUrl: https://github.com/Azure/azure-sdk-for-cpp/tree/azure-security-keyvault-secrets_4.2.0/sdk/keyvault/azure-security-keyvault-secrets/CHANGELOG.md
+  ChangelogContent: |-
+    #### Features Added
+
+    - Added support for challenge-based and multi-tenant authentication.
 - Name: azure-storage-common
   Version: 12.3.2
   DisplayName: Storage - Common
@@ -101,30 +127,3 @@ entries:
     #### Features Added
 
     - New features in `12.5.0-beta.1` are now generally available.
-- Name: azure-security-keyvault-secrets
-  Version: 4.2.0
-  DisplayName: 'Key Vault - Secrets '
-  ServiceName: Key Vault
-  VersionType: GA
-  Hidden: false
-  ChangelogUrl: https://github.com/Azure/azure-sdk-for-cpp/tree/azure-security-keyvault-secrets_4.2.0/sdk/keyvault/azure-security-keyvault-secrets/CHANGELOG.md
-  ChangelogContent: |-
-    #### Features Added
-
-    - Added support for challenge-based and multi-tenant authentication.
-- Name: azure-security-keyvault-keys
-  Version: 4.4.0
-  DisplayName: Key Vault - Keys
-  ServiceName: Key Vault
-  VersionType: GA
-  Hidden: false
-  ChangelogUrl: https://github.com/Azure/azure-sdk-for-cpp/tree/azure-security-keyvault-keys_4.4.0/sdk/keyvault/azure-security-keyvault-keys/CHANGELOG.md
-  ChangelogContent: |-
-    #### Bugs Fixed
-
-    - [3366](https://github.com/Azure/azure-sdk-for-cpp/issues/4466) Fixed the user-agent string sent to the service to include the "keys" suffix in the value, when using `CryptographyClient`.
-
-    #### Features Added
-
-    - Added support for challenge-based and multi-tenant authentication.
-


### PR DESCRIPTION
Core 1.8.2, then core 1.9.0, then 1.10.0-beta.1, then identity, then all keyvault alphabetically, then all storage alphabetically.