### PR TITLE
Add sparse-checkout template, needed by the codeowners-linter pipeline

### DIFF
--- a/eng/common/pipelines/templates/steps/sparse-checkout.yml
+++ b/eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -1,0 +1,100 @@
+parameters:
+  - name: Paths
+    type: object
+    default: []
+  - name: Repositories
+    type: object
+    default:
+      - Name: $(Build.Repository.Name)
+        Commitish: $(Build.SourceVersion)
+        WorkingDirectory: $(System.DefaultWorkingDirectory)
+  - name: SkipCheckoutNone
+    type: boolean
+    default: false
+
+steps:
+  - ${{ if not(parameters.SkipCheckoutNone) }}:
+      - checkout: none
+
+  - task: PowerShell@2
+    ${{ if eq(length(parameters.Repositories), 1) }}:
+      displayName: 'Sparse checkout ${{ parameters.Repositories[0].Name }}'
+    ${{ else }}:
+      displayName: 'Sparse checkout repositories'
+    inputs:
+      targetType: inline
+      # Define this inline, because of the chicken/egg problem with loading a script when nothing
+      # has been checked out yet.
+      script: |
+        function SparseCheckout([Array]$paths, [Hashtable]$repository)
+        {
+            $dir = $repository.WorkingDirectory
+            if (!$dir) {
+              $dir = "./$($repository.Name)"
+            }
+            New-Item $dir -ItemType Directory -Force | Out-Null
+            Push-Location $dir
+
+            if (Test-Path .git/info/sparse-checkout) {
+              $hasInitialized = $true
+              Write-Host "Repository $($repository.Name) has already been initialized. Skipping this step."
+            } else {
+              Write-Host "Repository $($repository.Name) is being initialized."
+
+              if ($repository.Commitish -match '^refs/pull/\d+/merge$') {
+                Write-Host "git clone --no-checkout --filter=tree:0 -c remote.origin.fetch='+$($repository.Commitish):refs/remotes/origin/$($repository.Commitish)' https://github.com/$($repository.Name) ."
+                git clone --no-checkout --filter=tree:0 -c remote.origin.fetch=''+$($repository.Commitish):refs/remotes/origin/$($repository.Commitish)'' https://github.com/$($repository.Name) .
+              } else {
+                Write-Host "git clone --no-checkout --filter=tree:0 https://github.com/$($repository.Name) ."
+                git clone --no-checkout --filter=tree:0 https://github.com/$($repository.Name) .
+              }
+
+              # Turn off git GC for sparse checkout. Note: The devops checkout task does this by default
+              Write-Host "git config gc.auto 0"
+              git config gc.auto 0
+
+              Write-Host "git sparse-checkout init"
+              git sparse-checkout init
+
+              # Set non-cone mode otherwise path filters will not work in git >= 2.37.0
+              # See https://github.blog/2022-06-27-highlights-from-git-2-37/#tidbits
+              Write-Host "git sparse-checkout set --no-cone '/*' '!/*/' '/eng'"
+              git sparse-checkout set --no-cone '/*' '!/*/' '/eng'
+            }
+
+            # Prevent wildcard expansion in Invoke-Expression (e.g. for checkout path '/*')
+            $quotedPaths = $paths | ForEach-Object { "'$_'" }
+            $gitsparsecmd = "git sparse-checkout add $quotedPaths"
+            Write-Host $gitsparsecmd
+            Invoke-Expression -Command $gitsparsecmd
+
+            Write-Host "Set sparse checkout paths to:"
+            Get-Content .git/info/sparse-checkout
+
+            # sparse-checkout commands after initial checkout will auto-checkout again
+            if (!$hasInitialized) {
+              # Remove refs/heads/ prefix from branch names
+              $commitish = $repository.Commitish -replace '^refs/heads/', ''
+
+              # use -- to prevent git from interpreting the commitish as a path
+              Write-Host "git -c advice.detachedHead=false checkout $commitish --"
+
+              # This will use the default branch if repo.Commitish is empty
+              git -c advice.detachedHead=false checkout $commitish --
+            } else {
+              Write-Host "Skipping checkout as repo has already been initialized"
+            }
+
+            Pop-Location
+        }
+
+        # Paths may be sourced as a yaml object literal OR a dynamically generated variable json string.
+        # If the latter, convertToJson will wrap the 'string' in quotes, so remove them.
+        $paths = '${{ convertToJson(parameters.Paths) }}'.Trim('"') | ConvertFrom-Json
+        # Replace windows backslash paths, as Azure Pipelines default directories are sometimes formatted like 'D:\a\1\s'
+        $repositories = '${{ convertToJson(parameters.Repositories) }}' -replace '\\', '/' | ConvertFrom-Json -AsHashtable
+        foreach ($repo in $Repositories) {
+          SparseCheckout $paths $repo
+        }
+      pwsh: true
+      workingDirectory: $(System.DefaultWorkingDirectory)


### PR DESCRIPTION
The codeowners-linter pipeline needs the sparse-checkout template. For other azure-sdk-for-lang repositories this is pushed out when eng/common changes but this does not happen for azure-sdk.