### PR TITLE
Remove the preview version of Azure.ResourceManager.Hci

### DIFF
--- a/_data/releases/latest/dotnet-packages.csv
+++ b/_data/releases/latest/dotnet-packages.csv
@@ -111,7 +111,7 @@
 "Azure.ResourceManager.Authorization","1.0.1","","Resource Management - Authorization","Authorization","authorization","","","mgmt","true","","02/20/2023","09/05/2022","","","","","","","",""
 "Azure.ResourceManager.Automanage","1.0.0","","Resource Management - Automanage","Automanage","automanage","","","mgmt","true","","02/21/2023","02/21/2023","","","","","","","",""
 "Azure.ResourceManager.Automation","1.0.1","","Resource Management - Automation","Automation","automation","","","mgmt","true","","02/14/2023","11/05/2022","","","","","","","",""
-"Azure.ResourceManager.Hci","1.0.1","1.0.0-beta.5","Resource Management - Azure Stack HCI","Stack HCI","azurestackhci","","","mgmt","true","","02/16/2023","08/29/2022","","","","","","","",""
+"Azure.ResourceManager.Hci","1.0.1","","Resource Management - Azure Stack HCI","Stack HCI","azurestackhci","","","mgmt","true","","02/16/2023","08/29/2022","","","","","","","",""
 "Azure.ResourceManager.Avs","1.1.1","","Resource Management - Azure VMware Solution","Azure VMware Solution","avs","","","mgmt","true","","02/16/2023","09/13/2022","","","","","","","",""
 "Azure.ResourceManager.RecoveryServicesBackup","1.0.0","","Resource Management - Backup","Recovery Services","recoveryservices-backup","","","mgmt","true","","02/20/2023","02/20/2023","","","","","","","",""
 "Azure.ResourceManager.Batch","1.1.1","","Resource Management - Batch","Batch","batch","","","mgmt","true","","02/15/2023","09/19/2022","","","","","","","",""

--- a/_data/releases/latest/dotnet-packages.csv
+++ b/_data/releases/latest/dotnet-packages.csv
@@ -111,7 +111,7 @@
 "Azure.ResourceManager.Authorization","1.0.1","","Resource Management - Authorization","Authorization","authorization","","","mgmt","true","","02/20/2023","09/05/2022","","","","","","","",""
 "Azure.ResourceManager.Automanage","1.0.0","","Resource Management - Automanage","Automanage","automanage","","","mgmt","true","","02/21/2023","02/21/2023","","","","","","","",""
 "Azure.ResourceManager.Automation","1.0.1","","Resource Management - Automation","Automation","automation","","","mgmt","true","","02/14/2023","11/05/2022","","","","","","","",""
-"Azure.ResourceManager.Hci","1.0.1","2.0.0-beta.1","Resource Management - Azure Stack HCI","Stack HCI","azurestackhci","","","mgmt","true","","02/16/2023","08/29/2022","","","","","","","",""
+"Azure.ResourceManager.Hci","1.0.1","1.0.0-beta.5","Resource Management - Azure Stack HCI","Stack HCI","azurestackhci","","","mgmt","true","","02/16/2023","08/29/2022","","","","","","","",""
 "Azure.ResourceManager.Avs","1.1.1","","Resource Management - Azure VMware Solution","Azure VMware Solution","avs","","","mgmt","true","","02/16/2023","09/13/2022","","","","","","","",""
 "Azure.ResourceManager.RecoveryServicesBackup","1.0.0","","Resource Management - Backup","Recovery Services","recoveryservices-backup","","","mgmt","true","","02/20/2023","02/20/2023","","","","","","","",""
 "Azure.ResourceManager.Batch","1.1.1","","Resource Management - Batch","Batch","batch","","","mgmt","true","","02/15/2023","09/19/2022","","","","","","","",""


### PR DESCRIPTION
@weshaggard 
The preview version of Azure.ResourceManager.Hci was being set to 2.0.0-beta.1. This version was unlisted on nuget but the automation that updates the versions was still finding 2.0.0-beta.1 because the release and tag for Azure.ResourceManager.Hci_2.0.0-beta.1 both still existed. I've removed the release and tag and, as per our conversation, the preview version is getting set to empty since the GA version is higher.