### PR TITLE
Fix devcontainer for azure-sdk site

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,5 @@
-FROM debian:10
+# Use Ruby version from https://pages.github.com/versions/
+FROM ruby:2.7.4-buster
 
 # This Dockerfile adds a non-root 'vscode' user with sudo access. However, for Linux,
 # this user's GID/UID must match your local user UID/GID to avoid permission issues
@@ -33,12 +34,6 @@ RUN apt-get update \
         git \
         openssh-client \
         less \
-        #
-        # Install ruby
-        make \
-        ruby-full \
-        build-essential \
-        zlib1g-dev \
         locales \
     #
     # Add en_US.UTF-8 locale
@@ -46,11 +41,6 @@ RUN apt-get update \
     #
     # Generate locale files
     && locale-gen \
-    #
-    # Install jekyll
-    && gem install \
-        bundler \
-        jekyll \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \
@@ -67,3 +57,7 @@ RUN apt-get update \
 
 # Switch back to the non-root user
 USER ${USERNAME}
+SHELL ["/bin/bash", "-c"]
+
+# Speed up subsequent `bundle install`
+RUN echo 'gem: --no-ri --no-rdoc' > /home/${USERNAME}/.gemrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,6 +21,12 @@
             ]
         }
     },
+
+    "features": {
+        // Use the GitHub CLI to easily push and create PRs from terminal.
+        "ghcr.io/devcontainers/features/github-cli:1": {}
+    },
+
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     "forwardPorts": [4000],
     "portsAttributes": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,24 +2,34 @@
     "name": "Jekyll",
     "dockerFile": "Dockerfile",
 
-    // Set *default* container specific settings.json values on container create.
-    "settings": { 
-        "terminal.integrated.shell.linux": "/bin/bash",
-        "csv-edit.quoteAllFields": true,
-        "csv-edit.quoteEmptyOrNullFields": "true",
-        "csv-edit.readOption_hasHeader": "true",
-        "csv-edit.writeOption_hasHeader": "true"
+    "customizations": {
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": {
+                "terminal.integrated.shell.linux": "/bin/bash",
+                "csv-edit.quoteAllFields": true,
+                "csv-edit.quoteEmptyOrNullFields": "true",
+                "csv-edit.readOption_hasHeader": "true",
+                "csv-edit.writeOption_hasHeader": "true"
+            },
+
+            // Extensions we want installed when the container is created.
+            "extensions": [
+                "docsmsft.docs-authoring-pack",
+                "github.vscode-pull-request-github",
+                "janisdd.vscode-edit-csv"
+            ]
+        }
     },
-
-    // Extensions we want installed when the container is created.
-    "extensions": [
-        "docsmsft.docs-authoring-pack",
-        "github.vscode-pull-request-github",
-        "janisdd.vscode-edit-csv"
-    ],
-
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     "forwardPorts": [4000],
+    "portsAttributes": {
+        // Suppress prompt to open browser to wrong address. VSCode will open root site and not /azure-sdk.
+        "4000": {
+            "label": "Site",
+            "onAutoForward": "silent"
+        }
+    },
 
     // Install the bundle after the container is created.
     "postCreateCommand": "bundle install",

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,12 @@
 source "https://rubygems.org"
 
-gem 'github-pages', '>200', group: :jekyll_plugins
-gem 'jekyll-relative-links'
-gem 'wdm', '>= 0.1.0' if Gem.win_platform?
-gem 'tzinfo-data'
+# See https://pages.github.com/versions/
+gem "webrick", "~> 1.8"
+gem "github-pages", ">200", group: [:jekyll_plugins]
+gem "jekyll-relative-links", group: [:jekyll_plugins]
+
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+# Performance-booster for watching directories on Windows
+gem "wdm", "~> 0.1.0" if Gem.win_platform?

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,37 +1,45 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.7.2)
+    activesupport (7.1.3)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
-    addressable (2.8.5)
+    addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
+    base64 (0.2.0)
+    bigdecimal (3.1.6)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
     coffee-script-source (1.11.1)
     colorator (1.1.0)
     commonmarker (0.23.10)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.2.3)
+    connection_pool (2.4.1)
     dnsruby (1.70.0)
       simpleidn (~> 0.2.1)
+    drb (2.2.0)
+      ruby2_keywords
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     ethon (0.16.0)
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
-    eventmachine (1.2.7-x64-mingw32)
-    execjs (2.8.1)
-    faraday (2.7.10)
+    execjs (2.9.1)
+    faraday (2.8.1)
+      base64
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
-    ffi (1.15.5)
-    ffi (1.15.5-x64-mingw-ucrt)
-    ffi (1.15.5-x64-mingw32)
+    ffi (1.16.3)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
     github-pages (228)
@@ -208,13 +216,14 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
-    mini_portile2 (2.8.4)
+    mini_portile2 (2.8.5)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    minitest (5.19.0)
-    nokogiri (1.15.4)
+    minitest (5.21.2)
+    mutex_m (0.2.0)
+    nokogiri (1.15.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (4.25.1)
@@ -223,7 +232,7 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.7)
-    racc (1.7.1)
+    racc (1.7.3)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -244,28 +253,24 @@ GEM
       unf (~> 0.1.4)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    typhoeus (1.4.0)
+    typhoeus (1.4.1)
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2023.3)
-      tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.8.2)
+    unf_ext (0.0.9.1)
     unicode-display_width (1.8.0)
-    wdm (0.1.1)
+    webrick (1.8.1)
 
 PLATFORMS
-  x64-mingw-ucrt
-  x64-mingw32
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   github-pages (> 200)
   jekyll-relative-links
   tzinfo-data
-  wdm (>= 0.1.0)
+  webrick (~> 1.8)
 
 BUNDLED WITH
-   2.3.17
+   2.1.4

--- a/_config.yml
+++ b/_config.yml
@@ -35,11 +35,15 @@ plugins:
 
 # Files and directories that Jekyll will exclude from the build
 exclude:
-  - .idea/
+  - .devcontainer/
+  - .github/
+  - .gitattributes
   - .gitignore
-  - eng
-  - vendor
+  - .idea/
+  - .vscode/
   - docs/policies/README*
+  - eng/
+  - vendor/
 
 feedback_subject_line: Azure SDK Design Guidelines Feedback
 feedback_email: adparch@microsoft.com


### PR DESCRIPTION
A number of problems, including a Gemfile.lock that had outdated and incompatible versions with Ruby 3, which github-pages now requires. Basically copied most of my personal site's devcontainer configuration which works.

Unfortunately, we cannot have VSCode prompt to open the browser to the site automatically. After about 15 minutes, it seems impossible to have it direct to a subdirectory of the local server address and port.