### PR TITLE
Fix/unify liks in C++ release notes

### DIFF
--- a/_data/releases/2021-08/cpp.yml
+++ b/_data/releases/2021-08/cpp.yml
@@ -44,8 +44,8 @@ entries:
 
     #### Bugs Fixed
 
-    - [2647](https://github.com/Azure/azure-sdk-for-cpp/issues/2647) Make the curl transport adapter to check the connection close header.
-    - [2474](https://github.com/Azure/azure-sdk-for-cpp/issues/2474) Fix compiling with MSVC and `/analyze`.
+    - [[#2647]](https://github.com/Azure/azure-sdk-for-cpp/issues/2647) Make the curl transport adapter to check the connection close header.
+    - [[#2474]](https://github.com/Azure/azure-sdk-for-cpp/issues/2474) Fix compiling with MSVC and `/analyze`.
     - Make WinHTTP transport adapter to NOT use SSL/TLS for unsecured HTTP connections.
 - Name: azure-identity
   Version: 1.1.0

--- a/_data/releases/2021-09/cpp.yml
+++ b/_data/releases/2021-09/cpp.yml
@@ -9,7 +9,7 @@ entries:
   ChangelogContent: |-
     #### Bugs Fixed
 
-    - [2785](https://github.com/Azure/azure-sdk-for-cpp/issues/2785) Fix to build on g++ 5.5.
+    - [[#2785]](https://github.com/Azure/azure-sdk-for-cpp/issues/2785) Fix to build on g++ 5.5.
 - Name: azure-storage-files-shares
   Version: 12.2.0
   DisplayName: Storage - Files Shares
@@ -80,7 +80,7 @@ entries:
   ChangelogContent: |-
     #### Bugs Fixed
 
-    - [2750](https://github.com/Azure/azure-sdk-for-cpp/issues/2750) Support for Azure `managedhsm` cloud and any other non-public Azure cloud.
+    - [[#2750]](https://github.com/Azure/azure-sdk-for-cpp/issues/2750) Support for Azure `managedhsm` cloud and any other non-public Azure cloud.
 
     #### Features Added
 

--- a/_data/releases/2021-10/cpp.yml
+++ b/_data/releases/2021-10/cpp.yml
@@ -9,5 +9,5 @@ entries:
   ChangelogContent: |-
     #### Features Added
 
-    - [2833](https://github.com/Azure/azure-sdk-for-cpp/issues/2833) Added `GetCryptographyClient()` to `KeyClient` to return a `CryptographyClient` that uses the same options, policies, and pipeline as the `KeyClient` that created it.
+    - [[#2833]](https://github.com/Azure/azure-sdk-for-cpp/issues/2833) Added `GetCryptographyClient()` to `KeyClient` to return a `CryptographyClient` that uses the same options, policies, and pipeline as the `KeyClient` that created it.
 

--- a/_data/releases/2021-11/cpp.yml
+++ b/_data/releases/2021-11/cpp.yml
@@ -9,7 +9,7 @@ entries:
   ChangelogContent: |-
     #### Bugs Fixed
 
-    [2848](https://github.com/Azure/azure-sdk-for-cpp/issues/2848) Update the libcurl transport adapter to work with HTTP/1.1 only.
+    - [[#2848]](https://github.com/Azure/azure-sdk-for-cpp/issues/2848) Update the libcurl transport adapter to work with HTTP/1.1 only.
 
     #### Features Added
 

--- a/_data/releases/2022-01/cpp.yml
+++ b/_data/releases/2022-01/cpp.yml
@@ -9,5 +9,5 @@ entries:
   ChangelogContent: |-
     #### Bugs Fixed
 
-    - [2741](https://github.com/Azure/azure-sdk-for-cpp/issues/2741) Fixed linking problem when Azure SDK is built as DLL.
+    - [[#2741]](https://github.com/Azure/azure-sdk-for-cpp/issues/2741) Fixed linking problem when Azure SDK is built as DLL.
 

--- a/_data/releases/2023-04/cpp.yml
+++ b/_data/releases/2023-04/cpp.yml
@@ -76,7 +76,7 @@ entries:
   ChangelogContent: |-
     #### Bugs Fixed
 
-    - [3366](https://github.com/Azure/azure-sdk-for-cpp/issues/4466) Fixed the user-agent string sent to the service to include the "keys" suffix in the value, when using `CryptographyClient`.
+    - [[#4466]](https://github.com/Azure/azure-sdk-for-cpp/issues/4466) Fixed the user-agent string sent to the service to include the "keys" suffix in the value, when using `CryptographyClient`.
 
     #### Features Added
 

--- a/_data/releases/2023-05/cpp.yml
+++ b/_data/releases/2023-05/cpp.yml
@@ -77,7 +77,7 @@ entries:
   ChangelogContent: |-
     #### Bugs Fixed
 
-    - [3366](https://github.com/Azure/azure-sdk-for-cpp/issues/4466) Fixed the user-agent string sent to the service to include the "keys" suffix in the value, when using `CryptographyClient`.
+    - [[#4466]](https://github.com/Azure/azure-sdk-for-cpp/issues/4466) Fixed the user-agent string sent to the service to include the "keys" suffix in the value, when using `CryptographyClient`.
 
     #### Features Added
 

--- a/_data/releases/2024-03/cpp.yml
+++ b/_data/releases/2024-03/cpp.yml
@@ -20,5 +20,5 @@ entries:
   ChangelogContent: |-
     #### Bugs Fixed
 
-    - [[5244]](https://github.com/Azure/azure-sdk-for-cpp/issues/5244) WinHTTP transport not closing correctly in case of a request timeout.
+    - [[#5244]](https://github.com/Azure/azure-sdk-for-cpp/issues/5244) WinHTTP transport not closing correctly in case of a request timeout.
 

--- a/_data/releases/2024-04/cpp.yml
+++ b/_data/releases/2024-04/cpp.yml
@@ -10,7 +10,7 @@ entries:
     #### Bugs Fixed
 
     - [[#5450]](https://github.com/Azure/azure-sdk-for-cpp/issues/5450) Reverted libcurl connection pool to use more conservative caching strategy.
-    - [[#4352]](https://github.com/Azure/azure-sdk-for-cpp/pull/5371) Fixed compilation error on Visual Studio 2017. (A community contribution, courtesy of _[morten-ofstad](https://github.com/morten-ofstad)_)
+    - [[#5371]](https://github.com/Azure/azure-sdk-for-cpp/pull/5371) Fix use of namespace qualifiers that have not been explicitly introduced. (A community contribution, courtesy of _[morten-ofstad](https://github.com/morten-ofstad)_)
 - Name: azure-security-keyvault-keys
   Version: 4.5.0-beta.1
   DisplayName: Key Vault - Keys
@@ -88,7 +88,7 @@ entries:
 
     #### Bugs Fixed
 
-    - Fixed [#5297](https://github.com/Azure/azure-sdk-for-cpp/issues/5297). The actual fix for this was to use a single management client per connection.
+    - Fixed [[#5297]](https://github.com/Azure/azure-sdk-for-cpp/issues/5297). The actual fix for this was to use a single management client per connection.
 - Name: azure-core
   Version: 1.12.0-beta.1
   DisplayName: Core


### PR DESCRIPTION
Bringing in changes from https://github.com/Azure/azure-sdk-for-cpp/pull/6048
Note that the changes to "Other Changes" section is not included, because over here that section is removed entirely.