### PR TITLE
Hide deprecated brokered authN NuGet package from docs

### DIFF
--- a/_data/releases/latest/dotnet-packages.csv
+++ b/_data/releases/latest/dotnet-packages.csv
@@ -46,7 +46,7 @@
 "Azure.Health.Insights.RadiologyInsights","","1.0.0-beta.1","Health Insights Radiology Insights","Cognitive Services","healthinsights","","","client","true","","","","","","","","","","",""
 "Azure.Identity","1.11.3","1.12.0-beta.2","Identity","Other","identity","","","client","true","","05/06/2024","10/30/2019","active","","","","","","",""
 "Azure.Identity.Broker","1.1.0","1.2.0-beta.1","Identity Broker","Other","identity","","","client","true","","","11/07/2023","","","","","","","",""
-"Azure.Identity.BrokeredAuthentication","","1.0.0-beta.4","Identity Brokered Authentication","Other","identity","","","client","true","","","","deprecated","10/19/2023","","Azure.Identity.Broker","NA","","",""
+"Azure.Identity.BrokeredAuthentication","","1.0.0-beta.4","Identity Brokered Authentication","Other","identity","","","client","true","","","","deprecated","10/19/2023","true","Azure.Identity.Broker","NA","","",""
 "Azure.AI.Vision.ImageAnalysis","","1.0.0-beta.2","Image Analysis","Cognitive Services","https://github.com/Azure/azure-sdk-for-net/tree/main/sdk/vision/Azure.AI.Vision.ImageAnalysis","","","client","true","","","","","","","","","","",""
 "Azure.Security.KeyVault.Administration","4.4.0","","Key Vault - Administration","Key Vault","keyvault","","","client","true","","02/14/2024","06/15/2021","","","","","","","",""
 "Azure.Security.KeyVault.Certificates","4.6.0","","Key Vault - Certificates","Key Vault","keyvault","","","client","true","","02/14/2024","01/09/2020","active","","","Microsoft.Azure.KeyVault","","","",""


### PR DESCRIPTION
Prevent display of this row on the Learn docs page:
![image](https://github.com/Azure/azure-sdk/assets/10702007/1ff936b4-3079-4cf6-b5ad-38c15dabbb0d)
