### PR TITLE
Fix broken link in the .NET release notes

### DIFF
--- a/_data/releases/2026-03/dotnet.yml
+++ b/_data/releases/2026-03/dotnet.yml
@@ -244,7 +244,7 @@ entries:
   ChangelogContent: |-
     #### Features Added
 
-    - Added experimental `Microsoft.Extensions.Configuration` and `Microsoft.Extensions.DependencyInjection` integration for Azure SDK clients. For details, see the [Configuration and Dependency Injection](https://github.com/Azure/azure-sdk-for-net/blob/release/Azure.Identity_1.18.0/sdk/core/Azure.Core/src/docs/ConfigurationAndDependencyInjection.md) documentation.
+    - Added experimental `Microsoft.Extensions.Configuration` and `Microsoft.Extensions.DependencyInjection` integration for Azure SDK clients.
 
     - The `WorkloadIdentityCredentialOptions.IsAzureProxyEnabled` property, which enables Azure Kubernetes token proxy mode, is only available in beta releases of this package.
 


### PR DESCRIPTION
The removed link is no longer valid and breaking Verify site CI across the repo.