### PR TITLE
Remove scottaddie from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -70,30 +70,30 @@
 /_data/                          @ronniegeraghty @weshaggard
 /**/android.md                   @ronniegeraghty @vcolin7 @anuchandy
 /**/android.yml                  @ronniegeraghty @vcolin7 @anuchandy
-/**/android-packages.csv         @ronniegeraghty @weshaggard @vcolin7 @anuchandy @scottaddie
+/**/android-packages.csv         @ronniegeraghty @weshaggard @vcolin7 @anuchandy
 /**/c.md                         @ronniegeraghty @RickWinter
-/**/c-packages.csv               @ronniegeraghty @weshaggard @RickWinter @scottaddie
+/**/c-packages.csv               @ronniegeraghty @weshaggard @RickWinter
 /**/cpp.md                       @ronniegeraghty @antkmsft
 /**/cpp.yml                      @ronniegeraghty @antkmsft
-/**/cpp-packages.csv             @ronniegeraghty @weshaggard @antkmsft @scottaddie
+/**/cpp-packages.csv             @ronniegeraghty @weshaggard @antkmsft
 /**/dotnet.md                    @ronniegeraghty @JonathanCrd
 /**/dotnet.yml                   @ronniegeraghty @JonathanCrd
-/**/dotnet-packages.csv          @ronniegeraghty @weshaggard @JonathanCrd @scottaddie
+/**/dotnet-packages.csv          @ronniegeraghty @weshaggard @JonathanCrd
 /**/ios.md                       @ronniegeraghty @vcolin7 @tjprescott
 /**/ios.yml                      @ronniegeraghty @vcolin7 @tjprescott
-/**/ios-packages.csv             @ronniegeraghty @weshaggard @vcolin7 @tjprescott @scottaddie
+/**/ios-packages.csv             @ronniegeraghty @weshaggard @vcolin7 @tjprescott
 /**/java.md                      @ronniegeraghty @jairmyree
 /**/java.yml                     @ronniegeraghty @jairmyree
-/**/java-packages.csv            @ronniegeraghty @weshaggard @jairmyree @scottaddie
+/**/java-packages.csv            @ronniegeraghty @weshaggard @jairmyree
 /**/js.md                        @ronniegeraghty @timovv
 /**/js.yml                       @ronniegeraghty @timovv
-/**/js-packages.csv              @ronniegeraghty @weshaggard @timovv @scottaddie
+/**/js-packages.csv              @ronniegeraghty @weshaggard @timovv
 /**/python.md                    @ronniegeraghty @kashifkhan
 /**/python.yml                   @ronniegeraghty @kashifkhan
-/**/python-packages.csv          @ronniegeraghty @weshaggard @kashifkhan @scottaddie
+/**/python-packages.csv          @ronniegeraghty @weshaggard @kashifkhan
 /**/go.md                        @ronniegeraghty @gracewilcox
 /**/go.yml                       @ronniegeraghty @gracewilcox
-/**/go-packages.csv              @ronniegeraghty @weshaggard @gracewilcox @scottaddie
+/**/go-packages.csv              @ronniegeraghty @weshaggard @gracewilcox
 /**/rust.md                      @ronniegeraghty @heaths
 /**/rust.yml                     @ronniegeraghty @heaths
 /**/rust-packages.csv            @ronniegeraghty @weshaggard @heaths


### PR DESCRIPTION
Removes `@scottaddie` from CODEOWNERS package CSV ownership rules so those updates no longer request review from that user.

The remaining owners for each affected language package CSV rule are unchanged.