### PR TITLE
Deprecate Azure.Monitor.Query package

### DIFF
--- a/_data/releases/latest/dotnet-packages.csv
+++ b/_data/releases/latest/dotnet-packages.csv
@@ -77,7 +77,7 @@
 "Azure.MixedReality.Authentication","1.2.0","","Mixed Reality Authentication","Mixed Reality","mixedreality","","","client","true","","09/09/2022","02/23/2021","02/10/2021","active","","","","","","",""
 "Azure.IoT.ModelsRepository","","1.0.0-preview.6","Models Repository","IoT","modelsrepository","","NA","client","true","","","","03/10/2021","","","","","","","",""
 "Azure.Monitor.Ingestion","1.2.0","","Monitor Ingestion","Monitor","monitor","","","client","true","","08/05/2025","02/21/2023","07/07/2022","","","","","","","",""
-"Azure.Monitor.Query","1.7.1","","Monitor Query","Monitor","monitor","","","client","true","","08/12/2025","10/07/2021","06/07/2021","","","","","","","",""
+"Azure.Monitor.Query","1.7.1","","Monitor Query","Monitor","monitor","","","client","true","","08/12/2025","10/07/2021","06/07/2021","deprecated","10/16/2025","","Azure.Monitor.Query.Logs,Azure.Monitor.Query.Metrics,Azure.ResourceManager.Monitor","https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/monitor/MigrationGuide_Query.md","","",""
 "Azure.Developer.MicrosoftPlaywrightTesting.NUnit","","1.0.0-beta.4","NUnit ? Microsoft Playwright Testing","Microsoft Playwright Testing","playwrighttesting","NA","","client","true","","","","10/23/2024","deprecated","03/08/2026","","Azure.Developer.Playwright.NUnit","https://aka.ms/mpt/migration-guidance","playwright-testing","",""
 "Azure.Analytics.OnlineExperimentation","","1.0.0-beta.1","Online Experimentation","Online Experimentation","onlineexperimentation","","NA","client","true","","","","06/11/2025","","","","","","","",""
 "Azure.AI.OpenAI.Assistants","","1.0.0-beta.4","OpenAI Assistants","Cognitive Services","openai","","","client","true","","","","02/01/2024","","","","","","","",""


### PR DESCRIPTION
`Azure.Monitor.Query` was split as part of the TypeSpec conversion. Now that the replacement packages have shipped, it's time to deprecate the monolithic package. It's already deprecated on nuget.org.