### PR TITLE
Fix paths in version update pipeline

### DIFF
--- a/eng/pipelines/version-updater.yml
+++ b/eng/pipelines/version-updater.yml
@@ -60,7 +60,7 @@ jobs:
     workingDirectory: $(AzureSDKClonePath)
   
   - pwsh: |
-      git clone https://$(azuresdk-github-pat)@github.com/Azure/azure-rest-api-specs $(System.DefaultWorkingDirectory)/azure-rest-api-specs
+      git clone https://$(azuresdk-github-pat)@github.com/Azure/azure-rest-api-specs $(Pipeline.Workspace)/azure-rest-api-specs
     displayName: Clone azure-rest-api-specs repo
   
   - task: PowerShell@2
@@ -69,7 +69,7 @@ jobs:
       pwsh: true
       filePath: $(AzureSDKClonePath)/eng/scripts/Update-Spec-Versions.ps1
       arguments: >
-        -specsRoot $(System.DefaultWorkingDirectory)/azure-rest-api-specs/
+        -specsRoot $(Pipeline.Workspace)/azure-rest-api-specs/
   
   - bash: |
       npm install
@@ -77,7 +77,7 @@ jobs:
     displayName: Installing Inventory Dashboard Data Scripts Dependencies
   
   - bash: |
-      npm run start $(System.DefaultWorkingDirectory)/azure-rest-api-specs/specification
+      npm run start $(Pipeline.Workspace)/azure-rest-api-specs/specification
     workingDirectory: $(AzureSDKClonePath)/eng/scripts/inventory-dashboard
     displayName: Run Inventory Dashboard Data Scripts
   
@@ -102,7 +102,7 @@ jobs:
   - template: template/steps/generate-releasenotes.yml
   
   - pwsh: |
-      git clone https://$(azuresdk-github-pat)@github.com/MicrosoftDocs/azure-dev-docs-pr $(System.DefaultWorkingDirectory)/azure-dev-docs-pr
+      git clone https://$(azuresdk-github-pat)@github.com/MicrosoftDocs/azure-dev-docs-pr $(Pipeline.Workspace)/azure-dev-docs-pr
     displayName: Clone azure-dev-docs-pr repo
   
   - task: PowerShell@2
@@ -111,13 +111,13 @@ jobs:
       pwsh: true
       filePath: $(AzureSDKClonePath)/eng/scripts/Generate-Package-Index.ps1
       arguments: >
-        -outputFolder $(System.DefaultWorkingDirectory)/azure-dev-docs-pr/articles/includes/
+        -outputFolder $(Pipeline.Workspace)/azure-dev-docs-pr/articles/includes/
   
   - pwsh: |
       $defaultBranch = (git remote show origin | Out-String) -replace "(?ms).*HEAD branch: (\w+).*", '$1'
       echo "##vso[task.setvariable variable=DefaultBranch]$defaultBranch"
     displayName: Setup default branch
-    workingDirectory: $(System.DefaultWorkingDirectory)/azure-dev-docs-pr
+    workingDirectory: $(Pipeline.Workspace)/azure-dev-docs-pr
   
   - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
     parameters:
@@ -128,10 +128,10 @@ jobs:
       CommitMsg: "Update package index with latest published versions"
       PRTitle: "Update package index with latest published versions"
       PushArgs: -f
-      WorkingDirectory: $(System.DefaultWorkingDirectory)/azure-dev-docs-pr
+      WorkingDirectory:$(Pipeline.Workspace)/azure-dev-docs-pr
   
   - pwsh: |
-      git clone https://github.com/dotnet/docs $(System.DefaultWorkingDirectory)/dotnet-docs
+      git clone https://github.com/dotnet/docs $(Pipeline.Workspace)/dotnet-docs
     displayName: Clone dotnet docs repo
   
   - task: PowerShell@2
@@ -141,13 +141,13 @@ jobs:
       filePath: $(AzureSDKClonePath)/eng/scripts/Generate-Package-Index.ps1
       arguments: >
         -language dotnet
-        -outputFolder $(System.DefaultWorkingDirectory)/dotnet-docs/docs/azure/includes/
+        -outputFolder $(Pipeline.Workspace)/dotnet-docs/docs/azure/includes/
   
   - pwsh: |
       $defaultBranch = (git remote show origin | Out-String) -replace "(?ms).*HEAD branch: (\w+).*", '$1'
       echo "##vso[task.setvariable variable=DefaultBranch]$defaultBranch"
     displayName: Setup default branch
-    workingDirectory: $(System.DefaultWorkingDirectory)/dotnet-docs
+    workingDirectory: $(Pipeline.Workspace)/dotnet-docs
   
   - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
     parameters:
@@ -158,4 +158,4 @@ jobs:
       CommitMsg: "Update package index with latest published versions"
       PRTitle: "Update package index with latest published versions"
       PushArgs: -f
-      WorkingDirectory: $(System.DefaultWorkingDirectory)/dotnet-docs
+      WorkingDirectory: $(Pipeline.Workspace)/dotnet-docs


### PR DESCRIPTION
Follow-up after https://github.com/Azure/azure-sdk/pull/7201 because the clones were going into the wrong directory.