### PR TITLE
Update C++ guidelines to explicitly state that client methods should be marked as const

### DIFF
--- a/docs/cpp/introduction.md
+++ b/docs/cpp/introduction.md
@@ -203,6 +203,8 @@ namespace _detail {
 
 {% include requirement/SHOULD id="cpp-design-naming-functions-noexcept" %} declare all functions that can never throw exceptions `noexcept`.
 
+{% include requirement/MUST id="cpp-design-naming-functions-const" %} declare all client functions as `const` since service clients are intended to be immutable.
+
 {% include requirement/MUST id="cpp-design-naming-variables-public-global" %} name namespace scope variables intended for user consumption with **PascalCase**.
 
 {% include requirement/MUST id="cpp-design-naming-variables-constants" %} name namespace scope `const` or `constexpr` variables intended for user consumption with **PascalCase**.


### PR DESCRIPTION
SDK clients are designed to be immutable as per the [guidelines](https://azure.github.io/azure-sdk/cpp_introduction.html#cpp-service-client-immutable), so it should be safe to mark them as `const` so that a user referencing client instances as `const&` will be able to call any of the marked methods.

> DO ensure that all service client classes thread safe (usually by making them immutable and stateless).

Related issues/PRs:
https://github.com/Azure/azure-sdk-for-cpp/pull/6328
https://github.com/Azure/autorest.cpp/issues/464
https://github.com/Azure/azure-sdk-for-cpp/issues/6329
https://github.com/Azure/azure-sdk-for-cpp/issues/6330
