### PR TITLE
Publish August 2026 release pages

### DIFF
--- a/_data/sidebars/releases_sidebar.yml
+++ b/_data/sidebars/releases_sidebar.yml
@@ -29,6 +29,8 @@ entries:
       url: /releases/latest/specs.html
   - title: 2026 Releases
     folderitems:
+    - title: August
+      url: /releases/2026-08/index.html
     - title: July
       url: /releases/2026-07/index.html
     - title: June

--- a/eng/common/scripts/allow-relative-links.txt
+++ b/eng/common/scripts/allow-relative-links.txt
@@ -11,3 +11,5 @@ AGENTS.md
 eng/**
 # Allow relative links for the top-level eval suite (evals is a cross-cutting asset at repo root).
 evals/**
+# Monthly release indexes intentionally link to sibling language pages before publication.
+releases/*/index.md

--- a/releases/2026-08/android.md
+++ b/releases/2026-08/android.md
@@ -1,0 +1,8 @@
+---
+title: Azure SDK for Android (August 2026)
+layout: post
+tags: android azure
+sidebar: releases_sidebar
+repository: azure/azure-sdk-for-android
+---
+{% include releases/notes/common.md language="android" date="2026-08" displayDate="August 2026" %}

--- a/releases/2026-08/c.md
+++ b/releases/2026-08/c.md
@@ -1,0 +1,49 @@
+---
+title: Azure SDK for Embedded C (August 2026)
+layout: post
+tags: c
+sidebar: releases_sidebar
+repository: Azure/azure-sdk-for-c
+---
+
+No packages released this month.
+
+<!--
+The Azure SDK team is pleased to make available the August 2026 client library release.
+
+#### Stable
+
+- _Add packages_
+
+#### Updates
+
+- _Add packages_
+
+#### Beta
+
+- _Add packages_
+
+## Installation Instructions
+
+To install any of our packages, copy and paste the following commands into a terminal:
+
+```bash
+$> 
+```
+
+## Feedback
+
+If you have a bug or feature request for one of the libraries, please post an issue to [GitHub](https://github.com/Azure/azure-sdk-for-c/issues).
+
+## Release highlights
+
+### _Package name_
+
+- Major changes only!
+
+## Latest Releases
+
+View all the latest versions of C packages [here][c-latest-releases].
+
+{% include refs.md %}
+-->

--- a/releases/2026-08/cpp.md
+++ b/releases/2026-08/cpp.md
@@ -1,0 +1,8 @@
+---
+title: Azure SDK for C++ (August 2026)
+layout: post
+tags: C++ cpp
+sidebar: releases_sidebar
+repository: Azure/azure-sdk-for-cpp
+---
+{% include releases/notes/common.md language="cpp" date="2026-08" displayDate="August 2026" %}

--- a/releases/2026-08/dotnet.md
+++ b/releases/2026-08/dotnet.md
@@ -1,0 +1,8 @@
+---
+title: Azure SDK for .NET (August 2026)
+layout: post
+tags: dotnet azure
+sidebar: releases_sidebar
+repository: azure/azure-sdk-for-net
+---
+{% include releases/notes/common.md language="dotnet" date="2026-08" displayDate="August 2026" %}

--- a/releases/2026-08/go.md
+++ b/releases/2026-08/go.md
@@ -1,0 +1,8 @@
+---
+title: Azure SDK for Go (August 2026)
+layout: post
+tags: go
+sidebar: releases_sidebar
+repository: Azure/azure-sdk-for-go
+---
+{% include releases/notes/common.md language="go" date="2026-08" displayDate="August 2026" %}

--- a/releases/2026-08/index.md
+++ b/releases/2026-08/index.md
@@ -1,0 +1,30 @@
+---
+title: Azure SDK (August 2026)
+layout: post
+tags: release
+sidebar: releases_sidebar
+---
+
+Thank you for your interest in the new Azure SDKs! We release new features, improvements, and bug fixes every month. Please subscribe to our [Azure SDK Blog RSS Feed](https://devblogs.microsoft.com/azure-sdk/feed) to get notified when a new release is available.
+
+You can find links to packages, code, and docs on our [Azure SDK Releases page](https://aka.ms/azsdk/releases).
+
+## Release Highlights
+
+*
+*
+*
+
+## Release Notes
+
+* [All release notes](index.md)
+* [.NET release notes](dotnet.md)
+* [Java release notes](java.md)
+* [JavaScript/TypeScript release notes](js.md)
+* [Python release notes](python.md)
+* [Rust release notes](rust.md)
+* [C++ release notes](cpp.md)
+* [Embedded C release notes](c.md)
+* [Android release notes](android.md)
+* [iOS release notes](ios.md)
+* [Go release notes](go.md)

--- a/releases/2026-08/ios.md
+++ b/releases/2026-08/ios.md
@@ -1,0 +1,8 @@
+---
+title: Azure SDK for iOS (August 2026)
+layout: post
+tags: ios azure
+sidebar: releases_sidebar
+repository: azure/azure-sdk-for-ios
+---
+{% include releases/notes/common.md language="ios" date="2026-08" displayDate="August 2026" %}

--- a/releases/2026-08/java.md
+++ b/releases/2026-08/java.md
@@ -1,0 +1,8 @@
+---
+title: Azure SDK for Java (August 2026)
+layout: post
+tags: java azure
+sidebar: releases_sidebar
+repository: azure/azure-sdk-for-java
+---
+{% include releases/notes/common.md language="java" date="2026-08" displayDate="August 2026" %}

--- a/releases/2026-08/js.md
+++ b/releases/2026-08/js.md
@@ -1,0 +1,8 @@
+---
+title: Azure SDK for JavaScript (August 2026)
+layout: post
+tags: javascript typescript azure
+sidebar: releases_sidebar
+repository: azure/azure-sdk-for-js
+---
+{% include releases/notes/common.md language="js" date="2026-08" displayDate="August 2026" %}

--- a/releases/2026-08/python.md
+++ b/releases/2026-08/python.md
@@ -1,0 +1,8 @@
+---
+title: Azure SDK for Python (August 2026)
+layout: post
+tags: python azure
+sidebar: releases_sidebar
+repository: azure/azure-sdk-for-python
+---
+{% include releases/notes/common.md language="python" date="2026-08" displayDate="August 2026" %}

--- a/releases/2026-08/rust.md
+++ b/releases/2026-08/rust.md
@@ -1,0 +1,8 @@
+---
+title: Azure SDK for Rust (August 2026)
+layout: post
+tags: rust
+sidebar: releases_sidebar
+repository: Azure/azure-sdk-for-rust
+---
+{% include releases/notes/common.md language="rust" date="2026-08" displayDate="August 2026" %}


### PR DESCRIPTION
## Summary
- publish the August 2026 release landing page and language pages from automation PR #10209
- add August to the releases sidebar
- allow intentional sibling links in monthly release index pages while continuing to verify that targets exist

## Why
The automation PR cannot be edited by maintainers and has remained open since August 3. Until these files merge, https://azure.github.io/azure-sdk/releases/2026-08/index.html returns 404 and the monthly blog cannot link to the August release notes.

Supersedes #10209 and #10247.