### PR TITLE
Fix link to Image Analysis SDK for .NET and Java 

### DIFF
--- a/_data/releases/latest/dotnet-packages.csv
+++ b/_data/releases/latest/dotnet-packages.csv
@@ -40,7 +40,7 @@
 "Azure.Identity","1.10.4","1.11.0-beta.1","Identity","Other","identity","","","client","true","","","10/30/2019","active","","","","","","",""
 "Azure.Identity.Broker","1.0.0","1.1.0-beta.1","Identity Broker","Other","identity","","","client","true","","","11/07/2023","","","","","","","",""
 "Azure.Identity.BrokeredAuthentication","","1.0.0-beta.4","Identity Brokered Authentication","Other","identity","","","client","true","","","","deprecated","10/19/2023","","Azure.Identity.Broker","NA","","",""
-"Azure.AI.Vision.ImageAnalysis","","1.0.0-beta.1","Image Analysis","Cognitive Services","https://msasg.visualstudio.com/Skyman/_git/Carbon","","","client","true","","","","","","","","","","",""
+"Azure.AI.Vision.ImageAnalysis","","1.0.0-beta.1","Image Analysis","Cognitive Services","https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/vision/Azure.AI.Vision.ImageAnalysis","","","client","true","","","","","","","","","","",""
 "Azure.Security.KeyVault.Administration","4.3.0","4.4.0-beta.2","Key Vault - Administration","Key Vault","keyvault","","","client","true","","","06/15/2021","","","","","","","",""
 "Azure.Security.KeyVault.Certificates","4.5.1","4.6.0-beta.2","Key Vault - Certificates","Key Vault","keyvault","","","client","true","","","01/09/2020","active","","","Microsoft.Azure.KeyVault","","","",""
 "Azure.Security.KeyVault.Keys","4.5.0","4.6.0-beta.2","Key Vault - Keys","Key Vault","keyvault","","","client","true","","","10/30/2019","active","","","Microsoft.Azure.KeyVault","","","",""

--- a/_data/releases/latest/java-packages.csv
+++ b/_data/releases/latest/java-packages.csv
@@ -57,7 +57,7 @@
 "azure-health-insights-clinicalmatching","com.azure","","1.0.0-beta.1","Health Insights Clinical Matching","Cognitive Services","healthinsights","","","client","true","","","","","","","","","","",""
 "azure-identity","com.azure","1.11.2","1.12.0-beta.1","Identity","Identity","identity","","","client","true","1.12.0-beta.1,02/12/2024","02/05/2024","10/29/2019","active","","","","","","",""
 "azure-identity-broker","com.azure","1.0.2","","Identity Broker","Identity","identity","","","client","true","","02/05/2024","11/08/2023","","","","","","","","Needs Review"
-"azure-ai-vision-imageanalysis","com.azure","","1.0.0-beta.1","Image Analysis","Cognitive Services","https://msasg.visualstudio.com/DefaultCollection/Skyman/_git/Carbon","","","client","true","","","","","","","","","","",""
+"azure-ai-vision-imageanalysis","com.azure","","1.0.0-beta.1","Image Analysis","Cognitive Services","https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/vision/azure-ai-vision-imageanalysis","","","client","true","","","","","","","","","","",""
 "azure-security-keyvault-administration","com.azure","4.4.3","4.5.0-beta.1","Key Vault - Administration","Key Vault","keyvault","","","client","true","","12/05/2023","06/18/2021","","","","","","","",""
 "azure-security-keyvault-certificates","com.azure","4.5.9","4.6.0-beta.1","Key Vault - Certificates","Key Vault","keyvault","","","client","true","","12/05/2023","01/07/2020","active","","","com.azure/azure-keyvault-certificates","","","",""
 "azure-security-keyvault-keys","com.azure","4.7.3","4.8.0-beta.1","Key Vault - Keys","Key Vault","keyvault","","","client","true","","12/05/2023","10/31/2019","active","","","com.azure/azure-keyvault-keys","","","",""


### PR DESCRIPTION
Fix link to Image Analysis SDK for .NET and Java. We already have the right link for Python and JS SDKs.