### PR TITLE
Update CODEOWNERS for eng/common

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -65,6 +65,7 @@
 /docs/tables/                 @kyle-patterson
 /docs/typescript/             @bterlson @salameer @xirzec
 /eng/                         @weshaggard
+/eng/common/                  @Azure/azure-sdk-eng
 /eng/scripts/inventory-dashboard         @ronniegeraghty
 /_posts/                      @kyle-patterson
 /_data/                       @ronniegeraghty @weshaggard


### PR DESCRIPTION
Add engsys team as owner for files under eng/common to enable engsys team to be able to approve and merge eng/common sync PRs.