### PR TITLE
Transition to GitHub App auth, remove azuresdk-github-pat usage

### DIFF
--- a/eng/pipelines/generate-release-structure.yml
+++ b/eng/pipelines/generate-release-structure.yml
@@ -23,3 +23,4 @@ steps:
     CommitMsg: "Add new release folder structure"
     PRTitle: "Add new release folder structure"
     PushArgs: -f
+    AuthToken: ''

--- a/eng/pipelines/template/steps/generate-releasenotes.yml
+++ b/eng/pipelines/template/steps/generate-releasenotes.yml
@@ -82,7 +82,7 @@ steps:
   - pwsh: |
       git clone https://github.com/Azure/azure-sdk.git $(AzureSDKReleaseNotesClonePath)
       cd $(AzureSDKReleaseNotesClonePath)
-      git remote add azure-sdk-fork "https://x-access-token:$(GH_TOKEN)@github.com/azure-sdk/azure-sdk.git"
+      git remote add azure-sdk-fork "https://x-access-token:$(GH_TOKEN)@github.com/Azure/azure-sdk.git"
     displayName: Clone azure-sdk for release notes
     condition: and(succeeded(), ne(variables['AzureSDKReleaseNotesClonePath'], variables['AzureSDKClonePath']))
 
@@ -104,8 +104,8 @@ steps:
           Write-Host "git fetch $RemoteName $PRBranchName"
           git fetch $RemoteName $PRBranchName
 
-          Write-Host "git checkout $PRBranchName."
-          git checkout $PRBranchName
+          Write-Host "git checkout -B $PRBranchName $RemoteName/$PRBranchName."
+          git checkout -B $PRBranchName "$RemoteName/$PRBranchName"
         }
         else {
           # Reset back to the head of default so we can build on top of that if the branch doesn't already exist.
@@ -133,6 +133,7 @@ steps:
     - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
       parameters:
         RepoName: azure-sdk
+        PROwner: Azure
         BaseBranchName: $(DefaultBranch)
         PRBranchName: $(PRBranchName)
         CommitMsg: "${{ repo.value.Language }} release notes for the $(ReleasePeriod) release"

--- a/eng/pipelines/template/steps/generate-releasenotes.yml
+++ b/eng/pipelines/template/steps/generate-releasenotes.yml
@@ -77,15 +77,17 @@ steps:
       Write-Host "[ReleaseStartDate]$releaseStartDate"
     displayName: Set Release Period Value
 
+  - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+
   - pwsh: |
       git clone https://github.com/Azure/azure-sdk.git $(AzureSDKReleaseNotesClonePath)
       cd $(AzureSDKReleaseNotesClonePath)
-      git remote add azure-sdk-fork "https://x-access-token:$(azuresdk-github-pat)@github.com/azure-sdk/azure-sdk.git"
+      git remote add azure-sdk-fork "https://x-access-token:$(GH_TOKEN)@github.com/azure-sdk/azure-sdk.git"
     displayName: Clone azure-sdk for release notes
     condition: and(succeeded(), ne(variables['AzureSDKReleaseNotesClonePath'], variables['AzureSDKClonePath']))
 
   - pwsh: |
-      ./eng/common/scripts/Delete-RemoteBranches.ps1 -RepoId "azure-sdk/azure-sdk" -BranchRegex '^${{ parameters.PrBranchName }}.*' -AuthToken $(azuresdk-github-pat)
+      ./eng/common/scripts/Delete-RemoteBranches.ps1 -RepoId "azure-sdk/azure-sdk" -BranchRegex '^${{ parameters.PrBranchName }}.*' -AuthToken $(GH_TOKEN)
     displayName: Clean Up Stale Branches
 
   - ${{ each repo in parameters.Repos }}:
@@ -126,7 +128,7 @@ steps:
           -releaseStartDate $(ReleaseStartDate)
           -releaseDirectory $(AzureSDKReleaseNotesClonePath)/_data/releases
           -repoLanguage ${{ repo.value.Language }}
-          -github_pat '$(azuresdk-github-pat)'
+          -github_pat '$(GH_TOKEN)'
 
     - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
       parameters:
@@ -137,6 +139,7 @@ steps:
         PRTitle: "${{ repo.value.Language }} release notes for the $(ReleasePeriod) release"
         PRBody: "This is an automated pull request to gather the ${{ repo.value.Language }} release notes for the $(ReleasePeriod) release. See [Producing Release Notes](https://github.com/Azure/azure-sdk/blob/main/docs/policies/releasenotes.md#producing-release-notes) for details of the processing."
         WorkingDirectory: $(AzureSDKReleaseNotesClonePath)
+        AuthToken: ''
 
     - pwsh: |
         gh pr merge $(Submitted.PullRequest.Number) --auto --squash
@@ -144,4 +147,4 @@ steps:
       displayName: Apply AutoMerge to Pull Request
       workingDirectory: $(AzureSDKReleaseNotesClonePath)
       env:
-        GH_TOKEN: $(azuresdk-github-pat)
+        GH_TOKEN: $(GH_TOKEN)

--- a/eng/pipelines/version-updater.yml
+++ b/eng/pipelines/version-updater.yml
@@ -20,13 +20,15 @@ jobs:
   - checkout: self
     path: azure-sdk
 
+  - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+    
   - task: PowerShell@2
     displayName: Update packages from package manager
     inputs:
       pwsh: true
       filePath: $(AzureSDKClonePath)/eng/scripts/Query-Azure-Packages.ps1
       arguments: >
-        -github_pat '$(azuresdk-github-pat)'
+        -github_pat '$(GH_TOKEN)'
         -nuget_pat '$(azure-sdk-nuget-pat)'
         -updateDeprecated ($${{ parameters.UpdateDeprecated }} -or ((Get-Date).DayOfWeek -eq "Sunday"))
 
@@ -36,7 +38,7 @@ jobs:
       pwsh: true
       filePath: $(AzureSDKClonePath)/eng/scripts/Update-Release-Versions.ps1
       arguments: >
-        -github_pat '$(azuresdk-github-pat)'
+        -github_pat '$(GH_TOKEN)'
 
   - task: AzureCLI@2
     displayName: Update release DevOps work-items
@@ -46,11 +48,11 @@ jobs:
       scriptLocation: inlineScript
       inlineScript: |
         $(AzureSDKClonePath)/eng/scripts/Update-DevOps-WorkItems.ps1 `
-          -github_pat '$(azuresdk-github-pat)'
+          -github_pat '$(GH_TOKEN)'
 
   - pwsh: |
       # Some steps, like release notes, require this remote all the time so lets always setup even if there are no changes
-      git remote add azure-sdk-fork "https://x-access-token:$(azuresdk-github-pat)@github.com/azure-sdk/azure-sdk.git"
+      git remote add azure-sdk-fork "https://x-access-token:$(GH_TOKEN)@github.com/azure-sdk/azure-sdk.git"
     displayName: Setup azure-sdk-fork remote
     workingDirectory: $(AzureSDKClonePath)
 
@@ -61,7 +63,7 @@ jobs:
     workingDirectory: $(AzureSDKClonePath)
 
   - pwsh: |
-      git clone https://$(azuresdk-github-pat)@github.com/Azure/azure-rest-api-specs $(Pipeline.Workspace)/azure-rest-api-specs
+      git clone https://x-access-token:$(GH_TOKEN)@github.com/Azure/azure-rest-api-specs $(Pipeline.Workspace)/azure-rest-api-specs
     displayName: Clone azure-rest-api-specs repo
 
   - task: PowerShell@2
@@ -91,6 +93,7 @@ jobs:
       PRTitle: "Update package index with latest published versions"
       PushArgs: -f
       WorkingDirectory: $(AzureSDKClonePath)
+      AuthToken: ''
 
   - pwsh: |
       gh pr merge $(Submitted.PullRequest.Number) --auto --squash
@@ -98,12 +101,12 @@ jobs:
     displayName: Apply AutoMerge to Pull Request
     workingDirectory: $(AzureSDKClonePath)
     env:
-      GH_TOKEN: $(azuresdk-github-pat)
+      GH_TOKEN: $(GH_TOKEN)
 
   - template: template/steps/generate-releasenotes.yml
 
   - pwsh: |
-      git clone https://$(azuresdk-github-pat)@github.com/MicrosoftDocs/azure-dev-docs-pr $(Pipeline.Workspace)/azure-dev-docs-pr
+      git clone https://x-access-token:$(GH_TOKEN)@github.com/MicrosoftDocs/azure-dev-docs-pr $(Pipeline.Workspace)/azure-dev-docs-pr
     displayName: Clone azure-dev-docs-pr repo
 
   - task: PowerShell@2
@@ -130,9 +133,10 @@ jobs:
       PRTitle: "Update package index with latest published versions"
       PushArgs: -f
       WorkingDirectory: $(Pipeline.Workspace)/azure-dev-docs-pr
+      AuthToken: ''
 
   - pwsh: |
-      git clone https://$(azuresdk-github-pat)@github.com/Azure/azure-rest-api-specs-pr $(Pipeline.Workspace)/azure-rest-api-specs-pr --branch RPSaaSMaster
+      git clone https://x-access-token:$(GH_TOKEN)@github.com/Azure/azure-rest-api-specs-pr $(Pipeline.Workspace)/azure-rest-api-specs-pr --branch RPSaaSMaster
     displayName: Clone azure-rest-api-specs-pr repo
 
   - task: PowerShell@2
@@ -185,3 +189,4 @@ jobs:
       PRTitle: "Update package index with latest published versions"
       PushArgs: -f
       WorkingDirectory: $(Pipeline.Workspace)/dotnet-docs
+      AuthToken: ''

--- a/eng/pipelines/version-updater.yml
+++ b/eng/pipelines/version-updater.yml
@@ -21,14 +21,18 @@ jobs:
     path: azure-sdk
 
   - template: /eng/common/pipelines/templates/steps/login-to-github.yml
-    
+    parameters:
+      TokenOwners:
+        - Azure
+        - MicrosoftDocs
+
   - task: PowerShell@2
     displayName: Update packages from package manager
     inputs:
       pwsh: true
       filePath: $(AzureSDKClonePath)/eng/scripts/Query-Azure-Packages.ps1
       arguments: >
-        -github_pat '$(GH_TOKEN)'
+        -github_pat '$(GH_TOKEN_Azure)'
         -nuget_pat '$(azure-sdk-nuget-pat)'
         -updateDeprecated ($${{ parameters.UpdateDeprecated }} -or ((Get-Date).DayOfWeek -eq "Sunday"))
 
@@ -38,7 +42,7 @@ jobs:
       pwsh: true
       filePath: $(AzureSDKClonePath)/eng/scripts/Update-Release-Versions.ps1
       arguments: >
-        -github_pat '$(GH_TOKEN)'
+        -github_pat '$(GH_TOKEN_Azure)'
 
   - task: AzureCLI@2
     displayName: Update release DevOps work-items
@@ -48,11 +52,11 @@ jobs:
       scriptLocation: inlineScript
       inlineScript: |
         $(AzureSDKClonePath)/eng/scripts/Update-DevOps-WorkItems.ps1 `
-          -github_pat '$(GH_TOKEN)'
+          -github_pat '$(GH_TOKEN_Azure)'
 
   - pwsh: |
       # Some steps, like release notes, require this remote all the time so lets always setup even if there are no changes
-      git remote add azure-sdk-fork "https://x-access-token:$(GH_TOKEN)@github.com/azure-sdk/azure-sdk.git"
+      git remote add azure-sdk-fork "https://x-access-token:$(GH_TOKEN_Azure)@github.com/Azure/azure-sdk.git"
     displayName: Setup azure-sdk-fork remote
     workingDirectory: $(AzureSDKClonePath)
 
@@ -63,7 +67,7 @@ jobs:
     workingDirectory: $(AzureSDKClonePath)
 
   - pwsh: |
-      git clone https://x-access-token:$(GH_TOKEN)@github.com/Azure/azure-rest-api-specs $(Pipeline.Workspace)/azure-rest-api-specs
+      git clone https://x-access-token:$(GH_TOKEN_Azure)@github.com/Azure/azure-rest-api-specs $(Pipeline.Workspace)/azure-rest-api-specs
     displayName: Clone azure-rest-api-specs repo
 
   - task: PowerShell@2
@@ -88,6 +92,7 @@ jobs:
     parameters:
       BaseBranchName: $(DefaultBranch)
       RepoName: azure-sdk
+      PROwner: Azure
       PRBranchName: PackageVersionUpdates
       CommitMsg: "Update package index with latest published versions"
       PRTitle: "Update package index with latest published versions"
@@ -101,12 +106,11 @@ jobs:
     displayName: Apply AutoMerge to Pull Request
     workingDirectory: $(AzureSDKClonePath)
     env:
-      GH_TOKEN: $(GH_TOKEN)
-
+      GH_TOKEN: $(GH_TOKEN_Azure)
   - template: template/steps/generate-releasenotes.yml
 
   - pwsh: |
-      git clone https://x-access-token:$(GH_TOKEN)@github.com/MicrosoftDocs/azure-dev-docs-pr $(Pipeline.Workspace)/azure-dev-docs-pr
+      git clone https://x-access-token:$(GH_TOKEN_MicrosoftDocs)@github.com/MicrosoftDocs/azure-dev-docs-pr $(Pipeline.Workspace)/azure-dev-docs-pr
     displayName: Clone azure-dev-docs-pr repo
 
   - task: PowerShell@2
@@ -127,6 +131,7 @@ jobs:
     parameters:
       BaseBranchName: $(DefaultBranch)
       RepoOwner: MicrosoftDocs
+      PROwner: MicrosoftDocs
       RepoName: azure-dev-docs-pr
       PRBranchName: PackageIndexUpdates
       CommitMsg: "Update package index with latest published versions"
@@ -136,7 +141,7 @@ jobs:
       AuthToken: ''
 
   - pwsh: |
-      git clone https://x-access-token:$(GH_TOKEN)@github.com/Azure/azure-rest-api-specs-pr $(Pipeline.Workspace)/azure-rest-api-specs-pr --branch RPSaaSMaster
+      git clone https://x-access-token:$(GH_TOKEN_Azure)@github.com/Azure/azure-rest-api-specs-pr $(Pipeline.Workspace)/azure-rest-api-specs-pr --branch RPSaaSMaster
     displayName: Clone azure-rest-api-specs-pr repo
 
   - task: PowerShell@2
@@ -183,6 +188,7 @@ jobs:
     parameters:
       BaseBranchName: $(DefaultBranch)
       RepoOwner: dotnet
+      PROwner: dotnet
       RepoName: docs
       PRBranchName: PackageIndexUpdates
       CommitMsg: "Update package index with latest published versions"


### PR DESCRIPTION
This pull request updates several pipeline YAML files to standardize the use of the `GH_TOKEN` secret for GitHub authentication, replacing the previously used `azuresdk-github-pat`. It also ensures that GitHub authentication steps are consistently included, and adds the `AuthToken` parameter where needed for pull request creation steps. These changes improve security and consistency across release and version updater pipelines.

**Authentication updates and consistency:**

* Replaced all uses of `azuresdk-github-pat` with `GH_TOKEN` for GitHub authentication in scripts, git commands, and environment variables in `eng/pipelines/version-updater.yml` and `eng/pipelines/template/steps/generate-releasenotes.yml`. This includes updating git clone URLs to use the `x-access-token` format. [[1]](diffhunk://#diff-0ee0d677b86f3952b7f56dabc3c38794abf144f15ed5d8ecbea0161d90f71df6R23-R31) [[2]](diffhunk://#diff-0ee0d677b86f3952b7f56dabc3c38794abf144f15ed5d8ecbea0161d90f71df6L39-R41) [[3]](diffhunk://#diff-0ee0d677b86f3952b7f56dabc3c38794abf144f15ed5d8ecbea0161d90f71df6L49-R55) [[4]](diffhunk://#diff-0ee0d677b86f3952b7f56dabc3c38794abf144f15ed5d8ecbea0161d90f71df6L64-R66) [[5]](diffhunk://#diff-0ee0d677b86f3952b7f56dabc3c38794abf144f15ed5d8ecbea0161d90f71df6R96-R109) [[6]](diffhunk://#diff-0ee0d677b86f3952b7f56dabc3c38794abf144f15ed5d8ecbea0161d90f71df6R136-R139) [[7]](diffhunk://#diff-3e533f9116866e1182ceb0dc188b9c08d4e4a92419cc17faa268839fca121785R80-R90) [[8]](diffhunk://#diff-3e533f9116866e1182ceb0dc188b9c08d4e4a92419cc17faa268839fca121785L129-R131) [[9]](diffhunk://#diff-3e533f9116866e1182ceb0dc188b9c08d4e4a92419cc17faa268839fca121785R142-R150)

* Added the `/eng/common/pipelines/templates/steps/login-to-github.yml` template to jobs in `eng/pipelines/version-updater.yml` and `eng/pipelines/template/steps/generate-releasenotes.yml` to ensure GitHub login is performed before any operations requiring authentication. [[1]](diffhunk://#diff-0ee0d677b86f3952b7f56dabc3c38794abf144f15ed5d8ecbea0161d90f71df6R23-R31) [[2]](diffhunk://#diff-3e533f9116866e1182ceb0dc188b9c08d4e4a92419cc17faa268839fca121785R80-R90)

**Pull request creation improvements:**

* Added the `AuthToken` parameter (set to an empty string) to pull request creation steps to clarify authentication handling and align with updated pipeline templates in both release structure and release notes generation workflows. [[1]](diffhunk://#diff-47d7a8a2561a11daf1932280f13299ad98190878c9df9e3311d94bb858d58487R26) [[2]](diffhunk://#diff-3e533f9116866e1182ceb0dc188b9c08d4e4a92419cc17faa268839fca121785R142-R150) [[3]](diffhunk://#diff-0ee0d677b86f3952b7f56dabc3c38794abf144f15ed5d8ecbea0161d90f71df6R96-R109) [[4]](diffhunk://#diff-0ee0d677b86f3952b7f56dabc3c38794abf144f15ed5d8ecbea0161d90f71df6R136-R139) [[5]](diffhunk://#diff-0ee0d677b86f3952b7f56dabc3c38794abf144f15ed5d8ecbea0161d90f71df6R192)

These changes help to centralize and secure GitHub authentication, reduce duplication, and ensure that all pipeline steps use the correct credentials.


Related to Azure/azure-sdk-tools#9842

Test Pipelines 
[automation - azure-sdk - version-updater](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6410595&view=results) - Passing
[automation - azure-sdk - generate-release-structure](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6366853&view=results) - Passing