### PR TITLE
Skip fork

### DIFF
--- a/eng/pipelines/version-updater.yml
+++ b/eng/pipelines/version-updater.yml
@@ -125,6 +125,7 @@ jobs:
       BaseBranchName: $(DefaultBranch)
       RepoOwner: MicrosoftDocs
       RepoName: azure-dev-docs-pr
+      RepoAuthToken: $(azure-sdk-gh-token-microsoftdocs)
       PRBranchName: PackageIndexUpdates
       CommitMsg: "Update package index with latest published versions"
       PRTitle: "Update package index with latest published versions"

--- a/eng/pipelines/version-updater.yml
+++ b/eng/pipelines/version-updater.yml
@@ -122,6 +122,8 @@ jobs:
 
   - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
     parameters:
+      PROwner: MicrosoftDocs
+      PROwnerAuthToken: $(azure-sdk-gh-token-microsoftdocs)
       BaseBranchName: $(DefaultBranch)
       RepoOwner: MicrosoftDocs
       RepoName: azure-dev-docs-pr


### PR DESCRIPTION
To workaround an issue where you cannot use one github app token to create a PR from a private fork I'm skipping the fork and pushing the changes directly to the private repo to create the PR.
See https://github.com/orgs/community/discussions/24549 for the limitation. 