### PR TITLE
Give CODEOWNERS file an owner in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -50,9 +50,6 @@
 ##### * Engineering Systems PRs must be approved by two engineering systems team members.
 #####
 
-# Check Enforcer and GitHub Event Processor yml files
-/.github/workflows/           @Azure/azure-sdk-eng
-
 # Engineering systems documents
 /docs/android/                @JonathanGiles @salameer
 /docs/clang/                  @JeffreyRichter @LarryOsterman @RickWinter
@@ -99,3 +96,9 @@
 /**/go.md                        @ronniegeraghty @gracewilcox
 /**/go.yml                       @ronniegeraghty @gracewilcox
 /**/go-packages.csv              @ronniegeraghty @gracewilcox @mario-guerra @scottaddie
+
+################################################################################
+# Event yml files and CODEOWNERS should be near the bottom of CODEOWNERS files #
+################################################################################
+/.github/workflows/           @Azure/azure-sdk-eng
+/.github/CODEOWNERS           @Azure/azure-sdk-eng


### PR DESCRIPTION
Give the CODEOWNERS file owners. Move the .github/workflows and .github/CODEOWNERS entries to the bottom of the file which makes it less likely an incorrect, overzealous pattern will match them.