### PR TITLE
[Python] Mark azure-cognitiveservices-personalizer as deprecated

### DIFF
--- a/_data/releases/latest/python-packages.csv
+++ b/_data/releases/latest/python-packages.csv
@@ -554,7 +554,7 @@
 "msrestazure","","0.6.4","MsRest Azure","Other","https://github.com/Azure/msrestazure-for-python/tree/v0.6.4/msrestazure","NA","NA","client","false","","","","","deprecated","11/8/2022","true","NA","NA","","",""
 "azure-cognitiveservices-search-newssearch","2.0.0","","News Search","News Search","cognitiveservices","NA","NA","client","false","","","","","deprecated","06/26/2024","","NA","NA","","",""
 "azure-opentelemetry-exporter-azuremonitor","","1.0.0b2","OpenTelemetry Exporter","Monitor","NA","NA","NA","client","false","","","","","deprecated","1/31/2021","","azure-monitor-opentelemetry-exporter","NA","","",""
-"azure-cognitiveservices-personalizer","","0.1.1","Personalizer","Cognitive Services","cognitiveservices","NA","NA","client","false","","","","","maintenance","","","","","","",""
+"azure-cognitiveservices-personalizer","","0.1.1","Personalizer","Cognitive Services","cognitiveservices","NA","NA","client","false","","","","","deprecated","10/01/2026","","NA","NA","","",""
 "azure-purview-administration","","1.0.0b1","Purview Administration","Purview","purview","NA","NA","client","false","","","","","","","","","","","",""
 "azure-cognitiveservices-knowledge-qnamaker","","0.3.1","Question Answering","Cognitive Services","cognitiveservices","","","client","false","","","","","deprecated","08/13/2024","","azure-ai-language-questionanswering","https://aka.ms/azsdk/python/migrate/azure-ai-language-questionanswering","","",""
 "azure-search","","1.0.0b2","Search","Search","search","NA","NA","client","false","","","","","deprecated","3/31/2023","true","azure-search-documents","NA","cognitive-search","",""


### PR DESCRIPTION
Update `python-packages.csv` to mark `azure-cognitiveservices-personalizer` as deprecated.

### Changes
- `Support`: `maintenance` → `deprecated`
- `EOLDate`: `10/01/2026`
- `Replace`: `NA` (no replacement package)
- `ReplaceGuide`: `NA`

Ref: [Deprecation process](https://github.com/Azure/azure-sdk-for-python/blob/main/doc/deprecation_process.md#update-ms-learn-docs)