### PR TITLE
Revert "Bump picomatch from 2.3.1 to 2.3.2 in /eng/common/tsp-client"

### DIFF
--- a/eng/common/tsp-client/package-lock.json
+++ b/eng/common/tsp-client/package-lock.json
@@ -1778,9 +1778,9 @@
       "peer": true
     },
     "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "license": "MIT",
       "peer": true,
       "engines": {


### PR DESCRIPTION
Reverts Azure/azure-sdk#9785