### PR TITLE
Cleanup Go release notes

### DIFF
--- a/releases/2021-08/go.md
+++ b/releases/2021-08/go.md
@@ -1,8 +1,8 @@
 ---
-title: Azure SDK for Go (%%MMMM yyyy%%)
+title: Azure SDK for Go (August 2021)
 layout: post
 tags: go
 sidebar: releases_sidebar
 repository: Azure/azure-sdk-for-go
 ---
-{% include releases/notes/common.md language="go" date="%%yyyy-MM%%" displayDate="%%MMMM yyyy%%" %}
+{% include releases/notes/common.md language="go" date="2021-08" displayDate="August 2021" %}

--- a/releases/2021-08/go.md
+++ b/releases/2021-08/go.md
@@ -6,4 +6,3 @@ sidebar: releases_sidebar
 repository: Azure/azure-sdk-for-go
 ---
 {% include releases/notes/common.md language="go" date="%%yyyy-MM%%" displayDate="%%MMMM yyyy%%" %}
-The Azure SDK team is pleased to make available the %%MMMM yyyy%% client library release.

--- a/releases/2021-10/go.md
+++ b/releases/2021-10/go.md
@@ -6,4 +6,3 @@ sidebar: releases_sidebar
 repository: Azure/azure-sdk-for-go
 ---
 {% include releases/notes/common.md language="go" date="2021-10" displayDate="October 2021" %}
-The Azure SDK team is pleased to make available the October 2021 client library release.

--- a/releases/2021-11/go.md
+++ b/releases/2021-11/go.md
@@ -6,4 +6,3 @@ sidebar: releases_sidebar
 repository: Azure/azure-sdk-for-go
 ---
 {% include releases/notes/common.md language="go" date="2021-11" displayDate="November 2021" %}
-The Azure SDK team is pleased to make available the November 2021 client library release.

--- a/releases/2021-12/go.md
+++ b/releases/2021-12/go.md
@@ -6,4 +6,3 @@ sidebar: releases_sidebar
 repository: Azure/azure-sdk-for-go
 ---
 {% include releases/notes/common.md language="go" date="2021-12" displayDate="December 2021" %}
-The Azure SDK team is pleased to make available the December 2021 client library release.

--- a/releases/2022-01/go.md
+++ b/releases/2022-01/go.md
@@ -6,4 +6,3 @@ sidebar: releases_sidebar
 repository: Azure/azure-sdk-for-go
 ---
 {% include releases/notes/common.md language="go" date="2022-01" displayDate="January 2022" %}
-The Azure SDK team is pleased to make available the January 2022 client library release.

--- a/releases/2022-02/go.md
+++ b/releases/2022-02/go.md
@@ -6,4 +6,3 @@ sidebar: releases_sidebar
 repository: Azure/azure-sdk-for-go
 ---
 {% include releases/notes/common.md language="go" date="2022-02" displayDate="February 2022" %}
-The Azure SDK team is pleased to make available the February 2022 client library release.

--- a/releases/2022-03/go.md
+++ b/releases/2022-03/go.md
@@ -6,4 +6,3 @@ sidebar: releases_sidebar
 repository: Azure/azure-sdk-for-go
 ---
 {% include releases/notes/common.md language="go" date="2022-03" displayDate="March 2022" %}
-The Azure SDK team is pleased to make available the March 2022 client library release.

--- a/releases/2022-04/go.md
+++ b/releases/2022-04/go.md
@@ -6,4 +6,3 @@ sidebar: releases_sidebar
 repository: Azure/azure-sdk-for-go
 ---
 {% include releases/notes/common.md language="go" date="2022-04" displayDate="April 2022" %}
-The Azure SDK team is pleased to make available the April 2022 client library release.

--- a/releases/2022-05/go.md
+++ b/releases/2022-05/go.md
@@ -6,4 +6,3 @@ sidebar: releases_sidebar
 repository: Azure/azure-sdk-for-go
 ---
 {% include releases/notes/common.md language="go" date="2022-05" displayDate="May 2022" %}
-The Azure SDK team is pleased to make available the May 2022 client library release.

--- a/releases/2022-06/go.md
+++ b/releases/2022-06/go.md
@@ -6,4 +6,3 @@ sidebar: releases_sidebar
 repository: Azure/azure-sdk-for-go
 ---
 {% include releases/notes/common.md language="go" date="2022-06" displayDate="June 2022" %}
-The Azure SDK team is pleased to make available the June 2022 client library release.

--- a/releases/2022-07/go.md
+++ b/releases/2022-07/go.md
@@ -6,4 +6,3 @@ sidebar: releases_sidebar
 repository: Azure/azure-sdk-for-go
 ---
 {% include releases/notes/common.md language="go" date="2022-07" displayDate="July 2022" %}
-The Azure SDK team is pleased to make available the July 2022 client library release.

--- a/releases/2022-08/go.md
+++ b/releases/2022-08/go.md
@@ -6,4 +6,3 @@ sidebar: releases_sidebar
 repository: Azure/azure-sdk-for-go
 ---
 {% include releases/notes/common.md language="go" date="2022-08" displayDate="August 2022" %}
-The Azure SDK team is pleased to make available the August 2022 client library release.

--- a/releases/2022-09/go.md
+++ b/releases/2022-09/go.md
@@ -6,4 +6,3 @@ sidebar: releases_sidebar
 repository: Azure/azure-sdk-for-go
 ---
 {% include releases/notes/common.md language="go" date="2022-09" displayDate="September 2022" %}
-The Azure SDK team is pleased to make available the September 2022 client library release.

--- a/releases/2022-10/go.md
+++ b/releases/2022-10/go.md
@@ -6,4 +6,3 @@ sidebar: releases_sidebar
 repository: Azure/azure-sdk-for-go
 ---
 {% include releases/notes/common.md language="go" date="2022-10" displayDate="October 2022" %}
-The Azure SDK team is pleased to make available the October 2022 client library release.

--- a/releases/2022-11/go.md
+++ b/releases/2022-11/go.md
@@ -6,4 +6,3 @@ sidebar: releases_sidebar
 repository: Azure/azure-sdk-for-go
 ---
 {% include releases/notes/common.md language="go" date="2022-11" displayDate="November 2022" %}
-The Azure SDK team is pleased to make available the November 2022 client library release.

--- a/releases/2022-12/go.md
+++ b/releases/2022-12/go.md
@@ -6,4 +6,3 @@ sidebar: releases_sidebar
 repository: Azure/azure-sdk-for-go
 ---
 {% include releases/notes/common.md language="go" date="2022-12" displayDate="December 2022" %}
-The Azure SDK team is pleased to make available the December 2022 client library release.

--- a/releases/2023-01/go.md
+++ b/releases/2023-01/go.md
@@ -6,4 +6,3 @@ sidebar: releases_sidebar
 repository: Azure/azure-sdk-for-go
 ---
 {% include releases/notes/common.md language="go" date="2023-01" displayDate="January 2023" %}
-The Azure SDK team is pleased to make available the January 2023 client library release.

--- a/releases/2023-02/go.md
+++ b/releases/2023-02/go.md
@@ -6,4 +6,3 @@ sidebar: releases_sidebar
 repository: Azure/azure-sdk-for-go
 ---
 {% include releases/notes/common.md language="go" date="2023-02" displayDate="February 2023" %}
-The Azure SDK team is pleased to make available the February 2023 client library release.

--- a/releases/2023-03/go.md
+++ b/releases/2023-03/go.md
@@ -6,4 +6,3 @@ sidebar: releases_sidebar
 repository: Azure/azure-sdk-for-go
 ---
 {% include releases/notes/common.md language="go" date="2023-03" displayDate="March 2023" %}
-The Azure SDK team is pleased to make available the March 2023 client library release.

--- a/releases/2023-04/go.md
+++ b/releases/2023-04/go.md
@@ -6,4 +6,3 @@ sidebar: releases_sidebar
 repository: Azure/azure-sdk-for-go
 ---
 {% include releases/notes/common.md language="go" date="2023-04" displayDate="April 2023" %}
-The Azure SDK team is pleased to make available the April 2023 client library release.

--- a/releases/2023-05/go.md
+++ b/releases/2023-05/go.md
@@ -6,4 +6,3 @@ sidebar: releases_sidebar
 repository: Azure/azure-sdk-for-go
 ---
 {% include releases/notes/common.md language="go" date="2023-05" displayDate="May 2023" %}
-The Azure SDK team is pleased to make available the May 2023 client library release.

--- a/releases/2023-06/go.md
+++ b/releases/2023-06/go.md
@@ -6,4 +6,3 @@ sidebar: releases_sidebar
 repository: Azure/azure-sdk-for-go
 ---
 {% include releases/notes/common.md language="go" date="2023-06" displayDate="June 2023" %}
-The Azure SDK team is pleased to make available the June 2023 client library release.

--- a/releases/2023-07/go.md
+++ b/releases/2023-07/go.md
@@ -6,4 +6,3 @@ sidebar: releases_sidebar
 repository: Azure/azure-sdk-for-go
 ---
 {% include releases/notes/common.md language="go" date="2023-07" displayDate="July 2023" %}
-The Azure SDK team is pleased to make available the July 2023 client library release.

--- a/releases/2023-08/go.md
+++ b/releases/2023-08/go.md
@@ -6,4 +6,3 @@ sidebar: releases_sidebar
 repository: Azure/azure-sdk-for-go
 ---
 {% include releases/notes/common.md language="go" date="2023-08" displayDate="August 2023" %}
-The Azure SDK team is pleased to make available the August 2023 client library release.

--- a/releases/2023-09/go.md
+++ b/releases/2023-09/go.md
@@ -6,4 +6,3 @@ sidebar: releases_sidebar
 repository: Azure/azure-sdk-for-go
 ---
 {% include releases/notes/common.md language="go" date="2023-09" displayDate="September 2023" %}
-The Azure SDK team is pleased to make available the September 2023 client library release.


### PR DESCRIPTION
Updating old Go release notes to remove extra line.

@weshaggard suggested this fix [here](https://github.com/Azure/azure-sdk/pull/6655#issuecomment-1734620461).

Related to [this issue](https://github.com/Azure/azure-sdk-pr/issues/1523).