### PR TITLE
Update Azure.AI.Projects entry to set Type column to client

### DIFF
--- a/_data/releases/latest/dotnet-packages.csv
+++ b/_data/releases/latest/dotnet-packages.csv
@@ -1,5 +1,5 @@
 "Package","VersionGA","VersionPreview","DisplayName","ServiceName","RepoPath","MSDocs","GHDocs","Type","New","PlannedVersions","LatestGADate","FirstGADate","FirstPreviewDate","Support","EOLDate","Hide","Replace","ReplaceGuide","MSDocService","ServiceId","Notes"
-"Azure.AI.Projects","","1.0.0-beta.1","AI Foundry","Cognitive Services","ai","","NA","","true","","","","11/19/2024","active","","","","","","",""
+"Azure.AI.Projects","","1.0.0-beta.1","AI Foundry","Cognitive Services","ai","","NA","client","true","","","","11/19/2024","active","","","","","","",""
 "Azure.AI.Inference","","1.0.0-beta.2","AI Model Inference","Cognitive Services","ai","","NA","client","true","","","","08/06/2024","","","","","","","",""
 "Azure.AI.AnomalyDetector","","3.0.0-preview.7","Anomaly Detector","Cognitive Services","anomalydetector","","","client","true","","","","08/21/2020","","","","Microsoft.Azure.CognitiveServices.AnomalyDetector","","","",""
 "Azure.Data.AppConfiguration","1.5.0","","App Configuration","App Configuration","appconfiguration","","","client","true","","08/06/2024","01/07/2020","09/09/2019","active","","","","","","",""


### PR DESCRIPTION
The Azure.AI.Projects entry was updated in this [PR](https://github.com/Azure/azure-sdk/pull/8293) yesterday but the Type column was left empty which is why this is showing up under Uncategorized instead of under Cognitive Services.