### PR TITLE
Fixing Communication message display name for Python SDK

### DIFF
--- a/_data/releases/latest/python-packages.csv
+++ b/_data/releases/latest/python-packages.csv
@@ -11,7 +11,7 @@
 "azure-eventhub-checkpointstoreblob-aio","1.1.4","","Azure Blob Storage Checkpoint Store AIO","Event Hubs","eventhub","","","client","true","","04/07/2021","01/14/2020","active","","","","","event-hubs","",""
 "azure-monitor-opentelemetry","1.4.0","","Azure Monitor OpenTelemetry","Monitor","monitor","","NA","client","true","","04/08/2024","09/14/2023","","","","","","","",""
 "azure-mixedreality-remoterendering","","1.0.0b2","Azure Remote Rendering","Azure Remote Rendering","remoterendering","","","client","true","","","","","","","","","","",""
-"azure-communication-messages","1.0.0","","azure-communication-messages","communication","communication","","NA","client","true","","03/25/2024","03/25/2024","","","","","","","","Needs Review"
+"azure-communication-messages","1.0.0","","Communication Messages","communication","communication","","NA","client","true","","03/25/2024","03/25/2024","","","","","","","","Needs Review"
 "azure-communication-callautomation","1.1.0","","Communication Call Automation","Communication","communication","","","client","true","","11/23/2023","06/16/2023","","","","","","","",""
 "azure-communication-chat","1.2.0","","Communication Chat","Communication","communication","","","client","true","","12/04/2023","04/20/2021","","","","","","","",""
 "azure-communication-email","1.0.0","","Communication Email","Communication","communication","","","client","true","","03/31/2023","03/31/2023","","","","","","","",""

--- a/_data/releases/latest/python-packages.csv
+++ b/_data/releases/latest/python-packages.csv
@@ -11,7 +11,7 @@
 "azure-eventhub-checkpointstoreblob-aio","1.1.4","","Azure Blob Storage Checkpoint Store AIO","Event Hubs","eventhub","","","client","true","","04/07/2021","01/14/2020","active","","","","","event-hubs","",""
 "azure-monitor-opentelemetry","1.4.0","","Azure Monitor OpenTelemetry","Monitor","monitor","","NA","client","true","","04/08/2024","09/14/2023","","","","","","","",""
 "azure-mixedreality-remoterendering","","1.0.0b2","Azure Remote Rendering","Azure Remote Rendering","remoterendering","","","client","true","","","","","","","","","","",""
-"azure-communication-messages","1.0.0","","Communication Messages","communication","communication","","NA","client","true","","03/25/2024","03/25/2024","","","","","","","","Needs Review"
+"azure-communication-messages","1.0.0","","Communication Messages","Communication","communication","","NA","client","true","","03/25/2024","03/25/2024","","","","","","","",""
 "azure-communication-callautomation","1.1.0","","Communication Call Automation","Communication","communication","","","client","true","","11/23/2023","06/16/2023","","","","","","","",""
 "azure-communication-chat","1.2.0","","Communication Chat","Communication","communication","","","client","true","","12/04/2023","04/20/2021","","","","","","","",""
 "azure-communication-email","1.0.0","","Communication Email","Communication","communication","","","client","true","","03/31/2023","03/31/2023","","","","","","","",""


### PR DESCRIPTION
Fixing Display name of Communication Python SDK, Currently it is like below:
Communication Messages
    Overview
    azure.communication.messages.
    
![image (6)](https://github.com/Azure/azure-sdk/assets/9246598/a524e234-b4bf-4c67-8539-87b4be3b0cf1)
