### PR TITLE
[Android] Deconflict duplicate guideline IDs

### DIFF
--- a/docs/android/design.md
+++ b/docs/android/design.md
@@ -745,9 +745,9 @@ public final class TextDocumentInput {
 }
 ```
 
-{% include requirement/MUST id="android-models-fluent" %} provide a fluent setter API to configure the model class, where each `set` method should `return this`. This allows chaining of set operations.
+{% include requirement/MUST id="android-models-fluent-api" %} provide a fluent setter API to configure the model class, where each `set` method should `return this`. This allows chaining of set operations.
 
-{% include requirement/MUST id="android-models-fluent" %} override all `set` methods when extending a fluent type to return the extended type. This allows chaining of `set` operations on the sub-class.
+{% include requirement/MUST id="android-models-fluent-override-set" %} override all `set` methods when extending a fluent type to return the extended type. This allows chaining of `set` operations on the sub-class.
 
 ```java
 @Fluent

--- a/docs/android/design.md
+++ b/docs/android/design.md
@@ -299,7 +299,7 @@ public final class ConfigurationClientBuilder {
 
 {% include requirement/MUSTNOT id="android-versioning-no-previews-in-stable" %} include preview API versions in a stable SDK release's API version enum.
 
-{% include requirement/MUST id="android-versioning-no-previews-in-stable" %} expose preview API versions only in beta SDKs.
+{% include requirement/MUST id="android-versioning-previews-only-in-beta" %} expose preview API versions only in beta SDKs.
 
 {% include requirement/MUST id="android-versioning-select-service-api" %} provide an enum of supported service API versions that can be supplied via the [options class](#option-parameters) when initializing the service client, as shown below:
 


### PR DESCRIPTION
The following IDs are used in more than one guideline. The means that links to the guidelines are ambiguous, and as we are indexing guidelines into Azure AI Search, we require the guideline IDs to be unqiue.

- android-models-fluent
- android-versioning-no-previews-in-stable

This PR ensures the IDs are not duplicated where the content of the guideline is different.