### PR TITLE
Remove Acrolinx documentation guidance

### DIFF
--- a/_includes/refs.md
+++ b/_includes/refs.md
@@ -5,7 +5,6 @@
 [Azure SDK Contributors Guide]: https://review.learn.microsoft.com/en-us/help/platform/reference-document-sdk-client-libraries
 [Microsoft Writing Style Guide]: https://styleguides.azurewebsites.net/StyleGuide/Read?id=2700
 [Microsoft Cloud Style Guide]: https://styleguides.azurewebsites.net/Styleguide/Read?id=2696
-[Acrolinx VS Code extension]: https://aka.ms/azsdk/acrolinx-vscode
 [general-logging]: {{ site.baseurl }}{% link docs/general/implementation.md %}#logging
 [general-distributed-tracing]: {{ site.baseurl }}{% link docs/general/implementation.md %}#distributed-tracing
 [rest-lro]: https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#long-running-operations--jobs

--- a/docs/general/documentation.md
+++ b/docs/general/documentation.md
@@ -24,8 +24,6 @@ There are several documentation deliverables that must be included in or as a co
 * [Microsoft Writing Style Guide].
 * [Microsoft Cloud Style Guide].
 
-{% include requirement/MUST id="general-docs-content-governance" %} use the [Acrolinx VS Code extension] when authoring or editing public-facing Markdown files, such as library READMEs, migration guides, and troubleshooting guides. Changelogs are an exception to this rule. Acrolinx is licensed for use only in the public and private GitHub repos for Tier 1 language SDKs. (MICROSOFT INTERNAL)
-
 {% include requirement/SHOULD id="general-docs-to-silence" %} attempt to document your library into silence. Preempt developers' usage questions and minimize GitHub issues by clearly explaining your API in the docstrings. Include information on service limits and errors they might hit, and how to avoid and recover from those errors.
 
 As you write your code, *doc it so you never hear about it again.* The less questions you have to answer about your client library, the more time you have to build new features for your service.


### PR DESCRIPTION
The Azure SDK guidance should no longer reference Acrolinx. This removes the Acrolinx-specific documentation requirement from the general documentation guidance and drops the now-unused shared reference link.

This is a documentation-only update.