### PR TITLE
Add CODEOWNERS linter baseline file and linter pipeline yml file.

### DIFF
--- a/.github/CODEOWNERS_baseline_errors.txt
+++ b/.github/CODEOWNERS_baseline_errors.txt
@@ -1,0 +1,3 @@
+xirzec is not a public member of Azure.
+ahsonkhan is not a public member of Azure.
+/**/c.yml glob does not have any matches in repository.

--- a/eng/common/pipelines/codeowners-linter.yml
+++ b/eng/common/pipelines/codeowners-linter.yml
@@ -1,0 +1,58 @@
+# Lint the CODEOWNERS file for a given repository and filter out baseline errors
+# Note: Due to the nature of the verifications, which includes source paths/globs
+# for the repository, this pipeline cannot use sparse-checkout.
+trigger: none
+
+pr:
+  branches:
+    include:
+      - main
+      - feature/*
+      - hotfix/*
+      - release/*
+  paths:
+    include:
+      - .github/CODEOWNERS
+      - .github/CODEOWNERS_baseline_errors.txt
+      - eng/common/pipelines/codeowners-linter.yml
+
+stages:
+- stage: Run
+  variables:
+    skipComponentGovernanceDetection: true
+    nugetMultiFeedWarnLevel: 'none'
+
+  jobs:
+  - job: Run
+    timeoutInMinutes: 120
+    pool:
+      name: azsdk-pool-mms-ubuntu-2204-general
+      vmImage: ubuntu-22.04
+
+    variables:
+      CodeownersLinterVersion: '1.0.0-dev.20231120.3'
+      DotNetDevOpsFeed: "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json"
+      RepoLabelUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/repository-labels-blob"
+      TeamUserUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/azure-sdk-write-teams-blob"
+      UserOrgUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/user-org-visibility-blob"
+
+    steps:
+      # Skip sparse checkout for the `azure-sdk-for-<lang>-pr` private mirrored repositories
+      # as we require the github service connection to be loaded.
+      - ${{ if not(contains(variables['Build.DefinitionName'], '-pr - ')) }}:
+        - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+          parameters:
+            Paths:
+              - '/*'
+
+      - task: DotNetCoreCLI@2
+        displayName: 'Install CodeownersLinter'
+        inputs:
+          command: custom
+          custom: 'tool'
+          arguments: 'install --global --add-source "$(DotNetDevOpsFeed)" --version "$(CodeownersLinterVersion)" "Azure.Sdk.Tools.CodeownersLinter"'
+          workingDirectory: '$(Build.SourcesDirectory)/eng/common'
+      - pwsh: |
+          codeowners-linter --repoRoot $(Build.SourcesDirectory) --repoName $(Build.Repository.Name) -fbl -rUri "$(RepoLabelUri)" -tUri "$(TeamUserUri)" -uUri "$(UserOrgUri)"
+        displayName: 'Lint CODEOWNERS and filter using baseline'
+        workingDirectory: '$(Build.SourcesDirectory)/eng/common'


### PR DESCRIPTION
This change includes the CODEOWNERS baseline error file as well as the pipeline yml file.

CODEOWNERS is now going to be linted. _This PR contains the existing linter errors, deduped, which are used to filter results, otherwise this pipeline couldn't be run on PRs that contain CODEOWNERS changes without the several hundred issues being fixed, which is not ideal._ The linter will run daily and on every change to CODEOWNERS or the baseline file. Specific details of the linting can be found [here](https://github.com/Azure/azure-sdk-tools/tree/main/tools/codeowners-utils#linting) but here is what's being verified in a nutshell.

- Metadata tags - PRLabels, ServiceLabels, ServiceOwners (previously /&lt;NotInRepo&gt;/, both are still valid for the moment) and AzureSdkOwners (new, used for issue triage). 
- Source paths - Does the path exist? If the path is a glob, is it valid and does it have matches in the repository? 
- Owners - There are several verifications for owners:
    - Does the owner, individual or team, have write access (every team/individual in a CODEOWNERS file needs to have write access, this is a GitHub thing).
    - Is the owner public? Individuals need to set their Azure membership to public. This is explicitly mentioned in the [onboarding documents](https://eng.ms/docs/products/azure-developer-experience/onboard/access) for azure-sdk repositories.

Fixes #6776 