### PR TITLE
Update mocking guidelines section for .NET

### DIFF
--- a/docs/dotnet/introduction.md
+++ b/docs/dotnet/introduction.md
@@ -956,7 +956,7 @@ ConfigurationSetting setting = client.Get("Key");
 Assert.AreEqual("Value", setting.Value);
 ```
 
-Review the [full sample](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample7_MockClient.md) in the GitHub repository.
+For more details on mocking, see [Unit testing and mocking with the Azure SDK for .NET](https://learn.microsoft.com/dotnet/azure/sdk/unit-testing-mocking).
 
 {% include requirement/MUST id="dotnet-mocking-constructor" %} provide protected parameterless constructor for mocking.
 


### PR DESCRIPTION
The "full sample" link redirected to a message asking customers to read the official doc on Learn:

![image](https://github.com/Azure/azure-sdk/assets/10702007/31e7b643-c747-4e79-b4b0-f1b98341ec0d)

This change eliminates that extra click.