### PR TITLE
Fix "Key Vault" product name

### DIFF
--- a/docs/tracing/distributed-tracing-conventions.md
+++ b/docs/tracing/distributed-tracing-conventions.md
@@ -261,40 +261,40 @@ In addition to common attributes listed in the [Public API calls](#public-api-ca
 
 <!-- endsemconv -->
 
-### Azure KeyVault attributes
+### Azure Key Vault attributes
 
-#### Azure KeyVault Certificates attributes
+#### Azure Key Vault Certificates attributes
 
 <!-- semconv azure.sdk.keyvault.certificates -->
 
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `az.keyvault.certificate.issuer.name` | string | Azure KeyVault certificate version. | `issuer01` | Recommended |
-| `az.keyvault.certificate.name` | string | Azure KeyVault certificate name. | `selfSignedCert01` | Recommended |
-| `az.keyvault.certificate.version` | string | Azure KeyVault certificate version. | `c3d31d7b36c942ad83ef36fc0785a4fc` | Recommended |
+| `az.keyvault.certificate.issuer.name` | string | Azure Key Vault certificate version. | `issuer01` | Recommended |
+| `az.keyvault.certificate.name` | string | Azure Key Vault certificate name. | `selfSignedCert01` | Recommended |
+| `az.keyvault.certificate.version` | string | Azure Key Vault certificate version. | `c3d31d7b36c942ad83ef36fc0785a4fc` | Recommended |
 
 <!-- endsemconv -->
 
-#### Azure KeyVault Keys attributes
+#### Azure Key Vault Keys attributes
 
 <!-- semconv azure.sdk.keyvault.keys -->
 
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `az.keyvault.key.id` | string | Azure KeyVault key id (full URL). | `"https://myvault.vault.azure.net/keys/CreateSoftKeyTest/78deebed173b48e48f55abf87ed4cf71` | Recommended |
-| `az.keyvault.key.name` | string | Azure KeyVault key name. | `test-key` | Recommended |
-| `az.keyvault.key.version` | string | Azure KeyVault key version. | `3d31e6e5c4c14eaf9be8d42c00225088` | Recommended |
+| `az.keyvault.key.id` | string | Azure Key Vault key id (full URL). | `"https://myvault.vault.azure.net/keys/CreateSoftKeyTest/78deebed173b48e48f55abf87ed4cf71` | Recommended |
+| `az.keyvault.key.name` | string | Azure Key Vault key name. | `test-key` | Recommended |
+| `az.keyvault.key.version` | string | Azure Key Vault key version. | `3d31e6e5c4c14eaf9be8d42c00225088` | Recommended |
 
 <!-- endsemconv -->
 
-#### Azure KeyVault Secrets attributes
+#### Azure Key Vault Secrets attributes
 
 <!-- semconv azure.sdk.keyvault.secrets -->
 
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `az.keyvault.secret.name` | string | Azure KeyVault secret name. | `test-secret` | Recommended |
-| `az.keyvault.secret.version` | string | Azure KeyVault secret version. | `4387e9f3d6e14c459867679a90fd0f79` | Recommended |
+| `az.keyvault.secret.name` | string | Azure Key Vault secret name. | `test-secret` | Recommended |
+| `az.keyvault.secret.version` | string | Azure Key Vault secret version. | `4387e9f3d6e14c459867679a90fd0f79` | Recommended |
 
 <!-- endsemconv -->
 

--- a/docs/tracing/distributed-tracing-conventions.yml
+++ b/docs/tracing/distributed-tracing-conventions.yml
@@ -246,7 +246,7 @@ groups:
   # keyvault certificates
   - id: azure.sdk.keyvault.certificates
     type: span
-    brief: 'Describes Azure KeyVault Certificates SDK spans.'
+    brief: 'Describes Azure Key Vault Certificates SDK spans.'
     extends: azure.sdk.api
     attributes:
       - ref: az.keyvault.certificate.name
@@ -256,7 +256,7 @@ groups:
   # keyvault keys
   - id: azure.sdk.keyvault.keys
     type: span
-    brief: 'Describes Azure KeyVault Keys SDK spans.'
+    brief: 'Describes Azure Key Vault Keys SDK spans.'
     extends: azure.sdk.api
     attributes:
       - ref: az.keyvault.key.name
@@ -266,7 +266,7 @@ groups:
   # keyvault secrets
   - id: azure.sdk.keyvault.secrets
     type: span
-    brief: 'Describes Azure KeyVault Secrets SDK spans.'
+    brief: 'Describes Azure Key Vault Secrets SDK spans.'
     extends: azure.sdk.api
     attributes:
       - ref: az.keyvault.secret.name
@@ -275,7 +275,7 @@ groups:
   # remote rendering
   - id: azure.sdk.remoterendering
     type: span
-    brief: 'Describes Azure KeyVault Secrets SDK spans.'
+    brief: 'Describes Azure Remote Rendering SDK spans.'
     extends: azure.sdk.api
     attributes:
       - ref: az.remoterendering.conversion.id


### PR DESCRIPTION
The official name is "Key Vault". We should use the correct name in official documentation.
