### PR TITLE
[identity] Bootstrap Identity docs section

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -67,7 +67,7 @@
 /docs/redirects/              @kyle-patterson
 /docs/tables/                 @kyle-patterson
 /docs/typescript/             @bterlson @salameer @xirzec
-/docs/identity/								@Azure/azure-sdk-write-identity
+/docs/identity/               @Azure/azure-sdk-write-identity
 /eng/                         @weshaggard
 /eng/common/                  @Azure/azure-sdk-eng
 /eng/scripts/inventory-dashboard         @ronniegeraghty

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -67,6 +67,7 @@
 /docs/redirects/              @kyle-patterson
 /docs/tables/                 @kyle-patterson
 /docs/typescript/             @bterlson @salameer @xirzec
+/docs/identity/								@Azure/azure-sdk-write-identity
 /eng/                         @weshaggard
 /eng/common/                  @Azure/azure-sdk-eng
 /eng/scripts/inventory-dashboard         @ronniegeraghty

--- a/docs/identity/README.md
+++ b/docs/identity/README.md
@@ -1,18 +1,18 @@
 # The Book of Identity
 
-Welcome to the Book of Identity for the Azure SDK. This contains a collection of articles, historical decisions, and other useful information about the non-trivial internals of the Azure Identity SDKs.
+Welcome to the Book of Identity for the Azure SDK. This contains a collection of articles, historical decisions, and other useful information about the non-trivial internals of the Azure Identity libraries.
 
-The intended audience are folks on the Identity feature crew or anyone wishing to have a deeper understanding of the SDK internals.
+The intended audience are folks on the Identity feature crew or anyone wishing to have a deeper understanding of the library internals.
 
 ## Why?
 
-Like most software, the Azure Identity SDKs are built with numerous design decisions, optimizations, and complexities that can be non-trivial to understand and navigate. Documenting these intricacies helps in several ways:
+Like most software, the Azure Identity libraries are built with numerous design decisions, optimizations, and complexities that can be non-trivial to understand and navigate. Documenting these intricacies helps in several ways:
 
 - Knowledge Sharing: Facilitates the transfer of knowledge within the team and for new members, reducing the onboarding time and helping everyone to understand the reasoning behind certain design choices.
-- Maintenance: Helps in maintaining and evolving the SDKs by providing a clear historical context and rationale behind existing implementations.
+- Maintenance: Helps in maintaining and evolving the libraries by providing a clear historical context and rationale behind existing implementations.
 - Troubleshooting: Aids in debugging and resolving issues by having a comprehensive reference that outlines the internal workings and decision-making processes.
 - Innovation: Encourages innovative thinking by providing a deep understanding of the current state, which can inspire new ideas and improvements.
 
-Inspired by dotnet's [Book of the Runtime](https://github.com/dotnet/runtime/tree/main/docs/design/coreclr/botr).
+Inspired by .NET's [Book of the Runtime](https://github.com/dotnet/runtime/tree/main/docs/design/coreclr/botr).
 
-> This document is experimental and may become obsolete due to lack of engagement. If there have been no changes or updates to this as of 7/16/2025, this entire section can be deleted.
+> NOTE: This document is experimental and may become obsolete due to lack of engagement. If there have been no changes or updates to this as of 7/16/2025, this entire section can be deleted.

--- a/docs/identity/README.md
+++ b/docs/identity/README.md
@@ -1,0 +1,18 @@
+# The Book of Identity
+
+Welcome to the Book of Identity for the Azure SDK. This contains a collection of articles, historical decisions, and other useful information about the non-trivial internals of the Azure Identity SDKs.
+
+The intended audience are folks on the Identity feature crew or anyone wishing to have a deeper understanding of the SDK internals.
+
+## Why?
+
+Like most software, the Azure Identity SDKs are built with numerous design decisions, optimizations, and complexities that can be non-trivial to understand and navigate. Documenting these intricacies helps in several ways:
+
+- Knowledge Sharing: Facilitates the transfer of knowledge within the team and for new members, reducing the onboarding time and helping everyone to understand the reasoning behind certain design choices.
+- Maintenance: Helps in maintaining and evolving the SDKs by providing a clear historical context and rationale behind existing implementations.
+- Troubleshooting: Aids in debugging and resolving issues by having a comprehensive reference that outlines the internal workings and decision-making processes.
+- Innovation: Encourages innovative thinking by providing a deep understanding of the current state, which can inspire new ideas and improvements.
+
+Inspired by dotnet's [Book of the Runtime](https://github.com/dotnet/runtime/tree/main/docs/design/coreclr/botr).
+
+> This document is experimental and may become obsolete due to lack of engagement. If there have been no changes or updates to this as of 7/16/2025, this entire section can be deleted.


### PR DESCRIPTION
Azure Identity SDKs are used in almost every scenario and will continue to be heavily used as usage of Entra ID expands throughout 1p and 3p customers.

Over the years some knowledge has accumulated and as a team we would like to document these decisions as well as backfill
previous decisions, designs, and other docs needed by new team members.

We wanted a place that is:
- Public by default
- Language agnostic
- Supports Markdown
- Is easy to add changes and review changes

This is an experiment, and we should evaluate whether we're getting the value we need out of it (and whether there's enough
engagement) but as a starting point we plan to bootstrap this in a Q&A.