### PR TITLE
Fix reflected XSS in Tipue Search via query parameter

### DIFF
--- a/js/tipuesearch.min.js
+++ b/js/tipuesearch.min.js
@@ -1,4 +1,5 @@
 (function ($) {
+    function escapeHtml(s) { return String(s).replace(/[&<>"']/g, function (c) { return ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]; }); }
     $.fn.tipuesearch = function (options) {
         var set = $.extend({ 'contentLocation': 'tipuesearch_content.json', 'contextBuffer': 60, 'contextLength': 60, 'contextStart': 90, 'debug': false, 'descriptiveWords': 25, 'highlightTerms': true, 'liveContent': '*', 'liveDescription': '*', 'minimumLength': 3, 'mode': 'static', 'newWindow': false, 'show': 9, 'showContext': true, 'showRelated': true, 'showTime': true, 'showTitleCount': true, 'showURL': true, 'wholeWords': true }, options); return this.each(function () {
             var tipuesearch_in = { pages: [] }; $.ajaxSetup({ async: false }); var tipuesearch_t_c = 0; $('#tipue_search_content').hide().html('<div class="tipue_search_spinner"><div class="tipue_search_rect1"></div><div class="tipue_search_rect2"></div><div class="rect3"></div></div>').show(); if (set.mode == 'live') {
@@ -86,7 +87,7 @@
                     }
                     if (c != 0) {
                         if (set.showTitleCount && tipuesearch_t_c == 0) { var title = document.title; document.title = '(' + c + ') ' + title; tipuesearch_t_c++; }
-                        if (show_replace) { out += '<div id="tipue_search_warning">' + tipuesearch_string_2 + ' ' + d + '. ' + tipuesearch_string_3 + ' <a id="tipue_search_replaced">' + d_r + '</a></div>'; }
+                        if (show_replace) { out += '<div id="tipue_search_warning">' + tipuesearch_string_2 + ' ' + escapeHtml(d) + '. ' + tipuesearch_string_3 + ' <a id="tipue_search_replaced">' + escapeHtml(d_r) + '</a></div>'; }
                         if (c == 1) { out += '<div id="tipue_search_results_count">' + tipuesearch_string_4; }
                         else { c_c = c.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ","); out += '<div id="tipue_search_results_count">' + c_c + ' ' + tipuesearch_string_5; }
                         if (set.showTime) { var endTimer = new Date().getTime(); var time = (endTimer - startTimer) / 1000; out += ' (' + time.toFixed(2) + ' ' + tipuesearch_string_14 + ')'; set.showTime = false; }
@@ -123,7 +124,7 @@
                             f = 0; for (var i = 0; i < tipuesearch_related.searches.length; i++) {
                                 if (d == tipuesearch_related.searches[i].search) {
                                     if (show_replace) { d_o = d; }
-                                    if (!f) { out += '<div class="tipue_search_related_title">' + tipuesearch_string_15 + ' <span class="tipue_search_related_bold">' + d_o + '</span></div><div class="tipue_search_related_cols">'; }
+                                    if (!f) { out += '<div class="tipue_search_related_title">' + tipuesearch_string_15 + ' <span class="tipue_search_related_bold">' + escapeHtml(d_o) + '</span></div><div class="tipue_search_related_cols">'; }
                                     out += '<div class="tipue_search_related_text"><a class="tipue_search_related" id="' + tipuesearch_related.searches[i].related + '">'; if (tipuesearch_related.searches[i].before) { out += '<span class="tipue_search_related_before">' + tipuesearch_related.searches[i].before + '</span> '; }
                                     out += tipuesearch_related.searches[i].related; if (tipuesearch_related.searches[i].after) { out += ' <span class="tipue_search_related_after">' + tipuesearch_related.searches[i].after + '</span>'; }
                                     out += '</a></div>'; f++;


### PR DESCRIPTION
Add escapeHtml() to sanitize user-controlled strings (d, d_r, d_o) before they are concatenated into HTML and injected via .html(). This prevents attackers from executing arbitrary JavaScript through crafted search URLs.