### PR TITLE
Add CODEOWNERS entry for .github/skills

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -100,6 +100,7 @@
 ################################################################################
 # Event yml files and CODEOWNERS should be near the bottom of CODEOWNERS files #
 ################################################################################
+/.github/skills/              @Azure/azsdk-cli
 /.github/workflows/           @Azure/azure-sdk-eng
 /.github/CODEOWNERS           @Azure/azure-sdk-eng
 


### PR DESCRIPTION
Adds a CODEOWNERS entry that assigns ownership of skill definitions under `.github/skills/` to the `@Azure/azsdk-cli` team.

The entry is placed alongside the other `.github/` ownership rules near the bottom of the file, following the existing section conventions.