### PR TITLE
Move package counts at the end of the section headers

### DIFF
--- a/_includes/releases/notes/package_display_names.md
+++ b/_includes/releases/notes/package_display_names.md
@@ -1,32 +1,26 @@
 {% assign allPackagesSortedByDisplayName = allPackages | sort: 'DisplayName' %}
 {% assign gaPackages = allPackagesSortedByDisplayName | where: "VersionType" , "GA" | map: 'DisplayName' | uniq %}
 {% if gaPackages.size > 0 %}
-#### Stable Packages
+#### Stable Packages ({{ gaPackages.size }})
 {% for package in gaPackages %}
 - {{ package }}
 {% endfor %}
-
-{{ gaPackages.size }} Stable packages
 {% endif %}
 
 {% assign patchPackages = allPackagesSortedByDisplayName | where: "VersionType", "Patch" | map: 'DisplayName' | uniq %}
 {% if patchPackages.size > 0 %}
-#### Patch Updates
+#### Patch Updates ({{ patchPackages.size }})
 {% for package in patchPackages %}
 - {{ package }}
 {% endfor %}
-
-{{ patchPackages.size }} updated packages
 {% endif %}
 
 {% assign betaPackages = allPackagesSortedByDisplayName | where: "VersionType", "Beta" | map: 'DisplayName' | uniq %}
 {% if betaPackages.size > 0 %}
-#### Beta Packages
+#### Beta Packages ({{ betaPackages.size }})
 {% for package in betaPackages %}
 - {{ package }}
 {% endfor %}
-
-{{ betaPackages.size }} beta packages
 {% endif %}
 
 Total of {{ allPackages.size }} packages released this month.


### PR DESCRIPTION
Moved the counts to be on the same line as the header except for the total at the bottom.