### PR TITLE
Fix string splitting method for artifactId extraction

### DIFF
--- a/eng/scripts/Query-Azure-Packages.ps1
+++ b/eng/scripts/Query-Azure-Packages.ps1
@@ -74,7 +74,7 @@ function Get-java-Packages
   {
     $artifactId = $tag
     if ($tag.Contains("+")) {
-      $_, $artifactId = $tag -split "+"
+      $_, $artifactId = $tag.Split("+")
     }
 
     if ($packages.Package -notcontains $artifactId) {


### PR DESCRIPTION
In PS `-split` uses regex so `+` doesn't work. We don't need regex so just use the string Split function instead.