### PR TITLE
Switch to using GitHubApp

### DIFF
--- a/eng/pipelines/version-updater.yml
+++ b/eng/pipelines/version-updater.yml
@@ -20,13 +20,18 @@ jobs:
   - checkout: self
     path: azure-sdk
 
+  - template: /eng/common/pipelines/templates/steps/login-to-github.yml
+    parameters:
+      TokenOwners:
+        - azure
+
   - task: PowerShell@2
     displayName: Update packages from package manager
     inputs:
       pwsh: true
       filePath: $(AzureSDKClonePath)/eng/scripts/Query-Azure-Packages.ps1
       arguments: >
-        -github_pat '$(azuresdk-github-pat)'
+        -github_pat '$(GH_TOKEN)'
         -nuget_pat '$(azure-sdk-nuget-pat)'
         -updateDeprecated ($${{ parameters.UpdateDeprecated }} -or ((Get-Date).DayOfWeek -eq "Sunday"))
 
@@ -36,7 +41,7 @@ jobs:
       pwsh: true
       filePath: $(AzureSDKClonePath)/eng/scripts/Update-Release-Versions.ps1
       arguments: >
-        -github_pat '$(azuresdk-github-pat)'
+        -github_pat '$(GH_TOKEN)'
 
   - task: AzureCLI@2
     displayName: Update release DevOps work-items
@@ -46,11 +51,11 @@ jobs:
       scriptLocation: inlineScript
       inlineScript: |
         $(AzureSDKClonePath)/eng/scripts/Update-DevOps-WorkItems.ps1 `
-          -github_pat '$(azuresdk-github-pat)'
+          -github_pat '$(GH_TOKEN)'
 
   - pwsh: |
       # Some steps, like release notes, require this remote all the time so lets always setup even if there are no changes
-      git remote add azure-sdk-fork "https://x-access-token:$(azuresdk-github-pat)@github.com/azure-sdk/azure-sdk.git"
+      git remote add azure-sdk-fork "https://x-access-token:$(GH_TOKEN)@github.com/azure-sdk/azure-sdk.git"
     displayName: Setup azure-sdk-fork remote
     workingDirectory: $(AzureSDKClonePath)
 
@@ -61,7 +66,7 @@ jobs:
     workingDirectory: $(AzureSDKClonePath)
 
   - pwsh: |
-      git clone https://$(azuresdk-github-pat)@github.com/Azure/azure-rest-api-specs $(Pipeline.Workspace)/azure-rest-api-specs
+      git clone https://$(GH_TOKEN)@github.com/Azure/azure-rest-api-specs $(Pipeline.Workspace)/azure-rest-api-specs
     displayName: Clone azure-rest-api-specs repo
 
   - task: PowerShell@2
@@ -103,7 +108,7 @@ jobs:
   - template: template/steps/generate-releasenotes.yml
 
   - pwsh: |
-      git clone https://$(azuresdk-github-pat)@github.com/MicrosoftDocs/azure-dev-docs-pr $(Pipeline.Workspace)/azure-dev-docs-pr
+      git clone https://$(GH_TOKEN)@github.com/MicrosoftDocs/azure-dev-docs-pr $(Pipeline.Workspace)/azure-dev-docs-pr
     displayName: Clone azure-dev-docs-pr repo
 
   - task: PowerShell@2
@@ -132,7 +137,7 @@ jobs:
       WorkingDirectory: $(Pipeline.Workspace)/azure-dev-docs-pr
 
   - pwsh: |
-      git clone https://$(azuresdk-github-pat)@github.com/Azure/azure-rest-api-specs-pr $(Pipeline.Workspace)/azure-rest-api-specs-pr --branch RPSaaSMaster
+      git clone https://$(GH_TOKEN)@github.com/Azure/azure-rest-api-specs-pr $(Pipeline.Workspace)/azure-rest-api-specs-pr --branch RPSaaSMaster
     displayName: Clone azure-rest-api-specs-pr repo
 
   - task: PowerShell@2
@@ -157,7 +162,7 @@ jobs:
       AZCOPY_AUTO_LOGIN_TYPE: 'PSCRED'
 
   - pwsh: |
-      git clone https://github.com/dotnet/docs $(Pipeline.Workspace)/dotnet-docs
+      git clone https://$(GH_TOKEN)@github.com/dotnet/docs $(Pipeline.Workspace)/dotnet-docs
     displayName: Clone dotnet docs repo
 
   - task: PowerShell@2


### PR DESCRIPTION
This pull request updates the authentication method used in the `eng/pipelines/version-updater.yml` pipeline. The main change is the replacement of the `azuresdk-github-pat` variable with the more generic `GH_TOKEN` for all GitHub operations, and the addition of a login step using a shared template. This standardizes GitHub authentication across all pipeline steps and improves maintainability.

**Authentication updates:**

* Replaced all usages of the `azuresdk-github-pat` variable with `GH_TOKEN` for GitHub authentication in PowerShell scripts, git commands, and repository cloning steps. [[1]](diffhunk://#diff-0ee0d677b86f3952b7f56dabc3c38794abf144f15ed5d8ecbea0161d90f71df6R23-R34) [[2]](diffhunk://#diff-0ee0d677b86f3952b7f56dabc3c38794abf144f15ed5d8ecbea0161d90f71df6L39-R44) [[3]](diffhunk://#diff-0ee0d677b86f3952b7f56dabc3c38794abf144f15ed5d8ecbea0161d90f71df6L49-R58) [[4]](diffhunk://#diff-0ee0d677b86f3952b7f56dabc3c38794abf144f15ed5d8ecbea0161d90f71df6L64-R69) [[5]](diffhunk://#diff-0ee0d677b86f3952b7f56dabc3c38794abf144f15ed5d8ecbea0161d90f71df6L106-R111) [[6]](diffhunk://#diff-0ee0d677b86f3952b7f56dabc3c38794abf144f15ed5d8ecbea0161d90f71df6L135-R140) [[7]](diffhunk://#diff-0ee0d677b86f3952b7f56dabc3c38794abf144f15ed5d8ecbea0161d90f71df6L160-R165)
* Added a step to log in to GitHub using the `/eng/common/pipelines/templates/steps/login-to-github.yml` template, specifying `azure` as a token owner.

These changes help ensure that all GitHub-related steps in the pipeline use a consistent and secure authentication method.

Test Pipeline https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6355047&view=results