### PR TITLE
[generate-releasenotes.yml] Fix repository ID in delete remote branches script

### DIFF
--- a/eng/pipelines/template/steps/generate-releasenotes.yml
+++ b/eng/pipelines/template/steps/generate-releasenotes.yml
@@ -87,7 +87,7 @@ steps:
     condition: and(succeeded(), ne(variables['AzureSDKReleaseNotesClonePath'], variables['AzureSDKClonePath']))
 
   - pwsh: |
-      ./eng/common/scripts/Delete-RemoteBranches.ps1 -RepoId "azure-sdk/azure-sdk" -BranchRegex '^${{ parameters.PrBranchName }}.*' -AuthToken $(GH_TOKEN)
+      ./eng/common/scripts/Delete-RemoteBranches.ps1 -RepoId "Azure/azure-sdk" -BranchRegex '^${{ parameters.PrBranchName }}.*' -AuthToken $(GH_TOKEN)
     displayName: Clean Up Stale Branches
 
   - ${{ each repo in parameters.Repos }}:


### PR DESCRIPTION
- introduced by https://github.com/Azure/azure-sdk/pull/9927/changes#diff-3e533f9116866e1182ceb0dc188b9c08d4e4a92419cc17faa268839fca121785
  - L85 was updated from repo `azure-sdk/azure-sdk.git` to `Azure/azure-sdk.git`
  - L90 kept using repo `azure-sdk/azure-sdk`
