### PR TITLE
Update CSV files for azure-schemaregistry-avroserializer deprecation

### DIFF
--- a/_data/releases/latest/python-packages.csv
+++ b/_data/releases/latest/python-packages.csv
@@ -62,7 +62,7 @@
 "azure-ai-language-questionanswering","1.1.0","","Question Answering","Cognitive Services","cognitivelanguage","","","client","true","","10/13/2022","11/03/2021","","","","","","","",""
 "azure-schemaregistry","1.2.0","1.3.0b2","Schema Registry","Schema Registry","schemaregistry","","","client","true","","","11/10/2021","","","","","","","",""
 "azure-schemaregistry-avroencoder","1.0.0","","Schema Registry - Avro","Schema Registry","schemaregistry","","","client","true","","05/10/2022","05/10/2022","","","","","","","",""
-"azure-schemaregistry-avroserializer","","1.0.0b4","Schema Registry - Avro","Schema Registry","schemaregistry","","","client","true","","","","","","","","","","",""
+"azure-schemaregistry-avroserializer","","1.0.0b4","Schema Registry - Avro","Schema Registry","schemaregistry","","","client","true","","","","deprecated","08/15/2023","","azure-schemaregistry-avroencoder","https://aka.ms/azsdk/python/migrate/sr-avroserializer-to-avroencoder","","",""
 "azure-servicebus","7.11.1","","Service Bus","Service Bus","servicebus","","","client","true","","07/12/2023","11/24/2020","active","","","","https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/servicebus/azure-servicebus/migration_guide.md","","",""
 "azure-synapse-spark","","0.7.0","Spark","Synapse","synapse","","","client","true","","","","","","","","","","",""
 "azure-storage-blob","12.17.0","12.18.0b1","Storage - Blobs","Storage","storage","","","client","true","","","10/30/2019","active","","","","","","",""


### PR DESCRIPTION
Deprecating the Python `azure-schemaregistry-avroserializer` package.

PR with doc/package updates in Python repo: https://github.com/Azure/azure-sdk-for-python/pull/31667