### PR TITLE
Add July 2026 release to sidebar nav

### DIFF
--- a/_data/sidebars/releases_sidebar.yml
+++ b/_data/sidebars/releases_sidebar.yml
@@ -29,6 +29,8 @@ entries:
       url: /releases/latest/specs.html
   - title: 2026 Releases
     folderitems:
+    - title: July
+      url: /releases/2026-07/index.html
     - title: June
       url: /releases/2026-06/index.html
     - title: May


### PR DESCRIPTION
## What

Adds the **July 2026** entry to the `2026 Releases` section of the releases sidebar nav.

## Why

The July 2026 release pages exist and resolve (created by automation PR #10145 on 2026-07-15), but `_data/sidebars/releases_sidebar.yml` was never updated, so July is missing from the left-hand navigation on the releases site. Direct URL `/releases/2026-07/index.html` works; the nav does not list it.

The sidebar-update step ran for prior months (June was added in #10068) but did not fire for July. This PR patches the nav by hand; the underlying automation gap should be fixed separately so future months don't require a manual PR.

## Change

One entry added above June:
```yaml
    - title: July
      url: /releases/2026-07/index.html
```