### PR TITLE
Clarify guidelines for LRO subtypes

### DIFF
--- a/docs/dotnet/introduction.md
+++ b/docs/dotnet/introduction.md
@@ -642,8 +642,10 @@ BlobBaseClient client = ...
 
 {% include requirement/MUST id="dotnet-lro-waituntil" %} take ```WaitUntil``` as the first parameter to LRO methods.
 
+{% include requirement/MUST id="dotnet-lro-waituntil" %} put methods that cannot be called until after the long-running operation has started on the subclass of ```Operation<T>```.  For example, if a service provides an API to cancel an operation, the ```Cancel``` method should appear on the subclass of ```Operation```.
+
 {% include requirement/MAY id="dotnet-lro-subclass" %} add additional APIs to subclasses of ```Operation<T>```.
-For example, some subclasses add a constructor allowing to create an operation instance from a previously saved operation ID. Also, some subclasses are more granular states besides the IsCompleted and HasValue states that are present on the base class.
+For example, some subclasses add a constructor allowing to create an operation instance from a previously saved operation ID.  Some service operations have intermediate states they pass through prior to completion.  These can be represented with an added ```Status``` property to augment the ```HasCompleted``` property on the base ```Operation``` type.
 
 {% include requirement/MUST id="dotnet-lro-constructor" %} provide a public constructor on subclasses of ```Operation<T>``` to allow users to access an existing LRO.
 


### PR DESCRIPTION
If an Azure service provides a REST API to cancel a long-running operation, .NET Azure client libraries put the `Cancel` method on a public subtype of `Operation`.  This is not clearly represented in the C# guidelines -- this PR updates the guidelines to reflect the guidance more clearly.