### PR TITLE
Update Go Release Template

### DIFF
--- a/eng/scripts/release-template/go.md
+++ b/eng/scripts/release-template/go.md
@@ -6,4 +6,3 @@ sidebar: releases_sidebar
 repository: Azure/azure-sdk-for-go
 ---
 {% include releases/notes/common.md language="go" date="%%yyyy-MM%%" displayDate="%%MMMM yyyy%%" %}
-The Azure SDK team is pleased to make available the %%MMMM yyyy%% client library release.


### PR DESCRIPTION
Updating the Go release template to remove a repeated line for future release notes.

@antkmsft pointed this out [here](https://github.com/Azure/azure-sdk-blog/pull/437#discussion_r1325261682)