### PR TITLE
Add Rust release notes to the release template and March 2025 release index

### DIFF
--- a/eng/scripts/release-template/index.md
+++ b/eng/scripts/release-template/index.md
@@ -22,6 +22,7 @@ You can find links to packages, code, and docs on our [Azure SDK Releases page](
 * [Java release notes](java.md)
 * [JavaScript/TypeScript release notes](js.md)
 * [Python release notes](python.md)
+* [Rust release notes](rust.md)
 * [C++ release notes](cpp.md)
 * [Embedded C release notes](c.md)
 * [Android release notes](android.md)

--- a/releases/2025-03/index.md
+++ b/releases/2025-03/index.md
@@ -22,6 +22,7 @@ You can find links to packages, code, and docs on our [Azure SDK Releases page](
 * [Java release notes](java.md)
 * [JavaScript/TypeScript release notes](js.md)
 * [Python release notes](python.md)
+* [Rust release notes](rust.md)
 * [C++ release notes](cpp.md)
 * [Embedded C release notes](c.md)
 * [Android release notes](android.md)


### PR DESCRIPTION
Add Rust release notes to the release template and March 2025 release index