### PR TITLE
[TypeScript] Deconflict duplicate guidelines ids

### DIFF
--- a/docs/typescript/implementation.md
+++ b/docs/typescript/implementation.md
@@ -285,7 +285,7 @@ A particular (major.minor) version of a library can choose what service APIs it 
 
 {% include requirement/MUSTNOT id="ts-versioning-no-version-0" %} use a major version of 0, even for beta packages.
 
-{% include requirement/MUST id="general-versioning-bump" %} select a version number greater than the highest version number of any other released Track 1 package for the service in any other npm scope or language.
+{% include requirement/MUST id="versioning-bump-from-track-1" %} select a version number greater than the highest version number of any other released Track 1 package for the service in any other npm scope or language.
 
 Semantic versioning is more of a lofty ideal than a practical specification for some libraries. Also, [one person's bug might be another person's key feature](https://xkcd.com/1172/). Package authors are required to follow semver in a way that is useful for their consumers.
 


### PR DESCRIPTION
The following IDs are used in more than one guideline. The means that links to the guidelines are ambiguous, and as we are indexing guidelines into Azure AI Search, we require the guideline IDs to be unqiue.

- general-versioning-bump

This PR ensures the IDs are not duplicated where the content of the guideline is different.