### PR TITLE
Add corehttp python package

### DIFF
--- a/_data/releases/latest/python-packages.csv
+++ b/_data/releases/latest/python-packages.csv
@@ -25,7 +25,7 @@
 "azure-ai-contentsafety","1.0.0","","Content Safety","Cognitive Services","contentsafety","","","client","true","","12/12/2023","12/12/2023","","","","","","","",""
 "azure-ai-language-conversations","1.1.0","","Conversational Language Understanding","Cognitive Services","cognitivelanguage","","","client","true","","06/13/2023","06/27/2022","","","","","","","",""
 "azure-core","1.30.1","","Core - Client - Core","Other","core","","","client","true","","02/29/2024","10/29/2019","active","","","","","","",""
-"corehttp","","1.0.0b5","Core HTTP","Other","core","","","client","true","","","","","","","","","","",""
+"corehttp","","1.0.0b5","Core - Client - Core HTTP","Other","core","","","client","true","","","","","","","","","","",""
 "azure-core-experimental","","1.0.0b4","Core - Client - Experimental","Other","core","","","client","true","","","","","","","","","","",""
 "azure-core-tracing-opentelemetry","","1.0.0b11","Core - Client - Tracing Opentelemetry","Other","core","","NA","client","true","","","","","","","","","","",""
 "azure-cosmos","4.5.1","4.5.2b5","Cosmos DB","Cosmos DB","cosmos","","","client","true","","","05/20/2020","active","","","","","","",""

--- a/_data/releases/latest/python-packages.csv
+++ b/_data/releases/latest/python-packages.csv
@@ -25,6 +25,7 @@
 "azure-ai-contentsafety","1.0.0","","Content Safety","Cognitive Services","contentsafety","","","client","true","","12/12/2023","12/12/2023","","","","","","","",""
 "azure-ai-language-conversations","1.1.0","","Conversational Language Understanding","Cognitive Services","cognitivelanguage","","","client","true","","06/13/2023","06/27/2022","","","","","","","",""
 "azure-core","1.30.1","","Core - Client - Core","Other","core","","","client","true","","02/29/2024","10/29/2019","active","","","","","","",""
+"corehttp","","1.0.0b5","Core HTTP","Other","core","","","client","true","","","","","","","","","","",""
 "azure-core-experimental","","1.0.0b4","Core - Client - Experimental","Other","core","","","client","true","","","","","","","","","","",""
 "azure-core-tracing-opentelemetry","","1.0.0b11","Core - Client - Tracing Opentelemetry","Other","core","","NA","client","true","","","","","","","","","","",""
 "azure-cosmos","4.5.1","4.5.2b5","Cosmos DB","Cosmos DB","cosmos","","","client","true","","","05/20/2020","active","","","","","","",""


### PR DESCRIPTION
This creates an entry in the "python-packages.csv" file for `corehttp`, the generic, non-Azure branded version of `azure-core`.

An ADO work item (20925) was recently made for the Python `corehttp` package, however, it was created after the release actually happened, so I am uncertain if the bot will automatically populate this entry. 

Note, I did not update "inventory.csv" because I don't see azure-core or any of the other python core libraries listed there.

FYI @scbedd 