### PR TITLE
Add Microsoft.FeatureManagement to the CSV file

### DIFF
--- a/_data/releases/latest/dotnet-packages.csv
+++ b/_data/releases/latest/dotnet-packages.csv
@@ -1,6 +1,7 @@
 "Package","VersionGA","VersionPreview","DisplayName","ServiceName","RepoPath","MSDocs","GHDocs","Type","New","PlannedVersions","LatestGADate","FirstGADate","Support","EOLDate","Hide","Replace","ReplaceGuide","MSDocService","ServiceId","Notes"
 "Azure.AI.AnomalyDetector","","3.0.0-preview.7","Anomaly Detector","Cognitive Services","anomalydetector","","","client","true","","","","","","","Microsoft.Azure.CognitiveServices.AnomalyDetector","","","",""
 "Azure.Data.AppConfiguration","1.3.0","","App Configuration","App Configuration","appconfiguration","","","client","true","","11/08/2023","01/07/2020","active","","","","","","",""
+"Microsoft.FeatureManagement","3.0.0","",".NET Feature Management","other","https://github.com/microsoft/FeatureManagement-Dotnet","","","","false","","10/27/2023","02/27/2020","active","","","","","","",""
 "Microsoft.Extensions.Configuration.AzureAppConfiguration","5.2.0","5.3.0-preview","App Configuration Provider","App Configuration","https://github.com/Azure/AppConfiguration-DotnetProvider","NA","NA","client","true","","","","","","","","","","",""
 "Azure.Security.Attestation","1.0.0","","Attestation","Attestation","attestation","","","client","true","","05/07/2021","05/07/2021","","","","","","","",""
 "Azure.MixedReality.ObjectAnchors.Conversion","","0.3.0-beta.6","Azure Object Anchors Conversion","Mixed Reality","objectanchors","","","client","true","","","","","","","","","","",""

--- a/_data/releases/latest/dotnet-packages.csv
+++ b/_data/releases/latest/dotnet-packages.csv
@@ -1,7 +1,7 @@
 "Package","VersionGA","VersionPreview","DisplayName","ServiceName","RepoPath","MSDocs","GHDocs","Type","New","PlannedVersions","LatestGADate","FirstGADate","Support","EOLDate","Hide","Replace","ReplaceGuide","MSDocService","ServiceId","Notes"
 "Azure.AI.AnomalyDetector","","3.0.0-preview.7","Anomaly Detector","Cognitive Services","anomalydetector","","","client","true","","","","","","","Microsoft.Azure.CognitiveServices.AnomalyDetector","","","",""
 "Azure.Data.AppConfiguration","1.3.0","","App Configuration","App Configuration","appconfiguration","","","client","true","","11/08/2023","01/07/2020","active","","","","","","",""
-"Microsoft.FeatureManagement","3.0.0","",".NET Feature Management","other","https://github.com/microsoft/FeatureManagement-Dotnet","NA","","","false","","10/27/2023","02/27/2020","active","","","","","","",""
+"Microsoft.FeatureManagement","3.0.0","",".NET Feature Management","other","https://github.com/microsoft/FeatureManagement-Dotnet","NA","NA","","false","","10/27/2023","02/27/2020","active","","","","","","",""
 "Microsoft.Extensions.Configuration.AzureAppConfiguration","5.2.0","5.3.0-preview","App Configuration Provider","App Configuration","https://github.com/Azure/AppConfiguration-DotnetProvider","NA","NA","client","true","","","","","","","","","","",""
 "Azure.Security.Attestation","1.0.0","","Attestation","Attestation","attestation","","","client","true","","05/07/2021","05/07/2021","","","","","","","",""
 "Azure.MixedReality.ObjectAnchors.Conversion","","0.3.0-beta.6","Azure Object Anchors Conversion","Mixed Reality","objectanchors","","","client","true","","","","","","","","","","",""

--- a/_data/releases/latest/dotnet-packages.csv
+++ b/_data/releases/latest/dotnet-packages.csv
@@ -1,7 +1,7 @@
 "Package","VersionGA","VersionPreview","DisplayName","ServiceName","RepoPath","MSDocs","GHDocs","Type","New","PlannedVersions","LatestGADate","FirstGADate","Support","EOLDate","Hide","Replace","ReplaceGuide","MSDocService","ServiceId","Notes"
 "Azure.AI.AnomalyDetector","","3.0.0-preview.7","Anomaly Detector","Cognitive Services","anomalydetector","","","client","true","","","","","","","Microsoft.Azure.CognitiveServices.AnomalyDetector","","","",""
 "Azure.Data.AppConfiguration","1.3.0","","App Configuration","App Configuration","appconfiguration","","","client","true","","11/08/2023","01/07/2020","active","","","","","","",""
-"Microsoft.FeatureManagement","3.0.0","",".NET Feature Management","other","https://github.com/microsoft/FeatureManagement-Dotnet","","","","false","","10/27/2023","02/27/2020","active","","","","","","",""
+"Microsoft.FeatureManagement","3.0.0","",".NET Feature Management","other","https://github.com/microsoft/FeatureManagement-Dotnet","NA","","","false","","10/27/2023","02/27/2020","active","","","","","","",""
 "Microsoft.Extensions.Configuration.AzureAppConfiguration","5.2.0","5.3.0-preview","App Configuration Provider","App Configuration","https://github.com/Azure/AppConfiguration-DotnetProvider","NA","NA","client","true","","","","","","","","","","",""
 "Azure.Security.Attestation","1.0.0","","Attestation","Attestation","attestation","","","client","true","","05/07/2021","05/07/2021","","","","","","","",""
 "Azure.MixedReality.ObjectAnchors.Conversion","","0.3.0-beta.6","Azure Object Anchors Conversion","Mixed Reality","objectanchors","","","client","true","","","","","","","","","","",""


### PR DESCRIPTION
Adding Microsoft.FeatureManagement to the CSV file which needs to be there for docs. It looks like they were half onboarded, having json files in the azure-docs-sdk-dotnet, but were never added to the CSV file.