### PR TITLE
Removing mocking guidelines for Rust

### DIFF
--- a/docs/rust/implementation.md
+++ b/docs/rust/implementation.md
@@ -43,7 +43,6 @@ impl SecretClientExt for SecretClient {
 
 * The trait **MUST** be exported from the crate root.
 * The trait **MUST** use the name of the client it extends with an "Ext" suffix e.g., "SecretClientExt".
-* The trait **MAY** extend the [service client methods trait for mocking](introduction.md#rust-client-mocking-trait-name) e.g., `pub trait SecretClientExt: SecretClientMethods {}`.
 
 You might consider this approach if the generated methods are sufficient but you want to add convenience methods.
 

--- a/docs/rust/introduction.md
+++ b/docs/rust/introduction.md
@@ -251,51 +251,7 @@ pub mod builders {
 
 ##### Mocking {#rust-client-mocking}
 
-{% include requirement/MUST id="rust-client-mocking-trait-name" %} define a trait named after the client name + "Methods" e.g., `SecretClientMethods`.
-
-{% include requirement/MUST id="rust-client-mocking-trait-namespace" %} place these traits in the root module e.g., `azure_storage_blobs` or `azure_security_keyvault_secrets` so they are automatically discoverable by the Language Server Protocol (LSP).
-
-{% include requirement/MUST id="rust-client-mocking-trait-methods" %} implement all methods of the client methods trait on the client which have the body `unimplemented!()` or `std::future::ready(unimplemented!())` for async methods e.g.,
-
-```rust
-pub trait SecretClientMethods {
-    fn endpoint(&self) -> &Url {
-        unimplemented!()
-    }
-
-    async fn set_secret(
-        &self,
-        _name: impl Into<String>,
-        _version: impl Into<String>,
-        _options: Option<SetSecretMethodOptions>,
-    ) -> azure_core::Result<Response> {
-        std::future::ready(unimplemented!())
-    }
-}
-
-pub struct SecretClient {
-    // ...
-}
-
-impl SecretClient {
-    // pub fn new(..) -> Result<Self>
-}
-
-impl SecretClientMethods for SecretClient {
-    fn endpoint(&self) -> &Url {
-        todo!()
-    }
-
-    async fn set_secret(
-        &self,
-        name: impl Into<String>,
-        version: impl Into<String>,
-        options: Option<SetSecretMethodOptions>,
-    ) -> azure_core::Result<Response> {
-        todo!()
-    }
-}
-```
+> We are reevaluating options for mocking to provide the best experience for API consumers whether or not they plan to utilize mocks or fakes.
 
 #### Service Methods {#rust-client-methods}
 
@@ -806,14 +762,6 @@ pub(crate) mod helpers;
 // helpers.rs
 pub fn helper() {} // not exported publicly
 ```
-
-### Support for Mocking {#rust-mocking}
-
-In addition to [mocking clients](#rust-client-mocking):
-
-{% include requirement/MUST id="rust-mocking-model-fields" %} declare all model fields public.
-
-{% include requirement/MUST id="rust-mocking-helpers" %} define a `from()` method for all helper types like pageables and LROs that allow callers to return those types from client mocks.
 
 ## Azure SDK Library Design
 


### PR DESCRIPTION
We are reevaluating options. The existing approach required importing a trait when most consumers probably wouldn't understand why or even need it for its intended purpose.
