### PR TITLE
Deprecate Communication Network Traversal package from supported languages

### DIFF
--- a/_data/releases/latest/dotnet-packages.csv
+++ b/_data/releases/latest/dotnet-packages.csv
@@ -14,7 +14,7 @@
 "Azure.Communication.Identity","1.3.1","","Communication Identity","Communication","communication","","","client","true","","03/22/2024","03/29/2021","active","","","","","","",""
 "Azure.Communication.JobRouter","1.0.0","","Communication JobRouter","Communication","communication","","","client","true","","11/17/2023","11/17/2023","","","","","","","",""
 "Azure.Communication.Messages","1.0.0","","Communication Messages","Communication","communication","","","client","true","","02/29/2024","02/29/2024","","","","","","","",""
-"Azure.Communication.NetworkTraversal","1.0.0","1.1.0-beta.1","Communication Network Traversal","Communication","communication","","","client","true","","02/09/2022","02/09/2022","","","","","","","",""
+"Azure.Communication.NetworkTraversal","1.0.0","1.1.0-beta.1","Communication Network Traversal","Communication","communication","","","client","true","","02/09/2022","02/09/2022","deprecated","03/31/2024","","NA","NA","","",""
 "Azure.Communication.PhoneNumbers","1.1.0","1.3.0-beta.5","Communication Phone Numbers","Communication","communication","","","client","true","","","04/26/2021","","","","","","","",""
 "Azure.Communication.Rooms","1.0.0","1.1.0-beta.1","Communication Rooms","Communication","communication","","","client","true","","","06/06/2023","","","","","","","",""
 "Azure.Communication.Sms","1.0.1","","Communication SMS","Communication","communication","","","client","true","","05/25/2021","03/29/2021","active","","","","","","",""

--- a/_data/releases/latest/java-packages.csv
+++ b/_data/releases/latest/java-packages.csv
@@ -23,7 +23,7 @@
 "azure-communication-identity","com.azure","1.5.3","","Communication Identity","Communication","communication","","","client","true","","03/22/2024","03/29/2021","active","","","","","","",""
 "azure-communication-jobrouter","com.azure","1.1.2","","Communication JobRouter","Communication","communication","","","client","true","","03/22/2024","12/01/2023","","","","","","","",""
 "azure-communication-messages","com.azure","1.0.1","","Communication Messages","Communication","communication","","","client","true","","03/22/2024","02/29/2024","","","","","","","","Needs Review"
-"azure-communication-networktraversal","com.azure","1.0.0","1.1.0-beta.2","Communication Network Traversal","Communication","communication","","","client","true","","02/11/2022","02/11/2022","","","","","","","",""
+"azure-communication-networktraversal","com.azure","1.0.0","1.1.0-beta.2","Communication Network Traversal","Communication","communication","","","client","true","","02/11/2022","02/11/2022","deprecated","03/31/2024","","NA","NA","","",""
 "azure-communication-phonenumbers","com.azure","1.1.11","1.2.0-beta.3","Communication Phone Numbers","Communication","communication","","","client","true","","03/22/2024","04/26/2021","","","","","","","",""
 "azure-communication-rooms","com.azure","1.0.9","1.1.0-beta.1","Communication Rooms","Communication","communication","","","client","true","","03/22/2024","06/08/2023","","","","","","","",""
 "azure-communication-sms","com.azure","1.1.22","","Communication Sms","Communication","communication","","","client","true","","03/22/2024","03/29/2021","active","","","","","","",""

--- a/_data/releases/latest/js-packages.csv
+++ b/_data/releases/latest/js-packages.csv
@@ -24,7 +24,7 @@
 "@azure-rest/communication-job-router","1.0.0","","Communication Job Router","Communication","https://github.com/Azure/azure-sdk-for-js/tree/item.Package_item.Version/sdk/communication/communication-job-router-rest/","NA","NA","client","true","","11/18/2023","11/18/2023","","","","","","","",""
 "@azure/communication-job-router","","1.0.0-beta.1","Communication Job Router","Communication","communication","","","client","true","","","","","","","","","","",""
 "@azure-rest/communication-messages","1.0.1","","Communication Messages","Communication","https://github.com/Azure/azure-sdk-for-js/tree/item.Package_item.Version/sdk/communication/communication-messages-rest/","NA","NA","client","true","","03/06/2024","02/29/2024","","","","","","","","Needs Review"
-"@azure/communication-network-traversal","","1.1.0-beta.1","Communication Network Traversal","Communication","communication","","","client","true","","","","","","","","","","",""
+"@azure/communication-network-traversal","","1.1.0-beta.1","Communication Network Traversal","Communication","communication","","","client","true","","","","deprecated","03/31/2024","","NA","NA","","",""
 "@azure/communication-phone-numbers","1.2.0","1.3.0-beta.4","Communication Phone Numbers","Communication","communication","","","client","true","","","04/26/2021","","","","","","","",""
 "@azure/communication-rooms","1.0.0","1.1.0-beta.1","Communication Rooms","Communication","communication","","","client","true","","","06/07/2023","","","","","","","",""
 "@azure/communication-sms","1.1.0","","Communication Sms","Communication","communication","","","client","true","","11/29/2023","03/29/2021","active","","","","","","",""

--- a/_data/releases/latest/python-packages.csv
+++ b/_data/releases/latest/python-packages.csv
@@ -17,7 +17,7 @@
 "azure-communication-email","1.0.0","","Communication Email","Communication","communication","","","client","true","","03/31/2023","03/31/2023","","","","","","","",""
 "azure-communication-identity","1.5.0","","Communication Identity","Communication","communication","","","client","true","","02/14/2024","04/20/2021","","","","","","","",""
 "azure-communication-jobrouter","1.0.0","","Communication JobRouter","Communication","communication","","NA","client","true","","11/15/2023","11/15/2023","","","","","","","",""
-"azure-communication-networktraversal","","1.1.0b1","Communication Network Traversal","Communication","communication","","","client","true","","","","","","","","","","",""
+"azure-communication-networktraversal","","1.1.0b1","Communication Network Traversal","Communication","communication","","","client","true","","","","deprecated","03/31/2024","","NA","NA","","",""
 "azure-communication-phonenumbers","1.1.0","1.2.0b3","Communication Phone Numbers","Communication","communication","","","client","true","","","04/26/2021","","","","","","","",""
 "azure-communication-rooms","1.0.0","1.1.0b1","Communication Rooms","Communication","communication","","","client","true","","","06/06/2023","","","","","","","",""
 "azure-communication-sms","1.0.1","","Communication Sms","Communication","communication","","","client","true","","06/04/2021","04/20/2021","","","","","","","",""


### PR DESCRIPTION
Deprecate Communication Network Traversal package from all supported languages: java, python, .NET, Javascript