### PR TITLE
Ignore stale Provisioning.Resources docs link

### DIFF
--- a/eng/ignore-links.txt
+++ b/eng/ignore-links.txt
@@ -15,3 +15,7 @@ https://github.com/Azure/azure-sdk-for-net/tree/Azure.Provisioning.Search_1.0.0/
 # move and remains under sdk/provisioning. A single RepoPath cannot satisfy both, so the stale GA
 # source link is ignored while the current preview link resolves correctly.
 https://github.com/Azure/azure-sdk-for-net/tree/Azure.Provisioning.EventHubs_1.1.0/sdk/eventhub/Azure.Provisioning.EventHubs/
+
+# Azure.Provisioning.Resources is deprecated and was replaced by Azure.Provisioning. Its MS Docs
+# preview readme page has since been removed, so the auto-generated docs link now 404s.
+https://learn.microsoft.com/dotnet/api/overview/azure/Provisioning.Resources-readme?view=azure-dotnet-preview&preserve-view=true


### PR DESCRIPTION
Azure.Provisioning.Resources is deprecated and has been replaced. Its generated Microsoft Docs preview URL now returns 404, so link verification should ignore this stale URL.