### PR TITLE
Update c.md template to default to no release and update latest embedded c release notes for June 2023 (no release)

### DIFF
--- a/eng/scripts/release-template/c.md
+++ b/eng/scripts/release-template/c.md
@@ -8,6 +8,9 @@ repository: Azure/azure-sdk-for-c
 
 The Azure SDK team is pleased to make available the %%MMMM yyyy%% client library release.
 
+No packages released this month.
+
+<!--
 #### Stable
 
 - _Add packages_
@@ -43,3 +46,4 @@ If you have a bug or feature request for one of the libraries, please post an is
 View all the latest versions of C packages [here][c-latest-releases].
 
 {% include refs.md %}
+-->

--- a/releases/2023-06/c.md
+++ b/releases/2023-06/c.md
@@ -8,38 +8,4 @@ repository: Azure/azure-sdk-for-c
 
 The Azure SDK team is pleased to make available the June 2023 client library release.
 
-#### Stable
-
-- _Add packages_
-
-#### Updates
-
-- _Add packages_
-
-#### Beta
-
-- _Add packages_
-
-## Installation Instructions
-
-To install any of our packages, copy and paste the following commands into a terminal:
-
-```bash
-$> 
-```
-
-## Feedback
-
-If you have a bug or feature request for one of the libraries, please post an issue to [GitHub](https://github.com/Azure/azure-sdk-for-c/issues).
-
-## Release highlights
-
-### _Package name_
-
-- Major changes only!
-
-## Latest Releases
-
-View all the latest versions of C packages [here][c-latest-releases].
-
-{% include refs.md %}
+No packages released this month.


### PR DESCRIPTION
Follow-up from https://github.com/Azure/azure-sdk/pull/6143#issuecomment-1558119606