### PR TITLE
fix FeatureManagement's CSV entry so the service level overview is generated properly

### DIFF
--- a/_data/releases/latest/dotnet-packages.csv
+++ b/_data/releases/latest/dotnet-packages.csv
@@ -367,7 +367,7 @@
 "","","","","Windows 10 IoT Core Services","","NA","NA","","","","","","","","true","","","","",""
 "","","","","Windows Virtual Desktop","","NA","NA","","","","","","","","true","","","","",""
 "","","","","Xamarin","","NA","NA","","","","","","","","true","","","","",""
-"Microsoft.FeatureManagement","3.0.0","",".NET Feature Management","other","https://github.com/microsoft/FeatureManagement-Dotnet","NA","NA","","false","","10/27/2023","02/27/2020","active","","","","","","",""
+"Microsoft.FeatureManagement","3.0.0","","Feature Management","App Configuration","NA","https://learn.microsoft.com/dotnet/api/microsoft.featuremanagement","NA","client","false","","","","","","false","","","azure-app-configuration","","Testing"
 "Azure.Communication.Administration","","1.0.0-beta.3","Azure.Communication.Administration","Communication","NA","NA","NA","","false","","","","","","","","","","",""
 "Azure.Communication.Calling","","1.0.0-beta.36","Azure.Communication.Calling","Communication","NA","NA","NA","","false","","","","deprecated","09/01/2023","","Azure.Communication.Calling.WindowsClient","NA","","",""
 "Azure.Communication.CallingServer","","1.0.0-beta.3","Azure.Communication.CallingServer","Communication","NA","NA","NA","","false","","","","","","","","","","",""


### PR DESCRIPTION
When re-adding the entry back, it was close but slightly off, the service name was set to other and should have been app configuration.