### PR TITLE
Remove azure-sdk-tools ref and sync eng/common instead

### DIFF
--- a/eng/ci.yml
+++ b/eng/ci.yml
@@ -1,14 +1,6 @@
 trigger:
 - master
 
-resources:
-  repositories:
-    - repository: azure-sdk-tools
-      type: github
-      name: Azure/azure-sdk-tools
-      endpoint: azure
-      ref: refs/tags/azure-sdk-tools_20240206.1
-
 pool:
   name: 'azsdk-pool-mms-ubuntu-2204-general'
   vmImage: 'ubuntu-22.04'
@@ -17,8 +9,6 @@ variables:
   BUNDLE_PATH: $(Pipeline.Workspace)/.bundle
 
 steps:
-- checkout: self
-- checkout: azure-sdk-tools
 
 - task: Cache@2
   inputs:
@@ -32,32 +22,27 @@ steps:
 - script: |
     gem install bundler
   displayName: Install bundler
-  workingDirectory: azure-sdk
 
 - script: |
     bundle install
   displayName: Install project dependencies
-  workingDirectory: azure-sdk
 
 - script: |
     bundle exec jekyll build --future
   displayName: Build Site
-  workingDirectory: azure-sdk
 
 - task: PowerShell@2
   displayName: Verify CSV data contents
   inputs:
     pwsh: true
-    workingDirectory: azure-sdk
-    filePath: azure-sdk/eng/scripts/Update-Release-Versions.ps1
+    filePath: ./eng/scripts/Update-Release-Versions.ps1
     arguments: "check"
 
 - task: PowerShell@2
   displayName: Verify site links
   inputs:
     pwsh: true
-    workingDirectory: azure-sdk
-    filePath: azure-sdk-tools/eng/common/scripts/Verify-Links.ps1
+    filePath: ./eng/common/scripts/Verify-Links.ps1
     arguments: >
       -urls ./_site/azure-sdk/index.html
       -ignoreLinksFile ./eng/ignore-links.txt

--- a/eng/ci.yml
+++ b/eng/ci.yml
@@ -44,8 +44,8 @@ steps:
     pwsh: true
     filePath: ./eng/common/scripts/Verify-Links.ps1
     arguments: >
-      -urls ./_site/index.html
+      -urls ./_site/azure-sdk/index.html
       -ignoreLinksFile ./eng/ignore-links.txt
       -inputCacheFile "https://azuresdkartifacts.blob.core.windows.net/verify-links-cache/verify-links-cache.txt"
       -devOpsLogging:$true
-      -baseUrl "file://$PWD/_site/"
+      -baseUrl "file://$PWD/_site/azure-sdk"

--- a/eng/ci.yml
+++ b/eng/ci.yml
@@ -12,7 +12,7 @@ steps:
 
 - task: Cache@2
   inputs:
-    key: 'gems | "$(Agent.OS)" | $(Build.SourcesDirectory)/azure-sdk/Gemfile | $(Build.SourcesDirectory)/azure-sdk/Gemfile.lock'
+    key: 'gems | "$(Agent.OS)" | $(Build.SourcesDirectory)/Gemfile | $(Build.SourcesDirectory)/Gemfile.lock'
     path: $(BUNDLE_PATH)
   displayName: Cache gems
 
@@ -44,8 +44,8 @@ steps:
     pwsh: true
     filePath: ./eng/common/scripts/Verify-Links.ps1
     arguments: >
-      -urls ./_site/azure-sdk/index.html
+      -urls ./_site/index.html
       -ignoreLinksFile ./eng/ignore-links.txt
       -inputCacheFile "https://azuresdkartifacts.blob.core.windows.net/verify-links-cache/verify-links-cache.txt"
       -devOpsLogging:$true
-      -baseUrl "file://$PWD/_site/azure-sdk"
+      -baseUrl "file://$PWD/_site/"

--- a/eng/pipelines/generate-release-structure.yml
+++ b/eng/pipelines/generate-release-structure.yml
@@ -5,32 +5,21 @@ pool:
   name: 'azsdk-pool-mms-win-2022-general'
   vmImage: 'windows-2022'
 
-resources:
-  repositories:
-    - repository: azure-sdk-tools
-      type: github
-      name: Azure/azure-sdk-tools
-      endpoint: azure
-
 steps:
-- checkout: self
-- checkout: azure-sdk-tools
 
 - task: PowerShell@2
   displayName: 'Generate Release Structure'
   inputs:
     pwsh: true
-    filePath: $(System.DefaultWorkingDirectory)/azure-sdk/eng/scripts/Generate-Release-Structure.ps1
+    filePath: ./eng/scripts/Generate-Release-Structure.ps1
     arguments: > 
       -ReleaseDateString "$(ReleaseDate)"
       -PublishRelease $$(PublishRelease)
 
-- template: eng/common/pipelines/templates/steps/create-pull-request.yml@azure-sdk-tools
+- template: /eng/common/pipelines/templates/steps/create-pull-request.yml
   parameters:
     RepoName: azure-sdk
     PRBranchName: AddReleaseStructure
     CommitMsg: "Add new release folder structure"
     PRTitle: "Add new release folder structure"
     PushArgs: -f
-    WorkingDirectory: $(System.DefaultWorkingDirectory)/azure-sdk
-    ScriptDirectory: $(System.DefaultWorkingDirectory)/azure-sdk-tools/eng/common/scripts

--- a/eng/pipelines/template/steps/generate-releasenotes.yml
+++ b/eng/pipelines/template/steps/generate-releasenotes.yml
@@ -75,7 +75,7 @@ steps:
     condition: and(succeeded(), ne(variables['AzureSDKReleaseNotesClonePath'], variables['AzureSDKClonePath']))
 
   - pwsh: |
-      $(AzureSDKToolsScriptsPath)/Delete-RemoteBranches.ps1 -RepoId "azure-sdk/azure-sdk" -BranchRegex '^${{ parameters.PrBranchName }}.*' -AuthToken $(azuresdk-github-pat)
+      ./eng/common/scripts/Delete-RemoteBranches.ps1 -RepoId "azure-sdk/azure-sdk" -BranchRegex '^${{ parameters.PrBranchName }}.*' -AuthToken $(azuresdk-github-pat)
     displayName: Clean Up Stale Branches
 
   - ${{ each repo in parameters.Repos }}:
@@ -114,12 +114,12 @@ steps:
         arguments: >
           -releasePeriod $(ReleasePeriod)
           -releaseStartDate $(ReleaseStartDate)
-          -commonScriptPath $(AzureSDKToolsScriptsPath)
+          -commonScriptPath ./eng/common/scripts
           -releaseDirectory $(AzureSDKReleaseNotesClonePath)/_data/releases
           -repoLanguage ${{ repo.value.Language }}
           -github_pat '$(azuresdk-github-pat)'
 
-    - template: eng/common/pipelines/templates/steps/create-pull-request.yml@azure-sdk-tools
+    - template: ./eng/common/pipelines/templates/steps/create-pull-request.yml
       parameters:
         RepoName: azure-sdk
         BaseBranchName: $(DefaultBranch)
@@ -128,7 +128,6 @@ steps:
         PRTitle: "${{ repo.value.Language }} release notes for the $(ReleasePeriod) release"
         PRBody: "This is an automated pull request to gather the ${{ repo.value.Language }} release notes for the $(ReleasePeriod) release. See [Producing Release Notes](https://github.com/Azure/azure-sdk/blob/main/docs/policies/releasenotes.md#producing-release-notes) for details of the processing."
         WorkingDirectory: $(AzureSDKReleaseNotesClonePath)
-        ScriptDirectory: $(AzureSDKToolsScriptsPath)
 
     - pwsh: |
         gh pr merge $(Submitted.PullRequest.Number) --auto --squash

--- a/eng/pipelines/template/steps/generate-releasenotes.yml
+++ b/eng/pipelines/template/steps/generate-releasenotes.yml
@@ -119,7 +119,7 @@ steps:
           -repoLanguage ${{ repo.value.Language }}
           -github_pat '$(azuresdk-github-pat)'
 
-    - template: ./eng/common/pipelines/templates/steps/create-pull-request.yml
+    - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
       parameters:
         RepoName: azure-sdk
         BaseBranchName: $(DefaultBranch)

--- a/eng/pipelines/version-updater.yml
+++ b/eng/pipelines/version-updater.yml
@@ -13,8 +13,8 @@ jobs:
   timeoutInMinutes: 360
   
   variables:
-    AzureSDKClonePath: $(System.DefaultWorkingDirectory)/azure-sdk
-    AzureSDKReleaseNotesClonePath: $(System.DefaultWorkingDirectory)/azure-sdk-notes
+    AzureSDKClonePath: $(Pipeline.Workspace)/azure-sdk
+    AzureSDKReleaseNotesClonePath: $(Pipeline.Workspace)/azure-sdk-notes
   
   steps:
   - checkout: self

--- a/eng/pipelines/version-updater.yml
+++ b/eng/pipelines/version-updater.yml
@@ -1,11 +1,3 @@
-resources:
-  repositories:
-    - repository: azure-sdk-tools
-      type: github
-      name: Azure/azure-sdk-tools
-      endpoint: azure
-      ref: refs/tags/azure-sdk-tools_20240206.1
-
 parameters:
 - name: UpdateDeprecated
   type: boolean
@@ -23,12 +15,11 @@ jobs:
   variables:
     AzureSDKClonePath: $(System.DefaultWorkingDirectory)/azure-sdk
     AzureSDKReleaseNotesClonePath: $(System.DefaultWorkingDirectory)/azure-sdk-notes
-    AzureSDKToolsScriptsPath: $(System.DefaultWorkingDirectory)/azure-sdk-tools/eng/common/scripts
   
   steps:
   - checkout: self
-  - checkout: azure-sdk-tools
-  
+    path: azure-sdk
+
   - task: PowerShell@2
     displayName: Update packages from package manager
     inputs:
@@ -90,7 +81,7 @@ jobs:
     workingDirectory: $(AzureSDKClonePath)/eng/scripts/inventory-dashboard
     displayName: Run Inventory Dashboard Data Scripts
   
-  - template: eng/common/pipelines/templates/steps/create-pull-request.yml@azure-sdk-tools
+  - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
     parameters:
       BaseBranchName: $(DefaultBranch)
       RepoName: azure-sdk
@@ -99,7 +90,6 @@ jobs:
       PRTitle: "Update package index with latest published versions"
       PushArgs: -f
       WorkingDirectory: $(AzureSDKClonePath)
-      ScriptDirectory: $(AzureSDKToolsScriptsPath)
   
   - pwsh: |
       gh pr merge $(Submitted.PullRequest.Number) --auto --squash
@@ -129,7 +119,7 @@ jobs:
     displayName: Setup default branch
     workingDirectory: $(System.DefaultWorkingDirectory)/azure-dev-docs-pr
   
-  - template: eng/common/pipelines/templates/steps/create-pull-request.yml@azure-sdk-tools
+  - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
     parameters:
       BaseBranchName: $(DefaultBranch)
       RepoOwner: MicrosoftDocs
@@ -139,7 +129,6 @@ jobs:
       PRTitle: "Update package index with latest published versions"
       PushArgs: -f
       WorkingDirectory: $(System.DefaultWorkingDirectory)/azure-dev-docs-pr
-      ScriptDirectory: $(AzureSDKToolsScriptsPath)
   
   - pwsh: |
       git clone https://github.com/dotnet/docs $(System.DefaultWorkingDirectory)/dotnet-docs
@@ -160,7 +149,7 @@ jobs:
     displayName: Setup default branch
     workingDirectory: $(System.DefaultWorkingDirectory)/dotnet-docs
   
-  - template: eng/common/pipelines/templates/steps/create-pull-request.yml@azure-sdk-tools
+  - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
     parameters:
       BaseBranchName: $(DefaultBranch)
       RepoOwner: dotnet
@@ -170,4 +159,3 @@ jobs:
       PRTitle: "Update package index with latest published versions"
       PushArgs: -f
       WorkingDirectory: $(System.DefaultWorkingDirectory)/dotnet-docs
-      ScriptDirectory: $(AzureSDKToolsScriptsPath)


### PR DESCRIPTION
We already sync eng/common periodically so we should reference things directly from the eng/common in the repo isntead of taking repo refs to azure-sdk-tools for some things and not other things. This has causes some issues troubleshooting and some inconsistencies so we should stop doing it.