### PR TITLE
Fix condition in GetServiceLifeCycle function

### DIFF
--- a/eng/scripts/Update-Spec-Versions.ps1
+++ b/eng/scripts/Update-Spec-Versions.ps1
@@ -39,7 +39,7 @@ function ResolveToSpecFolder($specPath, $jsonPath)
 function GetServiceLifeCycle($allSpecs, $serviceFamily, $resourcePath)
 {
   $stableSpecs = $allSpecs.Where({ 
-    $_.ServiceFamily -eq $serviceFamily -and $_.ResourcePath -eq $resourcePath -and $_.VersionType -eq "stable" -and $_.IsTypeSpec -ne "True"
+    $_.ServiceFamily -eq $serviceFamily -and $_.ResourcePath -eq $resourcePath -and $_.VersionType -eq "stable"
   })
 
   if ($stableSpecs.Count -eq 0) {


### PR DESCRIPTION
With all the TypeSpec conversions of older specs we should remove that from the condition. We will only return brownfield if there are no existing stable versions.