### PR TITLE
Require language selection in arch board review template

### DIFF
--- a/.github/ISSUE_TEMPLATE/arch-board-review.yml
+++ b/.github/ISSUE_TEMPLATE/arch-board-review.yml
@@ -74,19 +74,22 @@ body:
       placeholder: "https://github.com/Azure/azure-sdk/issues/..."
 
   # ── About the Client Library ───────────────────────────────────
-  - type: checkboxes
+  - type: dropdown
     id: languages
     attributes:
       label: Languages for this Review
       description: "Select all languages that need to be reviewed. You must provide the required artifacts for each selected language in the sections below."
+      multiple: true
       options:
-        - label: ".NET"
-        - label: "Java"
-        - label: "Python"
-        - label: "TypeScript"
-        - label: "Go"
-        - label: "C++"
-        - label: "Rust"
+        - ".NET"
+        - "Java"
+        - "Python"
+        - "TypeScript"
+        - "Go"
+        - "C++"
+        - "Rust"
+    validations:
+      required: true
 
   # ── Artifacts Required (per language) ──────────────────────────
   - type: markdown

--- a/.github/workflows/src/arch-board-review/issue-parsing.js
+++ b/.github/workflows/src/arch-board-review/issue-parsing.js
@@ -26,8 +26,30 @@ function isChecked(body, label) {
   return regex.test(body);
 }
 
+function getDropdownSelections(body, heading) {
+  const section = getLanguageSection(body, heading);
+  if (!section) {
+    return [];
+  }
+
+  // A multi-select dropdown renders its chosen values immediately after the
+  // heading (e.g. "Java, Python"). Only look at that leading value block,
+  // before any horizontal rule or markdown sub-heading that follows it.
+  const valueBlock = section.split(/\n(?:---|#{1,6}\s)/)[0];
+  return valueBlock
+    .split(/[\n,]+/)
+    .map((token) => token.trim())
+    .filter(Boolean);
+}
+
 function getSelectedLanguages(issueBody) {
-  return LANGUAGE_DEFINITIONS.filter((language) => isChecked(issueBody, language.label));
+  // Tolerant of both renderings: the legacy checkbox group (- [x] Java) and a
+  // required multi-select dropdown (comma-separated values under the heading).
+  const dropdownSelections = getDropdownSelections(issueBody, "Languages for this Review");
+  return LANGUAGE_DEFINITIONS.filter(
+    (language) =>
+      isChecked(issueBody, language.label) || dropdownSelections.includes(language.label),
+  );
 }
 
 function getLanguageSection(body, heading) {

--- a/.github/workflows/test/arch-board-review/issue-parsing.test.js
+++ b/.github/workflows/test/arch-board-review/issue-parsing.test.js
@@ -22,6 +22,28 @@ describe("issue-parsing", () => {
     ]);
   });
 
+  it("detects languages selected via a multi-select dropdown (comma-separated values)", () => {
+    const issueBody = `
+### Languages for this Review
+
+Java, Python, C++
+
+---
+## Artifacts Required (per language)
+
+For each selected language above, fill in the links below.
+
+### .NET
+Leave blank if .NET is not selected above.
+`;
+
+    expect(getSelectedLanguages(issueBody).map((language) => language.id)).toEqual([
+      "java",
+      "python",
+      "cpp",
+    ]);
+  });
+
   it("extracts a language section until the next heading", () => {
     const issueBody = `
 ### Java


### PR DESCRIPTION
## What

Makes the **Languages for this Review** field in the Architecture Board API-review issue template **required**, so a submission can never be filed with zero languages selected.

- Converts the field from an optional `checkboxes` group to a **multi-select `dropdown`** (`multiple: true`) with `validations.required: true`.
- GitHub issue forms cannot require "at least one" checkbox (the `required` flag on checkboxes is per individual option), so a required multi-select dropdown is the only control that enforces a non-empty selection at submit time.

## Why

Empty language selections currently slip through and get bounced during triage with a "No languages were selected" comment (an avoidable round trip). Enforcing selection upfront means issues reliably reach `ready-for-review`, which keeps per-language board views and architect assignment (#10167) accurate.

## Parser compatibility

`getSelectedLanguages` is now tolerant of **both** renderings:
- the dropdown's comma-separated value list (e.g. `Java, Python`), and
- the legacy `- [x] Java` checkbox format,

so existing open issues and all triage/assignment parsing keep working. Added a parser test for the dropdown rendering. Full suite green, eslint + prettier clean.

## Note

This is a focused follow-up to #10167 (architect assignment) and does not touch that PR's assignment logic. Assignment stays at `ready-for-review`; this change just makes reaching that state more reliable.