### PR TITLE
Ignore Release Planner Tests when updating ADO Work Items

### DIFF
--- a/eng/common/scripts/Helpers/DevOps-WorkItem-Helpers.ps1
+++ b/eng/common/scripts/Helpers/DevOps-WorkItem-Helpers.ps1
@@ -206,7 +206,7 @@ function FindLatestPackageWorkItem($lang, $packageName, $outputCommand = $true)
   return $latestWI
 }
 
-function FindPackageWorkItem($lang, $packageName, $version, $outputCommand = $true, $includeClosed = $false)
+function FindPackageWorkItem($lang, $packageName, $version, $outputCommand = $true, $includeClosed = $false, $ignoreReleasePlannerTests = $true)
 {
   $key = BuildHashKeyNoNull $lang $packageName $version
   if ($key -and $packageWorkItems.ContainsKey($key)) {
@@ -218,6 +218,7 @@ function FindPackageWorkItem($lang, $packageName, $version, $outputCommand = $tr
   $fields += "System.State"
   $fields += "System.AssignedTo"
   $fields += "System.Parent"
+  $fields += "System.Tags"
   $fields += "Custom.Language"
   $fields += "Custom.Package"
   $fields += "Custom.PackageDisplayName"
@@ -250,6 +251,10 @@ function FindPackageWorkItem($lang, $packageName, $version, $outputCommand = $tr
   }
   if ($version) {
     $query += " AND [PackageVersionMajorMinor] = '${version}'"
+  }
+
+  if($ignoreReleasePlannerTests){
+    $query += " AND [System.Tags] NOT CONTAINS 'Release Planner App Test'"
   }
 
   $workItems = Invoke-Query $fields $query $outputCommand

--- a/eng/common/scripts/Helpers/DevOps-WorkItem-Helpers.ps1
+++ b/eng/common/scripts/Helpers/DevOps-WorkItem-Helpers.ps1
@@ -155,7 +155,7 @@ function FindParentWorkItem($serviceName, $packageDisplayName, $outputCommand = 
     $serviceCondition = "[ServiceName] <> ''"
   }
 
-  $query = "SELECT [ID], [ServiceName], [PackageDisplayName], [Parent] FROM WorkItems WHERE [Work Item Type] = 'Epic' AND ${serviceCondition}'"
+  $query = "SELECT [ID], [ServiceName], [PackageDisplayName], [Parent] FROM WorkItems WHERE [Work Item Type] = 'Epic' AND ${serviceCondition}"
 
   if($ignoreReleasePlannerTests){
     $query += " AND [System.Tags] NOT CONTAINS 'Release Planner App Test'"

--- a/eng/common/scripts/Helpers/DevOps-WorkItem-Helpers.ps1
+++ b/eng/common/scripts/Helpers/DevOps-WorkItem-Helpers.ps1
@@ -135,7 +135,7 @@ function BuildHashKey()
 }
 
 $parentWorkItems = @{}
-function FindParentWorkItem($serviceName, $packageDisplayName, $outputCommand = $false)
+function FindParentWorkItem($serviceName, $packageDisplayName, $outputCommand = $false, $ignoreReleasePlannerTests = $true)
 {
   $key = BuildHashKey $serviceName $packageDisplayName
   if ($key -and $parentWorkItems.ContainsKey($key)) {
@@ -155,7 +155,11 @@ function FindParentWorkItem($serviceName, $packageDisplayName, $outputCommand = 
     $serviceCondition = "[ServiceName] <> ''"
   }
 
-  $query = "SELECT [ID], [ServiceName], [PackageDisplayName], [Parent] FROM WorkItems WHERE [Work Item Type] = 'Epic' AND ${serviceCondition}"
+  $query = "SELECT [ID], [ServiceName], [PackageDisplayName], [Parent] FROM WorkItems WHERE [Work Item Type] = 'Epic' AND ${serviceCondition}'"
+
+  if($ignoreReleasePlannerTests){
+    $query += " AND [System.Tags] NOT CONTAINS 'Release Planner App Test'"
+  }
 
   $fields = @("System.Id", "Custom.ServiceName", "Custom.PackageDisplayName", "System.Parent")
 

--- a/eng/scripts/Update-DevOps-WorkItems.ps1
+++ b/eng/scripts/Update-DevOps-WorkItems.ps1
@@ -3,7 +3,8 @@ param (
   [string] $pkgFilter = $null,
   [bool] $updateAllVersions = $false, # When false only updates the versions in the preview and ga in csv
   [string] $github_pat = $env:GITHUB_PAT,
-  [string] $devops_pat = $env:DEVOPS_PAT
+  [string] $devops_pat = $env:DEVOPS_PAT,
+  [bool] $ignoreReleasePlannerTests = $true
 )
 Set-StrictMode -Version 3
 


### PR DESCRIPTION
**[IN DRAFT]**

For testing purposes, the Release Planner App in DEV and PPE creates Work Items with the `Release Planner Test Service` tag on them.

Our `automation - azure-sdk - version-updater` > ` Update release DevOps work-items` task has not been updated to ignore these work items, so it has been founding duplicates when running. See [this run for context.](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3002208&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=d01ed771-bc1f-5e98-e7ad-71f8c6eef93d)

In this PR I am adding a new condition to the query to ignore the Work Item if the tags contain `Release Planner Test Service`.
