### PR TITLE
Revert "Remove error handling around maven so we know if it fails"

### DIFF
--- a/eng/scripts/Query-Azure-Packages.ps1
+++ b/eng/scripts/Query-Azure-Packages.ps1
@@ -572,8 +572,15 @@ switch($language)
     Write-Latest-Versions "python"
     Write-Latest-Versions "cpp"
     Write-Latest-Versions "go"
-    Write-Latest-Versions "java"
-    Write-Latest-Versions "android"
+
+    # Currently ignoring errors for maven search site until incident is fixed
+    # see https://github.com/Azure/azure-sdk/issues/5368
+    try {
+      Write-Latest-Versions "java"
+      Write-Latest-Versions "android"
+    }
+    catch { }
+    break
   }
   "java" {
     Write-Latest-Versions $language

--- a/eng/scripts/Query-Azure-Packages.ps1
+++ b/eng/scripts/Query-Azure-Packages.ps1
@@ -573,13 +573,16 @@ switch($language)
     Write-Latest-Versions "cpp"
     Write-Latest-Versions "go"
 
-    # Currently ignoring errors for maven search site until incident is fixed
-    # see https://github.com/Azure/azure-sdk/issues/5368
+    # Maven search api has lots of reliability issues so keeping this error 
+    # handling here to keep it from failing the pipeline all the time.
     try {
       Write-Latest-Versions "java"
       Write-Latest-Versions "android"
     }
-    catch { }
+    catch { 
+      Write-Host "Exception: $_"
+      Write-Host "Maven search appears to be down currently, so java and android updates might not complete successfully. See https://status.maven.org/ for current status. 
+    }
     break
   }
   "java" {


### PR DESCRIPTION
Maven search service still has a lot of reliability issues so I'm going to add back logic to handle those errors. 