### PR TITLE
Update display name for Python Monitor Query package

### DIFF
--- a/_data/releases/latest/python-packages.csv
+++ b/_data/releases/latest/python-packages.csv
@@ -72,7 +72,7 @@
 "azure-mixedreality-authentication","","1.0.0b1","Mixed Reality Authentication","Mixed Reality","mixedreality","","","client","true","","","","11/12/2021","","","","","","","",""
 "azure-iot-modelsrepository","","1.0.0b2","Models Repository","IoT","modelsrepository","","NA","client","true","","","","04/27/2021","deprecated","02/23/2024","","NA","NA","","",""
 "azure-monitor-ingestion","1.1.0","","Monitor Ingestion","Monitor","monitor","","","client","true","","07/18/2025","02/16/2023","07/15/2022","","","","","","","",""
-"azure-monitor-query","2.0.0","","Monitor Query","Monitor","monitor","","","client","true","","07/30/2025","10/06/2021","06/10/2021","","","","","","","",""
+"azure-monitor-query","2.0.0","","Monitor Query Logs","Monitor","monitor","","","client","true","","07/30/2025","10/06/2021","06/10/2021","","","","","","","",""
 "azure-monitor-querymetrics","1.0.0","","Monitor Query Metrics","Monitor","monitor","","NA","client","true","","07/28/2025","07/28/2025","","","","","","","","",""
 "azure-monitor-opentelemetry-exporter","","1.0.0b41","OpenTelemetry Exporter","Monitor","monitor","","","client","true","","","","02/11/2021","","","","","","","",""
 "azure-ai-personalizer","","1.0.0b1","Personalizer","Cognitive Services","personalizer","NA","","client","true","","","","11/07/2022","","","","","","","",""


### PR DESCRIPTION
This package now only contains Logs APIs. Renaming it accordingly.