### PR TITLE
Improve link checking perf

### DIFF
--- a/_includes/releases/variables/dotnet.md
+++ b/_includes/releases/variables/dotnet.md
@@ -1,6 +1,6 @@
 {% assign package_label = "NuGet" %}
 {% assign package_trim = "Azure." %}
-{% assign pre_suffix = "?view=azure-dotnet-preview&preserve-view=true" %}
+{% assign pre_suffix = "?view=azure-dotnet-preview&amp;preserve-view=true" %}
 {% assign package_root_url_template = "https://www.nuget.org/packages/item.Package" %}
 {% assign package_url_template = "https://www.nuget.org/packages/item.Package/item.Version" %}
 {% assign msdocs_url_template = "https://docs.microsoft.com/dotnet/api/overview/azure/item.TrimmedPackage-readme" %}

--- a/_includes/releases/variables/java.md
+++ b/_includes/releases/variables/java.md
@@ -1,6 +1,6 @@
 {% assign package_label = "Maven" %}
 {% assign package_trim = "azure-" %}
-{% assign pre_suffix = "?view=azure-java-preview&preserve-view=true" %}
+{% assign pre_suffix = "?view=azure-java-preview&amp;preserve-view=true" %}
 {% assign package_root_url_template = "https://search.maven.org/artifact/item.GroupId/item.Package" %}
 {% assign package_url_template = "https://search.maven.org/artifact/item.GroupId/item.Package/item.Version/jar/" %}
 {% assign msdocs_url_template =  "https://docs.microsoft.com/java/api/overview/azure/item.TrimmedPackage-readme" %}

--- a/_includes/releases/variables/js.md
+++ b/_includes/releases/variables/js.md
@@ -1,6 +1,6 @@
 {% assign package_label = "npm" %}
 {% assign package_trim = "@azure/" %}
-{% assign pre_suffix = ?view=azure-node-preview&preserve-view=true" %}
+{% assign pre_suffix = ?view=azure-node-preview&amp;preserve-view=true" %}
 {% assign package_root_url_template = "https://www.npmjs.com/package/item.Package" %}
 {% assign package_url_template = "https://www.npmjs.com/package/item.Package/v/item.Version" %}
 {% assign msdocs_url_template = "https://docs.microsoft.com/javascript/api/overview/azure/item.TrimmedPackage-readme" %}

--- a/_includes/releases/variables/python.md
+++ b/_includes/releases/variables/python.md
@@ -1,6 +1,6 @@
 {% assign package_label = "PyPI" %}
 {% assign package_trim = "azure-" %}
-{% assign pre_suffix = "?view=azure-python-preview&preserve-view=true" %}
+{% assign pre_suffix = "?view=azure-python-preview&amp;preserve-view=true" %}
 {% assign package_root_url_template = "https://pypi.org/project/item.Package" %}
 {% assign package_url_template = "https://pypi.org/project/item.Package/item.Version" %}
 {% assign msdocs_url_template = "https://docs.microsoft.com/python/api/overview/azure/item.TrimmedPackage-readme" %}

--- a/eng/scripts/Update-Release-Versions.ps1
+++ b/eng/scripts/Update-Release-Versions.ps1
@@ -105,6 +105,13 @@ function CheckOptionalLinks($linkTemplates, $pkg, $skipIfNA = $false)
     }
   }
 
+  # We always perfer to the MSDoc links over GHDocs so they will never be displayed if MSDoc is setup so we
+  # don't need to worry about checking the GHDoc links unless MSDocs is NA.
+  if ($pkg.MSDocs -ne "NA") 
+  {
+    return
+  }
+
   if (!$skipIfNA -or $pkg.GHDocs -eq "")
   {
     $ghdocvalid = ($pkg.VersionGA -or $pkg.VersionPreview)
@@ -286,6 +293,7 @@ function OutputVersions($lang)
   Write-Host "Checking doc links for other packages"
   foreach ($otherPackage in $otherPackages)
   {
+    if ($otherPackage.Hide) { continue }
     CheckOptionalLinks $langLinkTemplates $otherPackage -skipIfNA $true
   }
 


### PR DESCRIPTION
- Ensure the link caching is working by making the pre_suffix match the final link that is getting cached (i.e. & -> &amp;)

- Skip always checking ghdoc links if there is a valid msdoc link because we never display the ghdoc link if there is a valid msdoc link.