### PR TITLE
Fix Maven Central search query syntax for Java packages

### DIFF
--- a/eng/scripts/Query-Azure-Packages.ps1
+++ b/eng/scripts/Query-Azure-Packages.ps1
@@ -50,7 +50,7 @@ function Get-java-Packages
     "io.clientcore"
   )
   $groupIds = $groupIds | % { "g:" + $_ }
-  $groupIdQuery = $groupIds -join "+"
+  $groupIdQuery = $groupIds -join "+OR+"
   $baseMavenQueryUrl = "https://central.sonatype.com/solrsearch/select?q=${groupIdQuery}&rows=100&wt=json"
   Write-Host "Calling $baseMavenQueryUrl"
   $mavenQuery = Invoke-RestMethod $baseMavenQueryUrl -MaximumRetryCount 3 -UserAgent $userAgent -Headers $headers


### PR DESCRIPTION
## Problem

The `Update packages from package manager` pipeline step fails with:

```
Calling https://central.sonatype.com/solrsearch/select?q=g:com.azure+g:com.azure.cosmos.kafka+...&rows=100&wt=json
Exception: Response status code does not indicate success: 400 ().
Maven search appears to be down currently, so java and android updates might not complete successfully.
```

## Root Cause

The Maven Central `solrsearch/select` API no longer accepts implicit space-separated group queries (`g:X g:Y`). It now requires explicit `OR` operators between group terms.

The current query joins group IDs with `+` (URL-encoded space), producing:
```
q=g:com.azure g:com.azure.cosmos.kafka g:...
```

This is interpreted as an AND of all group constraints (impossible for a single artifact), resulting in a 400 Bad Request.

## Fix

Changed the join delimiter from `+` to `+OR+` so the query becomes:
```
q=g:com.azure OR g:com.azure.cosmos.kafka OR ...
```

**Verified locally:**
- Old URL -> HTTP 400
- New URL -> 897 packages returned successfully

Only the `Get-java-Packages` function is affected. `Get-android-Packages` queries a single group and is unaffected.