### PR TITLE
Fix CODEOWNERS entries for correctness and so the parser and linter can recognize them

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,48 +51,48 @@
 #####
 
 # Engineering systems documents
-docs/android/                @JonathanGiles @salameer
-docs/clang/                  @JeffreyRichter @LarryOsterman @RickWinter
-docs/cpp/                    @JeffreyRichter @LarryOsterman @RickWinter
-docs/dotnet/                 @KrzysztofCwalina @annelo-msft @salameer @tg-msft
-docs/general/                @salameer
-docs/golang/                 @JeffreyRichter @jhendrixMSFT @RickWinter
-docs/ios/                    @salameer
-docs/java/                   @JonathanGiles @salameer @srnagar
-docs/policies/               @Kurtzeborn @weshaggard @salameer
-docs/python/                 @johanste @salameer @annatisch
-docs/redirects/              @kyle-patterson
-docs/tables/                 @kyle-patterson
-docs/typescript/             @bterlson @salameer @xirzec
-eng/                         @weshaggard
-eng/scripts/inventory-dashboard         @ronniegeraghty
-_posts/                      @kyle-patterson
-_data/                       @ronniegeraghty @weshaggard
-_data/releases/inventory     @ronniegeraghty
-android.md                   @ronniegeraghty @vcolin7 @anuchandy
-android.yml                  @ronniegeraghty @vcolin7 @anuchandy
-android-packages.csv         @ronniegeraghty @vcolin7 @anuchandy @mario-guerra @scottaddie
-c.md                         @ronniegeraghty @ahsonkhan 
-c.yml                        @ronniegeraghty @ahsonkhan 
-c-packages.csv               @ronniegeraghty @ahsonkhan @mario-guerra @scottaddie
-cpp.md                       @ronniegeraghty @antkmsft 
-cpp.yml                      @ronniegeraghty @antkmsft
-cpp-packages.csv             @ronniegeraghty @antkmsft @mario-guerra @scottaddie
-dotnet.md                    @ronniegeraghty @m-redding
-dotnet.yml                   @ronniegeraghty @m-redding
-dotnet-packages.csv          @ronniegeraghty @m-redding @mario-guerra @scottaddie
-ios.md                       @ronniegeraghty @vcolin7 @tjprescott 
-ios.yml                      @ronniegeraghty @vcolin7 @tjprescott
-ios-packages.csv             @ronniegeraghty @vcolin7 @tjprescott @mario-guerra @scottaddie
-java.md                      @ronniegeraghty @mssfang
-java.yml                     @ronniegeraghty @mssfang
-java-packages.csv            @ronniegeraghty @mssfang @mario-guerra @scottaddie
-js.md                        @ronniegeraghty @timovv
-js.yml                       @ronniegeraghty @timovv
-js-packages.csv              @ronniegeraghty @timovv @mario-guerra @scottaddie
-python.md                    @ronniegeraghty @xiangyan99
-python.yml                   @ronniegeraghty @xiangyan99
-python-packages.csv          @ronniegeraghty @xiangyan99 @mario-guerra @scottaddie
-go.md                        @ronniegeraghty @chlowell
-go.yml                       @ronniegeraghty @chlowell
-go-packages.csv              @ronniegeraghty @chlowell @mario-guerra @scottaddie
+/docs/android/                @JonathanGiles @salameer
+/docs/clang/                  @JeffreyRichter @LarryOsterman @RickWinter
+/docs/cpp/                    @JeffreyRichter @LarryOsterman @RickWinter
+/docs/dotnet/                 @KrzysztofCwalina @annelo-msft @salameer @tg-msft
+/docs/general/                @salameer
+/docs/golang/                 @JeffreyRichter @jhendrixMSFT @RickWinter
+/docs/ios/                    @salameer
+/docs/java/                   @JonathanGiles @salameer @srnagar
+/docs/policies/               @Kurtzeborn @weshaggard @salameer
+/docs/python/                 @johanste @salameer @annatisch
+/docs/redirects/              @kyle-patterson
+/docs/tables/                 @kyle-patterson
+/docs/typescript/             @bterlson @salameer @xirzec
+/eng/                         @weshaggard
+/eng/scripts/inventory-dashboard         @ronniegeraghty
+/_posts/                      @kyle-patterson
+/_data/                       @ronniegeraghty @weshaggard
+/_data/releases/inventory     @ronniegeraghty
+/**/android.md                   @ronniegeraghty @vcolin7 @anuchandy
+/**/android.yml                  @ronniegeraghty @vcolin7 @anuchandy
+/**/android-packages.csv         @ronniegeraghty @vcolin7 @anuchandy @mario-guerra @scottaddie
+/**/c.md                         @ronniegeraghty @ahsonkhan
+/**/c.yml                        @ronniegeraghty @ahsonkhan
+/**/c-packages.csv               @ronniegeraghty @ahsonkhan @mario-guerra @scottaddie
+/**/cpp.md                       @ronniegeraghty @antkmsft
+/**/cpp.yml                      @ronniegeraghty @antkmsft
+/**/cpp-packages.csv             @ronniegeraghty @antkmsft @mario-guerra @scottaddie
+/**/dotnet.md                    @ronniegeraghty @m-redding
+/**/dotnet.yml                   @ronniegeraghty @m-redding
+/**/dotnet-packages.csv          @ronniegeraghty @m-redding @mario-guerra @scottaddie
+/**/ios.md                       @ronniegeraghty @vcolin7 @tjprescott
+/**/ios.yml                      @ronniegeraghty @vcolin7 @tjprescott
+/**/ios-packages.csv             @ronniegeraghty @vcolin7 @tjprescott @mario-guerra @scottaddie
+/**/java.md                      @ronniegeraghty @mssfang
+/**/java.yml                     @ronniegeraghty @mssfang
+/**/java-packages.csv            @ronniegeraghty @mssfang @mario-guerra @scottaddie
+/**/js.md                        @ronniegeraghty @timovv
+/**/js.yml                       @ronniegeraghty @timovv
+/**/js-packages.csv              @ronniegeraghty @timovv @mario-guerra @scottaddie
+/**/python.md                    @ronniegeraghty @xiangyan99
+/**/python.yml                   @ronniegeraghty @xiangyan99
+/**/python-packages.csv          @ronniegeraghty @xiangyan99 @mario-guerra @scottaddie
+/**/go.md                        @ronniegeraghty @chlowell
+/**/go.yml                       @ronniegeraghty @chlowell
+/**/go-packages.csv              @ronniegeraghty @chlowell @mario-guerra @scottaddie


### PR DESCRIPTION
There were two main types of changes:
1. The path entries should have had a leading slash as these paths are all in the root of the repository.
2. The single file entries are being changed to use their glob equivalent.
Both of these changes will allow the CodeownersParser and the CodeownersLinter to better process them as both tools use Microsoft.Extensions.FileSystemGlobbing. The azure-sdk-for-language repositories were all similarly updated earlier this year.