### PR TITLE
Deprecate Python package `azure-ai-vision`

### DIFF
--- a/_data/releases/latest/python-packages.csv
+++ b/_data/releases/latest/python-packages.csv
@@ -6,7 +6,7 @@
 "azure-appconfiguration-provider","1.0.0","1.1.0b3","App Configuration Provider","App Configuration","appconfiguration","","","client","true","","","03/09/2023","","","","","","","",""
 "azure-security-attestation","1.0.0","","Attestation","Attestation","attestation","","","client","true","","07/06/2021","07/06/2021","","","","","","","",""
 "azure-search-documents","11.4.0","","Azure AI Search","Search","search","","","client","true","","11/11/2023","07/07/2020","active","","","azure-search","","cognitive-search","",""
-"azure-ai-vision","","0.15.1b1","Azure AI Vision SDK","Cognitive Services","https://msasg.visualstudio.com/Skyman/_git/Carbon","NA","NA","client","true","","","","","","","","","","",""
+"azure-ai-vision","","0.15.1b1","Azure AI Vision SDK","Cognitive Services","https://msasg.visualstudio.com/Skyman/_git/Carbon","NA","NA","client","true","","","","deprecated","01/22/2024","","azure-ai-vision-imageanalysis","https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/vision/azure-ai-vision-imageanalysis","","",""
 "azure-eventhub-checkpointstoreblob","1.1.4","","Azure Blob Storage Checkpoint Store","Event Hubs","eventhub","","","client","true","","04/07/2021","01/14/2020","active","","","","","event-hubs","",""
 "azure-eventhub-checkpointstoreblob-aio","1.1.4","","Azure Blob Storage Checkpoint Store AIO","Event Hubs","eventhub","","","client","true","","04/07/2021","01/14/2020","active","","","","","event-hubs","",""
 "azure-monitor-opentelemetry","1.2.0","","Azure Monitor OpenTelemetry","Monitor","monitor","","NA","client","true","","01/19/2024","09/14/2023","","","","","","","",""


### PR DESCRIPTION
The package `azure-ai-vision` was a beta package (less than a year old) with Image Analysis APIs, with plans to add more API surfaces to it to support other vision scenarios. However, plans have changed and that did not happen. We now have a separate SDK (package) dedicated to Image Analysis, package name `azure-ai-vision-imageanalysis`. Deprecating the old in favor of the new. 