### PR TITLE
Use PODs instead of builders for Rust options

### DIFF
--- a/docs/rust/implementation.md
+++ b/docs/rust/implementation.md
@@ -52,52 +52,6 @@ In all options above except if merely re-exposing public APIs without alteration
 
 {% include requirement/MUST id="rust-client-convenience-telemetry-telemeter" %} must telemeter the convenience client methods just like any service client methods.
 
-### Options Builders {#rust-client-options-builders}
-
-The `azure_core` crate depends on an `azure_core_macros` crate that defines the `ClientOptions` and `ClientMethodOptions` derive macros. These intentionally have the same name as their associated traits in `azure_core` as with `std` crate macros.
-These macros make it easy for code emitters and developers to create standard client options and client method options while maintaining standard builder setters by the `azure_core` developers.
-
-Though the derive macros and traits differ in setters and use, they share similar functionality. The following implementation details will focus primarily on `ClientOptions` and `ClientOptionsBuilder`.
-
-{% include requirement/SHOULD id="rust-client-options-builders-client-options" %} use the `ClientOptions` derive macro for client options.
-
-{% include requirement/SHOULD id="rust-client-options-builders-client-method-options" %} use the `ClientMethodOptions` derive macro for client method options.
-
-Client options and client method options should follow the form:
-
-```rust
-use azure_core::{ClientOptions, ClientMethodOptions};
-
-pub struct SecretClient {
-    // ...
-}
-
-#[derive(Clone, Debug, ClientOptions)]
-pub struct SecretClientOptions {
-    api_version: Option<String>,
-    // Other client-specific options ...,
-    client_options: ClientOptions,
-}
-
-impl SecretClient {
-    pub fn get_secret(
-        &self,
-        name: impl AsRef<str>,
-        options: Option<SecretClientGetSecretOptions>,
-    ) -> Result<Response<KeyVaultSecret>> {
-        todo!()
-    }
-}
-
-#[derive(Clone, Debug, Default, ClientMethodOptions)]
-pub struct SecretClientGetSecretOptions {
-    // Other client method-specific options ...,
-    method_options: ClientMethodOptions,
-}
-```
-
-If either `client_options` or `method_options` conflicts, you can name the field whatever you want and attribute it with `#[options]` for the derive macro to discover it.
-
 ### Tests {#rust-client-tests}
 
 We will implement tests [idiomatically with cargo][rust-lang-tests].

--- a/docs/rust/introduction.md
+++ b/docs/rust/introduction.md
@@ -513,6 +513,8 @@ Builders are an idiomatic pattern in Rust, such as the [typestate builder patter
 
 {% include requirement/MAY id="rust-builders-support" %} implement builders for special cases e.g., URI builders.
 
+If you do implement a builder, it must be defined according to the following guidelines:
+
 {% include requirement/MUST id="rust-builders-factory" %} define a `builder()` factory method on the type to be constructed that returns a struct with the same as the type + "Builder" e.g., `Model::builder()` returns a `ModelBuilder`.
 
 {% include requirement/MUST id="rust-builders-self" %} consume `mut self` in `with_` setter methods and return `Self` except in the final `build(&self)` method.


### PR DESCRIPTION
This was agreed to in a 2024-10-29 meeting of stakeholders and partners. It simplifies the API and we can always add builders later without being a breaking change.