### PR TITLE
Deprecate Azure.Provisioning.Resources

### DIFF
--- a/_data/releases/latest/dotnet-packages.csv
+++ b/_data/releases/latest/dotnet-packages.csv
@@ -98,7 +98,7 @@
 "Azure.Developer.Playwright.NUnit","1.0.0","","Playwright NUnit","Load Testing","loadtestservice","","","client","true","","08/29/2025","08/29/2025","07/01/2025","","","","","","","",""
 "Azure.Communication.ProgrammableConnectivity","","1.0.0-beta.1","Programmable Connectivity","Communication","communication","NA","","client","true","","","","05/12/2024","deprecated","9/15/2025","","NA","NA","","",""
 "Azure.Provisioning","1.5.0","1.6.0-beta.1","Provisioning","Provisioning","provisioning","","NA","client","true","","03/04/2026","10/25/2024","03/26/2024","","","","","","","",""
-"Azure.Provisioning.Resources","","0.2.0","Provisioning - Resources","Provisioning","provisioning","","NA","client","true","","","","04/05/2024","deprecated","12/30/2025","","Azure.Provisioning","","","",""
+"Azure.Provisioning.Resources","","0.2.0","Provisioning - Resources","Provisioning","provisioning","","NA","client","true","","","","04/05/2024","deprecated","12/30/2025","","Azure.Provisioning","NA","","",""
 "Azure.Analytics.Purview.Account","","1.0.0-beta.1","Purview Account","Purview","purview","","","client","true","","","","08/24/2021","","","","","","","",""
 "Azure.Analytics.Purview.Administration","","1.0.0-beta.1","Purview Administration","Purview","purview","","","client","true","","","","10/19/2021","","","","","","","",""
 "Azure.Analytics.Purview.Catalog","","1.0.0-beta.4","Purview Catalog","Purview","purview","","","client","true","","","","05/12/2021","deprecated","06/01/2024","","NA","NA","","",""

--- a/_data/releases/latest/dotnet-packages.csv
+++ b/_data/releases/latest/dotnet-packages.csv
@@ -98,7 +98,7 @@
 "Azure.Developer.Playwright.NUnit","1.0.0","","Playwright NUnit","Load Testing","loadtestservice","","","client","true","","08/29/2025","08/29/2025","07/01/2025","","","","","","","",""
 "Azure.Communication.ProgrammableConnectivity","","1.0.0-beta.1","Programmable Connectivity","Communication","communication","NA","","client","true","","","","05/12/2024","deprecated","9/15/2025","","NA","NA","","",""
 "Azure.Provisioning","1.5.0","1.6.0-beta.1","Provisioning","Provisioning","provisioning","","NA","client","true","","03/04/2026","10/25/2024","03/26/2024","","","","","","","",""
-"Azure.Provisioning.Resources","","0.2.0","Provisioning - Resources","Provisioning","provisioning","","NA","client","true","","","","04/05/2024","","","","","","","",""
+"Azure.Provisioning.Resources","","0.2.0","Provisioning - Resources","Provisioning","provisioning","","NA","client","true","","","","04/05/2024","deprecated","12/30/2025","","Azure.Provisioning","","","",""
 "Azure.Analytics.Purview.Account","","1.0.0-beta.1","Purview Account","Purview","purview","","","client","true","","","","08/24/2021","","","","","","","",""
 "Azure.Analytics.Purview.Administration","","1.0.0-beta.1","Purview Administration","Purview","purview","","","client","true","","","","10/19/2021","","","","","","","",""
 "Azure.Analytics.Purview.Catalog","","1.0.0-beta.4","Purview Catalog","Purview","purview","","","client","true","","","","05/12/2021","deprecated","06/01/2024","","NA","NA","","",""


### PR DESCRIPTION
## Description

Marks `Azure.Provisioning.Resources` as deprecated in the .NET package index with an end-of-support date of December 30, 2025, and identifies `Azure.Provisioning` as its replacement.

Someone manually updated this package on NuGet without updating the CSV file.