### PR TITLE
Upgrade github-pages dependencies

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# Use Ruby 2.7 version from approved Mirosoft Container Registry.
+# Use Ruby 2.7 version from approved Microsoft Container Registry.
 # This image already contains the vscode:vscode user:group and sudoers support.
 FROM mcr.microsoft.com/devcontainers/ruby:2.7-buster
 ARG USERNAME=vscode

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,11 @@
 source "https://rubygems.org"
 
 # See https://pages.github.com/versions/
+gem "github-pages", ">= 231", group: [:jekyll_plugins]
+
+# Force certain dependencies that may be upgraded to an unsupported version for Ruby 2.7 otherwise.
+gem "nokogiri", "~> 1.15.6"
 gem "webrick", "~> 1.8"
-gem "github-pages", ">200", group: [:jekyll_plugins]
-gem "jekyll-relative-links", group: [:jekyll_plugins]
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.3)
+    activesupport (7.1.3.2)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -14,7 +14,7 @@ GEM
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     base64 (0.2.0)
-    bigdecimal (3.1.6)
+    bigdecimal (3.1.7)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -23,10 +23,9 @@ GEM
     commonmarker (0.23.10)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
-    dnsruby (1.70.0)
+    dnsruby (1.72.0)
       simpleidn (~> 0.2.1)
-    drb (2.2.0)
-      ruby2_keywords
+    drb (2.2.1)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
@@ -42,9 +41,9 @@ GEM
     ffi (1.16.3)
     forwardable-extended (2.6.0)
     gemoji (4.1.0)
-    github-pages (229)
+    github-pages (231)
       github-pages-health-check (= 1.18.2)
-      jekyll (= 3.9.4)
+      jekyll (= 3.9.5)
       jekyll-avatar (= 0.8.0)
       jekyll-coffeescript (= 1.2.2)
       jekyll-commonmark-ghpages (= 0.4.0)
@@ -58,7 +57,7 @@ GEM
       jekyll-paginate (= 1.1.0)
       jekyll-readme-index (= 0.3.0)
       jekyll-redirect-from (= 0.16.0)
-      jekyll-relative-links (= 0.7.0)
+      jekyll-relative-links (= 0.6.1)
       jekyll-remote-theme (= 0.4.3)
       jekyll-sass-converter (= 1.5.2)
       jekyll-seo-tag (= 2.8.0)
@@ -97,9 +96,9 @@ GEM
       activesupport (>= 2)
       nokogiri (>= 1.4)
     http_parser.rb (0.8.0)
-    i18n (1.14.1)
+    i18n (1.14.4)
       concurrent-ruby (~> 1.0)
-    jekyll (3.9.4)
+    jekyll (3.9.5)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -145,7 +144,7 @@ GEM
       jekyll (>= 3.0, < 5.0)
     jekyll-redirect-from (0.16.0)
       jekyll (>= 3.3, < 5.0)
-    jekyll-relative-links (0.7.0)
+    jekyll-relative-links (0.6.1)
       jekyll (>= 3.3, < 5.0)
     jekyll-remote-theme (0.4.3)
       addressable (~> 2.0)
@@ -212,7 +211,7 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.4)
-    listen (3.8.0)
+    listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
@@ -221,9 +220,9 @@ GEM
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    minitest (5.22.0)
+    minitest (5.22.3)
     mutex_m (0.2.0)
-    nokogiri (1.16.3)
+    nokogiri (1.15.6)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (4.25.1)
@@ -231,7 +230,7 @@ GEM
       sawyer (~> 0.9)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (5.0.4)
+    public_suffix (5.0.5)
     racc (1.7.3)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
@@ -267,8 +266,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  github-pages (> 200)
-  jekyll-relative-links
+  github-pages (>= 231)
+  nokogiri (~> 1.15.6)
   tzinfo-data
   webrick (~> 1.8)
 


### PR DESCRIPTION
Fixes break in devcontainer with explicit version dependency on
nokogiri, which otherwise will pull a newer version that doesn't support
Ruby 2.7.
