### PR TITLE
Skip deprecated go track 1 packages in release doc generation

### DIFF
--- a/eng/scripts/Generate-Package-Index.ps1
+++ b/eng/scripts/Generate-Package-Index.ps1
@@ -115,10 +115,16 @@ function Write-Markdown($lang)
   $allPackageList = $clientPackageList + $otherPackages
 
   $allFileContent = Get-Heading
+  $deprecated = 0
   foreach($pkg in $allPackageList)
   {
-    $allFileContent += Get-Row $pkg $langLinkTemplates
+    if ($pkg.Support -eq 'deprecated') {
+      $deprecated++
+    } else {
+      $allFileContent += Get-Row $pkg $langLinkTemplates
+    }
   }
+  Write-Host "Skipped $deprecated deprecated package"
 
   $allMdfile = Join-Path $outputFolder "$fileLang-all.md"
   Write-Host "Writing $allMdfile"


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk/issues/5998

This removes packages with empty `ServiceName` values from [go-packages.csv](https://github.com/Azure/azure-sdk/blob/main/_data/releases/latest/go-packages.csv) and [go-all.md](https://github.com/MicrosoftDocs/azure-dev-docs-pr/blob/bdd3d924361d91932fc444f172514d84b4be56bd/articles/includes/go-all.md?plain=1#L249) because they are deprecated/track 1. 