### PR TITLE
update ai-evaluation metadata

### DIFF
--- a/_data/releases/latest/python-packages.csv
+++ b/_data/releases/latest/python-packages.csv
@@ -426,7 +426,7 @@
 "azure-iothub-service-client","1.4.6","","azure-iothub-service-client","","NA","NA","NA","","false","","","","","","true","","","","",""
 "iothub-client","1.1.2.0","","iothub-client","","NA","NA","NA","","false","","","","active","","true","","","","",""
 "iothub-service-client","1.1.0.0","","iothub-service-client","","NA","NA","NA","","false","","","","active","","true","","","","",""
-"azure-ai-evaluation","","1.0.0b2","AI Evaluation","Cognitive Services","evaluation","NA","NA","client","true","","","","","","","","","","","Needs Review, Updated metadata to go in Cognitive Services on 9/30/2024."
+"azure-ai-evaluation","","1.0.0b2","AI Evaluation","Cognitive Services","evaluation","NA","NA","client","true","","","","","","","","","","","Updated metadata to go in Cognitive Services on 9/30/2024."
 "azure-functions","","","","Functions","","NA","NA","client","false","","","","","","","","","","","Added for MSDocs ToC generation. Not published by azure-sdk automation."
 "adal","","","Active Directory Authentication Library","Active Directory","","NA","NA","client","false","","","","","","","","","","","Added for MSDocs ToC generation. Not published by azure-sdk automation."
 "azure-cognitiveservices-anomalydetector","","0.3.1","Anomaly Detector","Cognitive Services","cognitiveservices","","","client","false","","","","deprecated","3/31/2023","","azure-ai-anomalydetector","NA","","",""

--- a/_data/releases/latest/python-packages.csv
+++ b/_data/releases/latest/python-packages.csv
@@ -426,7 +426,7 @@
 "azure-iothub-service-client","1.4.6","","azure-iothub-service-client","","NA","NA","NA","","false","","","","","","true","","","","",""
 "iothub-client","1.1.2.0","","iothub-client","","NA","NA","NA","","false","","","","active","","true","","","","",""
 "iothub-service-client","1.1.0.0","","iothub-service-client","","NA","NA","NA","","false","","","","active","","true","","","","",""
-"azure-ai-evaluation","","1.0.0b2","Unknown Display Name","Unknown Service","NA","NA","NA","","false","","","","","","","","","","","Needs Review"
+"azure-ai-evaluation","","1.0.0b2","AI Evaluation","Cognitive Services","ai","NA","NA","client","true","","","","","","","","","","","Needs Review, Updated metadata to go in Cognitive Services on 9/30/2024."
 "azure-functions","","","","Functions","","NA","NA","client","false","","","","","","","","","","","Added for MSDocs ToC generation. Not published by azure-sdk automation."
 "adal","","","Active Directory Authentication Library","Active Directory","","NA","NA","client","false","","","","","","","","","","","Added for MSDocs ToC generation. Not published by azure-sdk automation."
 "azure-cognitiveservices-anomalydetector","","0.3.1","Anomaly Detector","Cognitive Services","cognitiveservices","","","client","false","","","","deprecated","3/31/2023","","azure-ai-anomalydetector","NA","","",""

--- a/_data/releases/latest/python-packages.csv
+++ b/_data/releases/latest/python-packages.csv
@@ -426,7 +426,7 @@
 "azure-iothub-service-client","1.4.6","","azure-iothub-service-client","","NA","NA","NA","","false","","","","","","true","","","","",""
 "iothub-client","1.1.2.0","","iothub-client","","NA","NA","NA","","false","","","","active","","true","","","","",""
 "iothub-service-client","1.1.0.0","","iothub-service-client","","NA","NA","NA","","false","","","","active","","true","","","","",""
-"azure-ai-evaluation","","1.0.0b2","AI Evaluation","Cognitive Services","ai","NA","NA","client","true","","","","","","","","","","","Needs Review, Updated metadata to go in Cognitive Services on 9/30/2024."
+"azure-ai-evaluation","","1.0.0b2","AI Evaluation","Cognitive Services","evaluation","NA","NA","client","true","","","","","","","","","","","Needs Review, Updated metadata to go in Cognitive Services on 9/30/2024."
 "azure-functions","","","","Functions","","NA","NA","client","false","","","","","","","","","","","Added for MSDocs ToC generation. Not published by azure-sdk automation."
 "adal","","","Active Directory Authentication Library","Active Directory","","NA","NA","client","false","","","","","","","","","","","Added for MSDocs ToC generation. Not published by azure-sdk automation."
 "azure-cognitiveservices-anomalydetector","","0.3.1","Anomaly Detector","Cognitive Services","cognitiveservices","","","client","false","","","","deprecated","3/31/2023","","azure-ai-anomalydetector","NA","","",""


### PR DESCRIPTION
Updating `azure-ai-evaluation` metadata to slot under Cognitive Services in the MS Learn ToC. `DisplayName` of "AI Evaluation".