### PR TITLE
Hide retracted go entry

### DIFF
--- a/_data/releases/latest/go-packages.csv
+++ b/_data/releases/latest/go-packages.csv
@@ -14,7 +14,6 @@
 "sdk/monitor/azingest","","0.1.0","Monitor Ingestion","Monitor","monitor/azingest","","","client","true","","","","","","","","","","",""
 "sdk/monitor/azquery","1.1.0","","Monitor Query","Monitor","monitor/azquery","","","client","true","","05/09/2023","02/08/2023","","","","","","","",""
 "sdk/ai/azopenai","","0.2.0","OpenAI","OpenAI","ai/azopenai","","","client","true","","","","","","","","","","",""
-"sdk/cognitiveservices/azopenai","","0.1.2","OpenAI","Cognitive Services","cognitiveservices/azopenai","","","client","true","","","","deprecated","07/26/2023","true","ai/azopenai","NA","","",""
 "sdk/tracing/azotel","","0.2.0","OpenTelemetry","Tracing","tracing/azotel","","","client","true","","","","","","","","","","",""
 "sdk/messaging/azservicebus","1.4.1","","Service Bus","Service Bus","messaging/azservicebus","","","client","true","","09/06/2023","05/16/2022","","","","","","","",""
 "sdk/storage/azblob","1.1.0","","Storage - Blobs","Storage","storage/azblob","","","client","true","","07/13/2023","02/07/2023","","","","","","","",""

--- a/_data/releases/latest/go-packages.csv
+++ b/_data/releases/latest/go-packages.csv
@@ -14,7 +14,7 @@
 "sdk/monitor/azingest","","0.1.0","Monitor Ingestion","Monitor","monitor/azingest","","","client","true","","","","","","","","","","",""
 "sdk/monitor/azquery","1.1.0","","Monitor Query","Monitor","monitor/azquery","","","client","true","","05/09/2023","02/08/2023","","","","","","","",""
 "sdk/ai/azopenai","","0.2.0","OpenAI","OpenAI","ai/azopenai","","","client","true","","","","","","","","","","",""
-"sdk/cognitiveservices/azopenai","","0.1.2","OpenAI","Cognitive Services","cognitiveservices/azopenai","","","client","true","","","","deprecated","07/26/2023","","ai/azopenai","NA","","",""
+"sdk/cognitiveservices/azopenai","","0.1.2","OpenAI","Cognitive Services","cognitiveservices/azopenai","","","client","true","","","","deprecated","07/26/2023","true","ai/azopenai","NA","","",""
 "sdk/tracing/azotel","","0.2.0","OpenTelemetry","Tracing","tracing/azotel","","","client","true","","","","","","","","","","",""
 "sdk/messaging/azservicebus","1.4.1","","Service Bus","Service Bus","messaging/azservicebus","","","client","true","","09/06/2023","05/16/2022","","","","","","","",""
 "sdk/storage/azblob","1.1.0","","Storage - Blobs","Storage","storage/azblob","","","client","true","","07/13/2023","02/07/2023","","","","","","","",""


### PR DESCRIPTION
This package has been retracted, so the links are now "broken." Hiding listing from docs.