### PR TITLE
Deprecate Monitor Query package for JS

### DIFF
--- a/_data/releases/latest/js-packages.csv
+++ b/_data/releases/latest/js-packages.csv
@@ -95,7 +95,7 @@
 "@azure/microsoft-playwright-testing","","1.0.0-beta.7","Microsoft Playwright Testing","Microsoft Playwright Testing","playwrighttesting","","","client","true","","","","11/18/2024","","","","","","playwright-testing","",""
 "@azure/mixed-reality-authentication","","1.0.0-beta.1","Mixed Reality Authentication","Mixed Reality","mixedreality","","","client","true","","","","09/20/2021","","","","","","","",""
 "@azure/monitor-ingestion","1.2.0","","Monitor Ingestion","Monitor","monitor","","","client","true","","07/16/2025","02/17/2023","07/19/2022","","","","","","","",""
-"@azure/monitor-query","1.3.3","","Monitor Query","Monitor","monitor","","","client","true","","08/12/2025","10/07/2021","06/08/2021","","","","","","","",""
+"@azure/monitor-query","1.3.3","","Monitor Query","Monitor","monitor","","","client","true","","08/12/2025","10/07/2021","06/08/2021","deprecated","08/12/2025","","@azure/arm-monitor, @azure/monitor-query-logs, @azure/monitor-query-metrics","https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/monitor/MIGRATION_QUERY.md","","",""
 "@azure/monitor-query-logs","1.0.0","","Monitor Query Logs","Monitor","monitor","","NA","client","true","","07/30/2025","07/30/2025","","","","","","","","",""
 "@azure/monitor-query-metrics","1.0.0","","Monitor Query Metrics","Monitor","monitor","","NA","client","true","","07/31/2025","07/31/2025","","","","","","","","",""
 "@azure/notification-hubs","2.0.0","","Notification Hubs","Notification Hubs","notificationhubs","","NA","client","true","","10/14/2024","02/29/2024","08/05/2022","","","","","","","",""


### PR DESCRIPTION
The package was split as part of the TypeSpec conversion. Marked as deprecated and no longer supported, due to Azure policy violations.