### PR TITLE
Deprecate OTel Live Metrics NuGet package

### DIFF
--- a/_data/releases/latest/dotnet-packages.csv
+++ b/_data/releases/latest/dotnet-packages.csv
@@ -67,7 +67,7 @@
 "Azure.AI.OpenAI","","1.0.0-beta.16","OpenAI Inference","Cognitive Services","openai","","","client","true","","","","","","","","","","",""
 "Azure.Monitor.OpenTelemetry.AspNetCore","1.1.1","1.2.0-beta.3","OpenTelemetry AspNetCore","Monitor","monitor","","","client","true","","04/26/2024","11/29/2023","","","","","","","",""
 "Azure.Monitor.OpenTelemetry.Exporter","1.2.0","1.3.0-beta.1","OpenTelemetry Exporter","Monitor","monitor","","","client","true","","","09/20/2023","","","","","","","",""
-"Azure.Monitor.OpenTelemetry.LiveMetrics","","1.0.0-beta.3","OpenTelemetry LiveMetrics","Monitor","monitor","","","client","true","","","","","","","","","","",""
+"Azure.Monitor.OpenTelemetry.LiveMetrics","","1.0.0-beta.3","OpenTelemetry LiveMetrics","Monitor","monitor","","","client","true","","","","deprecated","05/01/2024","","Azure.Monitor.OpenTelemetry.AspNetCore","NA","","",""
 "Azure.AI.Personalizer","","2.0.0-beta.2","Personalizer","Cognitive Services","personalizer","","","client","true","","","","","","","","","","",""
 "Azure.Analytics.Purview.Account","","1.0.0-beta.1","Purview Account","Purview","purview","","","client","true","","","","","","","","","","",""
 "Azure.Analytics.Purview.Administration","","1.0.0-beta.1","Purview Administration","Purview","purview","","","client","true","","","","","","","","","","",""


### PR DESCRIPTION
The OTel Live Metrics package has already been marked as deprecated on nuget.org. The package never made it out of Beta, so marking end of support date as today. Its functionality moved to a separate package.