### PR TITLE
updating release notes generator with exception for july

### DIFF
--- a/eng/pipelines/template/steps/generate-releasenotes.yml
+++ b/eng/pipelines/template/steps/generate-releasenotes.yml
@@ -39,6 +39,10 @@ steps:
         {
           $secondFridayOfMonth = [DateTime]"2024-01-19"
         }
+        elseif ($d.Year -eq 2024 -and $d.Month -eq 7)
+        {
+          $secondFridayOfMonth = [DateTime]"2024-07-19"
+        }
 
         return $secondFridayOfMonth
       }


### PR DESCRIPTION
Adding clause for the second Friday of the month of July to be pushed out 1 week.