### PR TITLE
Retire Azure.Communication.Calling .net SDK package

### DIFF
--- a/_data/releases/latest/dotnet-packages.csv
+++ b/_data/releases/latest/dotnet-packages.csv
@@ -354,7 +354,7 @@
 "","","","","Windows Virtual Desktop","","NA","NA","","","","","","","","true","","","","",""
 "","","","","Xamarin","","NA","NA","","","","","","","","true","","","","",""
 "Azure.Communication.Administration","","1.0.0-beta.3","Azure.Communication.Administration","Communication","NA","NA","NA","","false","","","","","","","","","","",""
-"Azure.Communication.Calling","","1.0.0-beta.36","Azure.Communication.Calling","Communication","NA","NA","NA","","false","","","","deprecated","09/01/2023","","Azure.Communication.Calling.WindowsClient","","","",""
+"Azure.Communication.Calling","","1.0.0-beta.36","Azure.Communication.Calling","Communication","NA","NA","NA","","false","","","","deprecated","09/01/2023","","Azure.Communication.Calling.WindowsClient","NA","","",""
 "Azure.Communication.CallingServer","","1.0.0-beta.3","Azure.Communication.CallingServer","Communication","NA","NA","NA","","false","","","","","","","","","","",""
 "Azure.Core.Expressions.DataFactory","","1.0.0-beta.5","Azure.Core.Expressions.DataFactory","Other","core","NA","NA","","false","","","","","","","","","","",""
 "Azure.Communication.Calling.WindowsClient","1.2.0","","Communication Calling Windows Client","Communication","NA","NA","NA","","false","","","","","","","","","","",""

--- a/_data/releases/latest/dotnet-packages.csv
+++ b/_data/releases/latest/dotnet-packages.csv
@@ -354,7 +354,7 @@
 "","","","","Windows Virtual Desktop","","NA","NA","","","","","","","","true","","","","",""
 "","","","","Xamarin","","NA","NA","","","","","","","","true","","","","",""
 "Azure.Communication.Administration","","1.0.0-beta.3","Azure.Communication.Administration","Communication","NA","NA","NA","","false","","","","","","","","","","",""
-"Azure.Communication.Calling","","1.0.0-beta.36","Azure.Communication.Calling","Communication","NA","NA","NA","","false","","","","","","","","","","",""
+"Azure.Communication.Calling","","1.0.0-beta.36","Azure.Communication.Calling","Communication","NA","NA","NA","","false","","","","deprecated","09/01/2023","","Azure.Communication.Calling.WindowsClient","","","",""
 "Azure.Communication.CallingServer","","1.0.0-beta.3","Azure.Communication.CallingServer","Communication","NA","NA","NA","","false","","","","","","","","","","",""
 "Azure.Core.Expressions.DataFactory","","1.0.0-beta.5","Azure.Core.Expressions.DataFactory","Other","core","NA","NA","","false","","","","","","","","","","",""
 "Azure.Communication.Calling.WindowsClient","1.2.0","","Communication Calling Windows Client","Communication","NA","NA","NA","","false","","","","","","","","","","",""


### PR DESCRIPTION
Retire Azure.Communication.Calling and replace it with Azure.Communication.Calling.WindowsClient.

Azure.Communication.Calling was the old beta SDK that never made to GA. Since we had released GA under Azure.Communication.Calling.WindowsClient, it's time for us to retire the old SDK.

There isn't much usage of the Azure.Communication.Calling, so we leave the migration guide as optional.