### PR TITLE
Add java io.clientcore groupid

### DIFF
--- a/eng/scripts/Query-Azure-Packages.ps1
+++ b/eng/scripts/Query-Azure-Packages.ps1
@@ -34,7 +34,7 @@ function Get-android-Packages
 function Get-java-Packages
 {
   # Rest API docs https://search.maven.org/classic/#api
-  $baseMavenQueryUrl = "https://search.maven.org/solrsearch/select?q=g:com.microsoft.azure*%20OR%20g:com.azure*&rows=100&wt=json"
+  $baseMavenQueryUrl = "https://search.maven.org/solrsearch/select?q=g:com.microsoft.azure*%20OR%20g:com.azure*%20OR%20g:io.clientcore&rows=100&wt=json"
   $mavenQuery = Invoke-RestMethod $baseMavenQueryUrl -MaximumRetryCount 3
 
   Write-Host "Found $($mavenQuery.response.numFound) java packages on maven packages"
@@ -50,6 +50,14 @@ function Get-java-Packages
   }
 
   $repoTags = GetPackageVersions "java"
+  
+  foreach ($tag in $repoTags.Keys)
+  {
+    if ($packages.Package -notcontains $tag) {
+      $version = [AzureEngSemanticVersion]::SortVersions($repoTags[$tag].Versions)[0]
+      Write-Warning "${tag}_${version} - Didn't find this package using the maven search $baseMavenQueryUrl"
+    }
+  }
 
   foreach ($package in $packages)
   {


### PR DESCRIPTION
This adds the io.clientcore packages as well as outputs a warning for any packages we find a release tag for but didn't get from our maven query. There appears to be some issues (hopefully temporarily) where the search api doesn't return any packages that only have a single version published.