### PR TITLE
Add Preview Only tab to the spec index page

### DIFF
--- a/_data/sidebars/releases_sidebar.yml
+++ b/_data/sidebars/releases_sidebar.yml
@@ -23,6 +23,8 @@ entries:
       url: /releases/latest/android.html
     - title: iOS
       url: /releases/latest/ios.html
+    - title: Specs
+      url: /releases/latest/specs.html
   - title: 2023 Releases
     folderitems:
     - title: December

--- a/_includes/releases/specs.md
+++ b/_includes/releases/specs.md
@@ -17,7 +17,10 @@ This page provides an inventory of all Azure Rest API Specifications from [azure
   <li class="nav-item {% if include.type == 'mgmt' %}active{% endif %}">
     <a class="nav-link" href="{{ site.baseurl }}/releases/latest/mgmt/specs.html">Management TypeSpecs{% if include.type == 'mgmt' %} ({{specs.size}}){% endif %}</a>
   </li>
-  <li class="nav-item {% if include.type == 'all' %}active{% endif %}">
+  <li class="nav-item {% if include.type == 'all' and include.previewonly == 'true' %}active{% endif %}">
+    <a class="nav-link" href="{{ site.baseurl }}/releases/latest/all/preview-only-specs.html">Preview Only</a>
+  </li>
+  <li class="nav-item {% if include.type == 'all' and include.previewonly != 'true' %}active{% endif %}">
     <a class="nav-link" href="{{ site.baseurl }}/releases/latest/all/specs.html">All{% if include.type == 'all' %} ({{specs.size}}){% endif %}</a>
   </li>
 </ul>
@@ -36,10 +39,11 @@ This page provides an inventory of all Azure Rest API Specifications from [azure
       {% assign resourceNames = serviceFamily.items | group_by: "ResourcePath" %}
       {% for resourceName in resourceNames %}
         {% assign typeSpecs = resourceName.items | where: 'IsTypeSpec', 'True' %}
+        {% assign stables = resourceName.items | where: 'VersionType', 'stable' %}
+        {% if include.previewonly != 'true' or stables.size == 0 %}
         <tr scope="row">
           <td>{{ serviceFamily.name }} - {{ resourceName.name }} {% if typeSpecs.size > 0 %}<small><i>(TypeSpec)</i></small>{%endif%}</td>
           <td>
-            {% assign stables = resourceName.items | where: 'VersionType', 'stable' %}
             {% include releases/spec_version_summary.md versions=stables %}
           </td>
           <td>
@@ -47,6 +51,7 @@ This page provides an inventory of all Azure Rest API Specifications from [azure
             {% include releases/spec_version_summary.md versions=previews %}
           </td>
         </tr>
+        {% endif %}
       {% endfor %}
     {% endfor %}
     </tbody>

--- a/releases/latest/all/preview-only-specs.md
+++ b/releases/latest/all/preview-only-specs.md
@@ -1,0 +1,8 @@
+---
+title: Azure Rest API Specs (Latest)
+layout: default
+sidebar: releases_sidebar
+header: true
+---
+{% include releases/specs.md type="all" previewonly="true" %}
+{% include refs.md %}


### PR DESCRIPTION
In order to see a list of all the specs that don't have a GA version yet there was a request to get a list of all the specs that only have preview versions. This new tab adds that view.