### PR TITLE
Add release data update pipeline

### DIFF
--- a/eng/pipelines/update-azure-package-database.yml
+++ b/eng/pipelines/update-azure-package-database.yml
@@ -1,0 +1,26 @@
+# This pipeline updates an internal database used for visualizing package release statistics
+
+pr: none
+
+trigger: none
+
+pool:
+  name: azsdk-pool-mms-ubuntu-2204-general
+  vmImage: ubuntu-22.04
+
+steps:
+- checkout: self
+
+- task: AzureCLI@2
+  displayName: 'Update Release Data'
+  inputs:
+    azureSubscription: Azure SDK Engineering System
+    scriptType: pscore
+    scriptPath: $(System.DefaultWorkingDirectory)/eng/scripts/Update-Azure-Package-Data.ps1
+    arguments: >
+      -github_pat $(azuresdk-github-pat)
+      -languages @("java", "dotnet", "python", "javascript", "golang", "cpp")
+      -daysAgo 730
+      -clearTable
+      -updateDatabase
+

--- a/eng/pipelines/update-azure-package-database.yml
+++ b/eng/pipelines/update-azure-package-database.yml
@@ -4,6 +4,23 @@ pr: none
 
 trigger: none
 
+parameters:
+- name: Languages
+  type: string
+  default: '"java", "dotnet", "python", "javascript", "golang", "cpp"'
+- name: DaysAgo
+  type: string
+  default: '730'
+- name: Table
+  type: string
+  default: PackageReleaseData
+- name: ClearTable
+  type: boolean
+  default: true
+- name: UpdateDatabase
+  type: boolean
+  default: true
+
 pool:
   name: azsdk-pool-mms-ubuntu-2204-general
   vmImage: ubuntu-22.04
@@ -19,8 +36,9 @@ steps:
     scriptPath: $(System.DefaultWorkingDirectory)/eng/scripts/Update-Azure-Package-Data.ps1
     arguments: >
       -github_pat $(azuresdk-github-pat)
-      -languages @("java", "dotnet", "python", "javascript", "golang", "cpp")
-      -daysAgo 730
-      -clearTable
-      -updateDatabase
+      -languages ${{ parameters.Languages }}
+      -daysAgo ${{ parameters.DaysAgo }}
+      -Table ${{ parameters.Table }}
+      -clearTable:$${{ parameters.ClearTable }}
+      -updateDatabase:$${{ parameters.UpdateDatabase }}
 

--- a/eng/scripts/Update-Azure-Package-Data.ps1
+++ b/eng/scripts/Update-Azure-Package-Data.ps1
@@ -5,6 +5,7 @@ param (
   [array] $languages = @("java", "dotnet", "python", "javascript", "golang", "cpp"),
   [int] $daysAgo = 730,
   [string] $outPath = "package-data.csv",
+  [string] $table = 'PackageReleaseData',
   [switch] $clearTable,
   [switch] $updateDatabase
 )
@@ -328,11 +329,10 @@ function sendDataExplorerCommand([switch]$mgmt, [string]$query)
   return $resp
 }
 
-function Set-DataExplorer([switch]$clearTable)
+function Set-DataExplorer([string]$table, [switch]$clearTable)
 {
   $ErrorActionPreference = "Stop"
 
-  $table = 'BebroderTest'
   $packageBlob = 'https://azsdkpackagereleasedata.blob.core.windows.net/data/package-data.csv'
 
   if ($clearTable)
@@ -381,5 +381,5 @@ Set-Package-Data $Languages $daysAgo $outPath
 if ($updateDatabase)
 {
   az storage blob upload -f $outPath --account-name azsdkpackagereleasedata --container-name data --overwrite
-  Set-DataExplorer $clearTable
+  Set-DataExplorer $table $clearTable
 }


### PR DESCRIPTION
This pipeline runs the script which polls all package feeds, and makes a corresponding update of the csv output to an azure storage blob. Then it clears our kusto table and queues an ingest from the blob. The dataset is rather small (10k lines) so I found it easier to just reset the table rather than try to calculate what needed appending.