### PR TITLE
Fix links to Microsoft style guides

### DIFF
--- a/_includes/refs.md
+++ b/_includes/refs.md
@@ -4,6 +4,7 @@
 [General Azure SDK Terminology]: {{ site.baseurl }}{% link docs/general/terminology.md %}
 [Azure SDK Contributors Guide]: https://review.learn.microsoft.com/en-us/help/platform/reference-document-sdk-client-libraries
 [Microsoft Writing Style Guide]: https://learn.microsoft.com/en-us/style-guide
+[Microsoft Cloud Style Guide]: https://learn.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/term-collections/cloud-computing-terms
 [general-logging]: {{ site.baseurl }}{% link docs/general/implementation.md %}#logging
 [general-distributed-tracing]: {{ site.baseurl }}{% link docs/general/implementation.md %}#distributed-tracing
 [rest-lro]: https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#long-running-operations--jobs

--- a/_includes/refs.md
+++ b/_includes/refs.md
@@ -3,8 +3,7 @@
 [General Azure SDK Guidelines]: {{ site.baseurl }}{% link docs/general/introduction.md %}
 [General Azure SDK Terminology]: {{ site.baseurl }}{% link docs/general/terminology.md %}
 [Azure SDK Contributors Guide]: https://review.learn.microsoft.com/en-us/help/platform/reference-document-sdk-client-libraries
-[Microsoft Writing Style Guide]: https://styleguides.azurewebsites.net/StyleGuide/Read?id=2700
-[Microsoft Cloud Style Guide]: https://styleguides.azurewebsites.net/Styleguide/Read?id=2696
+[Microsoft Writing Style Guide]: https://learn.microsoft.com/en-us/style-guide
 [general-logging]: {{ site.baseurl }}{% link docs/general/implementation.md %}#logging
 [general-distributed-tracing]: {{ site.baseurl }}{% link docs/general/implementation.md %}#distributed-tracing
 [rest-lro]: https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#long-running-operations--jobs

--- a/_includes/refs.md
+++ b/_includes/refs.md
@@ -3,8 +3,8 @@
 [General Azure SDK Guidelines]: {{ site.baseurl }}{% link docs/general/introduction.md %}
 [General Azure SDK Terminology]: {{ site.baseurl }}{% link docs/general/terminology.md %}
 [Azure SDK Contributors Guide]: https://review.learn.microsoft.com/en-us/help/platform/reference-document-sdk-client-libraries
-[Microsoft Writing Style Guide]: https://learn.microsoft.com/en-us/style-guide
-[Microsoft Cloud Style Guide]: https://learn.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/term-collections/cloud-computing-terms
+[Microsoft Writing Style Guide]: https://learn.microsoft.com/style-guide
+[Microsoft Cloud Style Guide]: https://learn.microsoft.com/style-guide/a-z-word-list-term-collections/term-collections/cloud-computing-terms
 [general-logging]: {{ site.baseurl }}{% link docs/general/implementation.md %}#logging
 [general-distributed-tracing]: {{ site.baseurl }}{% link docs/general/implementation.md %}#distributed-tracing
 [rest-lro]: https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#long-running-operations--jobs


### PR DESCRIPTION
- Content was moved from `styleguides.azurewebsites.net` to `learn.microsoft.com`

Check "Verify Site" is still failing because multiple problems need to be fixed in separate PRs