### PR TITLE
Deprecate Monitor Query package for Java

### DIFF
--- a/_data/releases/latest/java-packages.csv
+++ b/_data/releases/latest/java-packages.csv
@@ -90,7 +90,7 @@
 "azure-mixedreality-authentication","com.azure","1.2.34","","Mixed Reality Authentication","Mixed Reality","mixedreality","","","client","true","","08/01/2025","02/26/2021","02/23/2021","active","","","","","","",""
 "azure-iot-modelsrepository","com.azure","","1.0.0-beta.1","Models Repository","IoT","modelsrepository","","NA","client","true","","","","03/30/2021","","","false","","","","",""
 "azure-monitor-ingestion","com.azure","1.2.11","","Monitor Ingestion","Monitor","monitor","","","client","true","","07/23/2025","02/16/2023","06/17/2022","","","","","","","",""
-"azure-monitor-query","com.azure","1.5.9","","Monitor Query","Monitor","monitor","","","client","true","","08/12/2025","10/07/2021","06/09/2021","","","","","","","",""
+"azure-monitor-query","com.azure","1.5.9","","Monitor Query","Monitor","monitor","","","client","true","","08/12/2025","10/07/2021","06/09/2021","deprecated","08/12/2025","","com.azure/azure-monitor-query-logs, com.azure/azure-monitor-query-metrics, com.azure.resourcemanager/azure-resourcemanager-monitor","https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/monitor/migration-guide-query.md","","",""
 "azure-monitor-query-logs","com.azure","1.0.0","","Monitor Query Logs","Monitor","monitor","","","client","true","","07/29/2025","07/25/2025","","","","","","","","",""
 "azure-monitor-query-metrics","com.azure","1.0.0","","Monitor Query Metrics","Monitor","monitor","","","client","true","","07/31/2025","07/30/2025","","","","","","","","",""
 "azure-ai-openai","com.azure","","1.0.0-beta.16","OpenAI","Cognitive Services","openai","","","client","true","","","","05/22/2023","active","","","","","","",""


### PR DESCRIPTION
Mark the package as deprecated and link to the 3 replacement packages