### PR TITLE
[iOS] Deconflict duplicate guideline ids

### DIFF
--- a/docs/ios/design.md
+++ b/docs/ios/design.md
@@ -209,7 +209,7 @@ public struct ConfigurationClientOptions: ClientOptions {
 
 {% include requirement/MUSTNOT id="ios-versioning-no-previews-in-stable" %} include preview API versions in a stable SDK release's API version enum.
 
-{% include requirement/MUST id="ios-versioning-no-previews-in-stable" %} expose preview API versions only in beta SDKs.
+{% include requirement/MUST id="ios-versioning-previews-only-in-beta" %} expose preview API versions only in beta SDKs.
 
 {% include requirement/MUST id="ios-versioning-select-service-api" %} provide an enum of supported service API versions that can be supplied via the [options struct](#option-parameters) when initializing the service client, as shown below:
 

--- a/docs/ios/implementation.md
+++ b/docs/ios/implementation.md
@@ -49,9 +49,9 @@ The following guidance applies to Swift [attributes](https://docs.swift.org/swif
 
 {% include requirement/SHOULD id="ios-attr-objc" %} use the `@objc` and `@objMembers` attributes ONLY when a Swift object must be exposed to ObjectiveC.
 
-{% include requirement/MUST id="ios-attr-available" %} use the `@available` attribute when implementation is contingent upon differences in supported OS or Swift versions.
+{% include requirement/MUST id="ios-attr-available-for-os-versions" %} use the `@available` attribute when implementation is contingent upon differences in supported OS or Swift versions.
 
-{% include requirement/MUST id="ios-attr-available" %} use the `@available` attribute to manage breaking changes and transition customers away from deprecated APIs. For example:
+{% include requirement/MUST id="ios-attr-available-for-breaking-changes" %} use the `@available` attribute to manage breaking changes and transition customers away from deprecated APIs. For example:
 ```swift
 // usable but will issue a warning
 @available(*, deprecated, message: "Optional message here...")


### PR DESCRIPTION
The following IDs are used in more than one guideline. The means that links to the guidelines are ambiguous, and as we are indexing guidelines into Azure AI Search, we require the guideline IDs to be unique.

- ios-versioning-no-previews-in-stable
- ios-attr-available

This PR ensures the IDs are not duplicated where the content of the guideline is different.