### PR TITLE
Revert testing of fine-grain pats

### DIFF
--- a/eng/common/pipelines/templates/steps/create-pull-request.yml
+++ b/eng/common/pipelines/templates/steps/create-pull-request.yml
@@ -1,15 +1,13 @@
-# By default expects azure-sdk-gh-token-azure and azure-sdk-gh-token-azure-sdk is set to the PAT for the azure-sdk account
+# Expects azuresdk-github-pat is set to the PAT for azure-sdk
 # Expects the buildtools to be cloned
 
 parameters:
   BaseBranchName: $(Build.SourceBranch)
   PRBranchName: not-specified
   PROwner: azure-sdk
-  PROwnerAuthToken: $(azure-sdk-gh-token-azure-sdk)
   CommitMsg: not-specified
   RepoOwner: Azure
   RepoName: $(Build.Repository.Name)
-  RepoAuthToken: $(azure-sdk-gh-token-azure)
   PushArgs:
   WorkingDirectory: $(System.DefaultWorkingDirectory)
   PRTitle: not-specified
@@ -18,7 +16,7 @@ parameters:
   GHReviewers: ''
   GHTeamReviewers: ''
   GHAssignees: ''
-  # Multiple labels separated by comma, e.g. "bug, APIView"
+  # Multiple labels seperated by comma, e.g. "bug, APIView"
   PRLabels: ''
   SkipCheckingForChanges: false
   CloseAfterOpenForTesting: false
@@ -29,7 +27,6 @@ steps:
   parameters:
     BaseRepoBranch: ${{ parameters.PRBranchName }}
     BaseRepoOwner: ${{ parameters.PROwner }}
-    BaseRepoAuthToken: ${{ parameters.PROwnerAuthToken }}
     CommitMsg: ${{ parameters.CommitMsg }}
     TargetRepoOwner: ${{ parameters.RepoOwner }}
     TargetRepoName: ${{ parameters.RepoName }}
@@ -51,7 +48,7 @@ steps:
       -BaseBranch "${{ parameters.BaseBranchName }}"
       -PROwner "${{ parameters.PROwner }}"
       -PRBranch "${{ parameters.PRBranchName }}"
-      -AuthToken "${{ parameters.RepoAuthToken }}"
+      -AuthToken "$(azuresdk-github-pat)"
       -PRTitle "${{ parameters.PRTitle }}"
       -PRBody "${{ coalesce(parameters.PRBody, parameters.CommitMsg, parameters.PRTitle) }}"
       -PRLabels "${{ parameters.PRLabels }}"

--- a/eng/common/pipelines/templates/steps/git-push-changes.yml
+++ b/eng/common/pipelines/templates/steps/git-push-changes.yml
@@ -1,7 +1,6 @@
 parameters:
   BaseRepoBranch: not-specified
   BaseRepoOwner: azure-sdk
-  BaseRepoAuthToken: $(azure-sdk-gh-token-azure-sdk)
   CommitMsg: not-specified
   TargetRepoOwner: Azure
   TargetRepoName: $(Build.Repository.Name)
@@ -32,7 +31,7 @@ steps:
 - template: /eng/common/pipelines/templates/steps/emit-rate-limit-metrics.yml
   parameters:
     GitHubUser: azure-sdk
-    GitHubToken: ${{ parameters.BaseRepoAuthToken }}
+    GitHubToken: $(azuresdk-github-pat)
 
 - task: PowerShell@2
   displayName: Push changes
@@ -44,6 +43,6 @@ steps:
     arguments: >
       -PRBranchName "${{ parameters.BaseRepoBranch }}"
       -CommitMsg "${{ parameters.CommitMsg }}"
-      -GitUrl "https://${{ parameters.BaseRepoAuthToken }}@github.com/${{ parameters.BaseRepoOwner }}/$(RepoNameWithoutOwner).git"
+      -GitUrl "https://$(azuresdk-github-pat)@github.com/${{ parameters.BaseRepoOwner }}/$(RepoNameWithoutOwner).git"
       -PushArgs "${{ parameters.PushArgs }}"
       -SkipCommit $${{ parameters.SkipCheckingForChanges }}

--- a/eng/pipelines/template/steps/generate-releasenotes.yml
+++ b/eng/pipelines/template/steps/generate-releasenotes.yml
@@ -80,12 +80,12 @@ steps:
   - pwsh: |
       git clone https://github.com/Azure/azure-sdk.git $(AzureSDKReleaseNotesClonePath)
       cd $(AzureSDKReleaseNotesClonePath)
-      git remote add azure-sdk-fork "https://$(azure-sdk-gh-token-azure-sdk)@github.com/azure-sdk/azure-sdk.git"
+      git remote add azure-sdk-fork "https://$(azuresdk-github-pat)@github.com/azure-sdk/azure-sdk.git"
     displayName: Clone azure-sdk for release notes
     condition: and(succeeded(), ne(variables['AzureSDKReleaseNotesClonePath'], variables['AzureSDKClonePath']))
 
   - pwsh: |
-      ./eng/common/scripts/Delete-RemoteBranches.ps1 -RepoId "azure-sdk/azure-sdk" -BranchRegex '^${{ parameters.PrBranchName }}.*' -AuthToken $(azure-sdk-gh-token-azure-sdk)
+      ./eng/common/scripts/Delete-RemoteBranches.ps1 -RepoId "azure-sdk/azure-sdk" -BranchRegex '^${{ parameters.PrBranchName }}.*' -AuthToken $(azuresdk-github-pat)
     displayName: Clean Up Stale Branches
 
   - ${{ each repo in parameters.Repos }}:
@@ -126,7 +126,7 @@ steps:
           -releaseStartDate $(ReleaseStartDate)
           -releaseDirectory $(AzureSDKReleaseNotesClonePath)/_data/releases
           -repoLanguage ${{ repo.value.Language }}
-          -github_pat '$(azure-sdk-gh-token-azure-sdk)'
+          -github_pat '$(azuresdk-github-pat)'
 
     - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
       parameters:
@@ -144,4 +144,4 @@ steps:
       displayName: Apply AutoMerge to Pull Request
       workingDirectory: $(AzureSDKReleaseNotesClonePath)
       env:
-        GH_TOKEN: $(azure-sdk-gh-token-azure)
+        GH_TOKEN: $(azuresdk-github-pat)

--- a/eng/pipelines/version-updater.yml
+++ b/eng/pipelines/version-updater.yml
@@ -26,7 +26,7 @@ jobs:
       pwsh: true
       filePath: $(AzureSDKClonePath)/eng/scripts/Query-Azure-Packages.ps1
       arguments: >
-        -github_pat '$(azure-sdk-gh-token-azure)'
+        -github_pat '$(azuresdk-github-pat)'
         -nuget_pat '$(azure-sdk-nuget-pat)'
         -updateDeprecated ($${{ parameters.UpdateDeprecated }} -or ((Get-Date).DayOfWeek -eq "Sunday"))
 
@@ -36,7 +36,7 @@ jobs:
       pwsh: true
       filePath: $(AzureSDKClonePath)/eng/scripts/Update-Release-Versions.ps1
       arguments: >
-        -github_pat '$(azure-sdk-gh-token-azure)'
+        -github_pat '$(azuresdk-github-pat)'
 
   - task: AzureCLI@2
     displayName: Update release DevOps work-items
@@ -46,11 +46,11 @@ jobs:
       scriptLocation: inlineScript
       inlineScript: |
         $(AzureSDKClonePath)/eng/scripts/Update-DevOps-WorkItems.ps1 `
-          -github_pat '$(azure-sdk-gh-token-azure)'
+          -github_pat '$(azuresdk-github-pat)'
 
   - pwsh: |
       # Some steps, like release notes, require this remote all the time so lets always setup even if there are no changes
-      git remote add azure-sdk-fork "https://$(azure-sdk-gh-token-azure-sdk)@github.com/azure-sdk/azure-sdk.git"
+      git remote add azure-sdk-fork "https://$(azuresdk-github-pat)@github.com/azure-sdk/azure-sdk.git"
     displayName: Setup azure-sdk-fork remote
     workingDirectory: $(AzureSDKClonePath)
 
@@ -61,7 +61,7 @@ jobs:
     workingDirectory: $(AzureSDKClonePath)
 
   - pwsh: |
-      git clone https://$(azure-sdk-gh-token-azure)@github.com/Azure/azure-rest-api-specs $(Pipeline.Workspace)/azure-rest-api-specs
+      git clone https://$(azuresdk-github-pat)@github.com/Azure/azure-rest-api-specs $(Pipeline.Workspace)/azure-rest-api-specs
     displayName: Clone azure-rest-api-specs repo
 
   - task: PowerShell@2
@@ -98,12 +98,12 @@ jobs:
     displayName: Apply AutoMerge to Pull Request
     workingDirectory: $(AzureSDKClonePath)
     env:
-      GH_TOKEN: $(azure-sdk-gh-token-azure)
+      GH_TOKEN: $(azuresdk-github-pat)
 
   - template: template/steps/generate-releasenotes.yml
 
   - pwsh: |
-      git clone https://$(azure-sdk-gh-token-microsoftdocs)@github.com/MicrosoftDocs/azure-dev-docs-pr $(Pipeline.Workspace)/azure-dev-docs-pr
+      git clone https://$(azuresdk-github-pat)@github.com/MicrosoftDocs/azure-dev-docs-pr $(Pipeline.Workspace)/azure-dev-docs-pr
     displayName: Clone azure-dev-docs-pr repo
 
   - task: PowerShell@2
@@ -122,12 +122,9 @@ jobs:
 
   - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
     parameters:
-      PROwner: MicrosoftDocs
-      PROwnerAuthToken: $(azure-sdk-gh-token-microsoftdocs)
       BaseBranchName: $(DefaultBranch)
       RepoOwner: MicrosoftDocs
       RepoName: azure-dev-docs-pr
-      RepoAuthToken: $(azure-sdk-gh-token-microsoftdocs)
       PRBranchName: PackageIndexUpdates
       CommitMsg: "Update package index with latest published versions"
       PRTitle: "Update package index with latest published versions"
@@ -135,7 +132,7 @@ jobs:
       WorkingDirectory: $(Pipeline.Workspace)/azure-dev-docs-pr
 
   - pwsh: |
-      git clone https://$(azure-sdk-gh-token-azure)@github.com/Azure/azure-rest-api-specs-pr $(Pipeline.Workspace)/azure-rest-api-specs-pr --branch RPSaaSMaster
+      git clone https://$(azuresdk-github-pat)@github.com/Azure/azure-rest-api-specs-pr $(Pipeline.Workspace)/azure-rest-api-specs-pr --branch RPSaaSMaster
     displayName: Clone azure-rest-api-specs-pr repo
 
   - task: PowerShell@2


### PR DESCRIPTION
These changes were used to test switching to fine-grained github pats over using the classic pat.

We have discovered a few issues with creating pull requests across orgs, in particular making a pull request from fork in the azure-sdk bot account into another org like MicrosoftDocs or dotnet does not work. This is because the fine grain tokens are scoped to a single org. This can kind of work for public repos if you don't use a token but this does not work at all for private repos, see https://github.com/orgs/community/discussions/24549. 